### PR TITLE
autofarm: handle crops with long growdurs

### DIFF
--- a/autofarm.rb
+++ b/autofarm.rb
@@ -14,6 +14,7 @@ Usage::
     autofarm threshold 150 helmet_plump tail_pig
 
 =end
+
 class AutoFarm
 
     def initialize
@@ -39,9 +40,12 @@ class AutoFarm
         has_seed = plant.flags[:SEED]
         season = df.cur_season
         harvest = df.cur_season_tick + plant.growdur * 10
-        will_finish = harvest < 10080
         can_plant = has_seed && plant.flags[season]
-        can_plant = can_plant && (will_finish || plant.flags[(season+1)%4])
+        while (harvest >= 10080)
+            season = (season + 1)%4
+            harvest = harvest - 10080
+            can_plant = can_plant && plant.flags[season]
+        end
         can_plant
     end
 


### PR DESCRIPTION
This is a fix I wrote years ago but never bothered to commit that allows autofarm to handle crops with growdurs that exceed a single season. There are none in standard DF, but some community mods add such crops.