### PR TITLE
Edit docs to match new keybinding directive

### DIFF
--- a/forum-dwarves.lua
+++ b/forum-dwarves.lua
@@ -28,7 +28,7 @@ safe to attempt running the script with any screen active, with an
 error message to inform you when the selected screen is not appropriate
 for this script.
 
-The target file's name is 'forumdwarves.txt'.  A remider to this effect
+The target file's name is 'forumdwarves.txt'.  A reminder to this effect
 will be displayed if the script is successful.
 
 .. note::

--- a/gui/choose-weapons.lua
+++ b/gui/choose-weapons.lua
@@ -3,8 +3,7 @@
 
 gui/choose-weapons
 ==================
-Bind to a key (the example config uses :kbd:`Ctrl`:kbd:`W`), and activate in the Equip->View/Customize
-page of the military screen.
+Activate in the :guilabel:`Equip->View/Customize` page of the military screen.
 
 Depending on the cursor location, it rewrites all 'individual choice weapon' entries
 in the selected squad or position to use a specific weapon type matching the assigned

--- a/gui/clone-uniform.lua
+++ b/gui/clone-uniform.lua
@@ -3,11 +3,9 @@
 
 gui/clone-uniform
 =================
-Bind to a key (the example config uses :kbd:`Ctrl`:kbd:`C`), and activate in the Uniforms
-page of the military screen with the cursor in the leftmost list.
-
 When invoked, the script duplicates the currently selected uniform template,
-and selects the newly created copy.
+and selects the newly created copy.  Activate in the Uniforms
+page of the military screen with the cursor in the leftmost list.
 
 ]====]
 local utils = require 'utils'

--- a/gui/guide-path.lua
+++ b/gui/guide-path.lua
@@ -3,8 +3,8 @@
 
 gui/guide-path
 ==============
-Bind to a key (the example config uses :kbd:`Alt`:kbd:`P`), and activate in the Hauling menu with
-the cursor over a Guide order.
+Activate in the :guilabel:`Hauling` menu with the cursor over 
+a :guilabel:`Guide` order.
 
 .. image:: /docs/images/guide-path.png
 

--- a/gui/liquids.lua
+++ b/gui/liquids.lua
@@ -3,12 +3,10 @@
 
 gui/liquids
 ===========
-To use, bind to a key (the example config uses Alt-L) and activate in the :kbd:`k` mode.
-
-.. image:: /docs/images/liquids.png
-
 This script is a gui front-end to `liquids` and works similarly,
 allowing you to add or remove water & magma, and create obsidian walls & floors.
+
+.. image:: /docs/images/liquids.png
 
 .. warning::
 

--- a/gui/mechanisms.lua
+++ b/gui/mechanisms.lua
@@ -3,13 +3,10 @@
 
 gui/mechanisms
 ==============
-To use, bind to a key (the example config uses :kbd:`Ctrl`:kbd:`M`)
-and activate in :kbd:`q` mode.
-
-.. image:: /docs/images/mechanisms.png
-
 Lists mechanisms connected to the building, and their links. Navigating
 the list centers the view on the relevant linked buildings.
+
+.. image:: /docs/images/mechanisms.png
 
 To exit, press :kbd:`Esc` or :kbd:`Enter`; :kbd:`Esc` recenters on
 the original building, while :kbd:`Enter` leaves focus on the current

--- a/gui/power-meter.lua
+++ b/gui/power-meter.lua
@@ -3,10 +3,8 @@
 
 gui/power-meter
 ===============
-An in-game interface for `power-meter`.
-
-Bind it to a key (default :kbd:`Ctrl`:kbd:`Shift`:kbd:`M`) and activate
-after selecting Pressure Plate in the build menu.
+Activate an in-game interface for `power-meter` after selecting 
+:guilabel:`Pressure Plate` in the build menu.
 
 .. image:: /docs/images/power-meter.png
 

--- a/gui/rename.lua
+++ b/gui/rename.lua
@@ -26,9 +26,6 @@ via a simple dialog in the game ui.
 
 The ``building`` or ``unit`` options are automatically assumed when in relevant UI state.
 
-The example config binds building/unit rename to :kbd:`Ctrl`:kbd:`Shift`:kbd:`N`, and
-unit profession change to :kbd:`Ctrl`:kbd:`Shift`:kbd:`T`.
-
 ]====]
 local gui = require 'gui'
 local dlg = require 'gui.dialogs'

--- a/gui/room-list.lua
+++ b/gui/room-list.lua
@@ -3,13 +3,13 @@
 
 gui/room-list
 =============
-To use, bind to a key (the example config uses :kbd:`Alt`:kbd:`R`) and activate in :kbd:`q` mode,
-either immediately or after opening the assign owner page.
+Activate in :kbd:`q` mode, either immediately or after opening the 
+assign owner page.
 
 .. image:: /docs/images/room-list.png
 
-The script lists other rooms owned by the same owner, or by the unit selected in the assign
-list, and allows unassigning them.
+The script lists other rooms owned by the same owner, or by the unit 
+selected in the assign list, and allows unassigning them.
 
 ]====]
 local utils = require 'utils'

--- a/gui/settings-manager.lua
+++ b/gui/settings-manager.lua
@@ -3,12 +3,7 @@
 
 gui/settings-manager
 ====================
-An in-game settings manager (init.txt/d_init.txt)
-
-Recommended for use as a keybinding::
-
-    keybinding add Alt-S@title settings-manager
-    keybinding add Alt-S@dwarfmode/Default settings-manager
+An in-game manager for settings defined in ``init.txt`` and ``d_init.txt``.
 
 ]====]
 

--- a/gui/siege-engine.lua
+++ b/gui/siege-engine.lua
@@ -3,10 +3,8 @@
 
 gui/siege-engine
 ================
-An in-game interface for `siege-engine`.
-
-Bind it to a key (the example config uses :kbd:`Alt`:kbd:`a`) and
-activate after selecting a siege engine in :kbd:`q` mode.
+Activate an in-game interface for `siege-engine`, after selecting 
+a siege engine in :kbd:`q` mode.
 
 .. image:: /docs/images/siege-engine.png
 

--- a/gui/workshop-job.lua
+++ b/gui/workshop-job.lua
@@ -3,8 +3,7 @@
 
 gui/workshop-job
 ================
-Bind to a key (the example config uses :kbd:`Alt`:kbd:`a`), and activate with a job selected in
-a workshop in the :kbd:`q` mode.
+Run with a job selected in a workshop in the :kbd:`q` mode.
 
 .. image:: /docs/images/workshop-job.png
 


### PR DESCRIPTION
Scripts now have keybinding info auto-generated for build-time HTML docs.  See DFHack/dfhack#972

At runtime, more reliable information can be sourced from the `hotkeys` or `keybinding` commands, or of course inspecting the init files.  See DFHack/dfhack#963