### PR TITLE
Should not count logs used in constructions

### DIFF
--- a/gui/dfstatus.lua
+++ b/gui/dfstatus.lua
@@ -126,7 +126,7 @@ function dfstatus:init()
     end
 
     for _, item in ipairs(df.global.world.items.all) do
-        if not item.flags.rotten and not item.flags.dump and not item.flags.forbid then
+        if not item.flags.rotten and not item.flags.dump and not item.flags.forbid and not item.flags.construction then
             if item:getType() == df.item_type.WOOD then
                 wood = wood + item:getStackSize()
             elseif item:getType() == df.item_type.DRINK then


### PR DESCRIPTION
I made my fort walls out of logs (heresy I know) and the count on logs was ~3k.  When I added the "not item.flags.construction" flag I went down to 200 available logs.

68x59 square wall, Hollow with a 64x55 inner wall.  Three high with floors on the inside and top.