### PR TITLE
fixed a few issues

### DIFF
--- a/modtools/create-unit.lua
+++ b/modtools/create-unit.lua
@@ -108,11 +108,11 @@ function createUnit(race_id, caste_id, location)
   gui.simulateInput(dwarfmodeScreen, 'D_LOOK_ARENA_CREATURE')
 
 -- move cursor to location instead of moving unit later, corrects issue of missing mapdata when moving the created unit.
-	if location then
-		df.global.cursor.x = tonumber(location[1])
-		df.global.cursor.y = tonumber(location[2])
-		df.global.cursor.z = tonumber(location[3])
-	end
+  if location then
+    df.global.cursor.x = tonumber(location[1])
+    df.global.cursor.y = tonumber(location[2])
+    df.global.cursor.z = tonumber(location[3])
+  end
 
   local spawnScreen = dfhack.gui.getCurViewscreen()
   if dfhack.world.isArena() then

--- a/modtools/create-unit.lua
+++ b/modtools/create-unit.lua
@@ -25,6 +25,7 @@ local usage = [====[
 modtools/create-unit
 ====================
 Creates a unit.  Usage::
+
     -race raceName
         specify the race of the unit to be created
         examples:
@@ -207,11 +208,13 @@ function createFigure(trgunit,he,he_group)
   -- set values that seem related to state and do event
   --change_state(hf, dfg.ui.site_id, region_pos)
 
+
   --lets skip skills for now
   --local skills = df.historical_figure_info.T_skills:new() -- skills snap shot
   -- ...
   -- note that innate skills are automaticaly set by DF
   hf.info.skills = {new=true}
+
 
   he.histfig_ids:insert('#', hf.id)
   he.hist_figures:insert('#', hf)
@@ -348,6 +351,7 @@ function wild(uid)
     -- region = df.global.world.map.map_blocks[df.global.world.map.x_count_block*x+y]
   end
 end
+
 
 function nameUnit(id, entityRawName, civ_id)
   --pick a random appropriate name

--- a/modtools/create-unit.lua
+++ b/modtools/create-unit.lua
@@ -601,16 +601,3 @@ if args.nick and type(args.nick) == 'string' then
   dfhack.units.setNickname(df.unit.find(unitId), args.nick)
 end
 
-
---[[ depracated by amostubal.  no longer necessary as we move the cursor in the creation of the unit.  no longer needs to utilize teleport...
-if args.location then
-  local u = df.unit.find(unitId)
-  local pos = df.coord:new()
-  pos.x = tonumber(args.location[1])
-  pos.y = tonumber(args.location[2])
-  pos.z = tonumber(args.location[3])
-  local teleport = dfhack.script_environment('teleport')
-  teleport.teleport(u, pos)
-end
---]]
-

--- a/modtools/create-unit.lua
+++ b/modtools/create-unit.lua
@@ -1,9 +1,13 @@
 -- Creates a unit.  Beta; use at own risk.
+
 -- Originally created by warmist
 -- Significant contributions over time by Boltgun, Dirst, Expwnent, lethosor, mifki and Putnam.
+
 -- version 0.55
 -- This is a beta version. Use at your own risk.
+
 -- Modifications from 0.5: civ -1 creates are NOT historical figures, mitigated screen-movement bug in createUnit()
+
 --[[
   TODO
     children and babies: set child/baby job
@@ -277,7 +281,7 @@ function createNemesis(trgunit,civ_id,group_id)
 end
 
 --createNemesis(u, u.civ_id,group)
-function createUnitInCiv(race_id, caste_id, location, civ_id, group_id)
+function createUnitInCiv(race_id, caste_id, civ_id, group_id, location)
   local uid = createUnit(race_id, caste_id, location)
   local unit = df.unit.find(uid)
   if ( civ_id ) then
@@ -287,11 +291,11 @@ function createUnitInCiv(race_id, caste_id, location, civ_id, group_id)
 end
 
 function createUnitInFortCiv(race_id, caste_id, location)
-  return createUnitInCiv(race_id, caste_id, location, df.global.ui.civ_id)
+  return createUnitInCiv(race_id, caste_id, df.global.ui.civ_id, 0, location)
 end
 
 function createUnitInFortCivAndGroup(race_id, caste_id, location)
-  return createUnitInCiv(race_id, caste_id, location, df.global.ui.civ_id, df.global.ui.group_id)
+  return createUnitInCiv(race_id, caste_id, df.global.ui.civ_id, df.global.ui.group_id, location)
 end
 
 function domesticate(uid, group_id)
@@ -498,7 +502,7 @@ local unitId
 if civ_id == -1 then
     unitId = createUnit(raceIndex, casteIndex, args.location)
   else
-    unitId = createUnitInCiv(raceIndex, casteIndex, args.location, civ_id, group_id)
+    unitId = createUnitInCiv(raceIndex, casteIndex, civ_id, group_id, args.location)
 end
 
 if civ_id then -- moved it here made more sense... why isn't this done inside of nemesis, above?
@@ -579,6 +583,7 @@ if args.name then
 else
   local unit = df.unit.find(unitId)
   unit.name.has_name = false
+  unit.name.first_name = "" -- remove the first name altogether. gets rid of units having number names.
   if unit.status.current_soul then
     unit.status.current_soul.name.has_name = false
   end
@@ -593,7 +598,7 @@ if args.nick and type(args.nick) == 'string' then
 end
 
 
---[[ depracated by amostubal.  no longeer necessary as we move the cursor in the creation of the unit.  no longer needs to utilize teleport...
+--[[ depracated by amostubal.  no longer necessary as we move the cursor in the creation of the unit.  no longer needs to utilize teleport...
 if args.location then
   local u = df.unit.find(unitId)
   local pos = df.coord:new()

--- a/modtools/create-unit.lua
+++ b/modtools/create-unit.lua
@@ -1,13 +1,9 @@
 -- Creates a unit.  Beta; use at own risk.
-
 -- Originally created by warmist
 -- Significant contributions over time by Boltgun, Dirst, Expwnent, lethosor, mifki and Putnam.
-
 -- version 0.55
 -- This is a beta version. Use at your own risk.
-
 -- Modifications from 0.5: civ -1 creates are NOT historical figures, mitigated screen-movement bug in createUnit()
-
 --[[
   TODO
     children and babies: set child/baby job


### PR DESCRIPTION
occasionally the original point of creation has no map data (its below the bottom floor of hell, and therefore does not exist).
figured that since the point it tries to create the unit is a series of simulated actions that moves through the arena spawn unit menus, that before opening the menu, you could just move the cursor there, if location was set, it worked.  

also added an argument to set the unit to civ_id and group_id of the the fort, to reduce on the verbose of most commands (nearly every use I have for create-unit is set to the civ and group of the fort...).  

moved the civ_id change closer to the point of actually creating the unit,  thought about moving it into the createNemesis function... but didn't.

corrected error involving out of bounds vector, on old forts in the setting of the age(o.l. 523/n.l. 540).  It was just a bad way to look up the historical figure, used the appropriate call.

the entire thing no longer needs teleport to operate.