### PR TITLE
Update siren.lua

### DIFF
--- a/siren.lua
+++ b/siren.lua
@@ -51,7 +51,7 @@ function add_thought(unit, emotion, thought)
     thought=thought,
     subthought=0,
     severity=0,
-    flags=0,
+    flags={},
     unk7=0,
     year=df.global.cur_year,
     year_tick=df.global.cur_year_tick})


### PR DESCRIPTION
`flags` [now bitfield](https://github.com/DFHack/df-structures/blob/master/df.units.xml#L1697) and [docs](https://dfhack.readthedocs.io/en/stable/docs/Lua%20API.html#bitfield-references) says that I can simply assign a lua table for that
Will it call default constructor or something similar? 
Or I should set every field in it?

> offtopic:
> xml says there only 4 fields but `pairs` iterate up to 31
> can I safely use last bits in bitfiels for my own purposes?