### PR TITLE
view-item-info: fix error for `CHEESE_MAT`

### DIFF
--- a/view-item-info.lua
+++ b/view-item-info.lua
@@ -241,8 +241,8 @@ end
 function GetReactionProduct (inmat, reaction)
     for k,v in pairs (inmat.reaction_product.id) do
         if v.value == reaction then
-            return {inmat.reaction_product.material.mat_type[k],
-                    inmat.reaction_product.material.mat_index[k]}
+            return inmat.reaction_product.material.mat_type[k],
+                    inmat.reaction_product.material.mat_index[k]
         end
     end
 end


### PR DESCRIPTION
```
df_43_05_win/hack/scripts/view-item-info.lua:279: bad argument #1 to 'decode' (material id is not a number)
stack traceback:
        [C]: in field 'decode'
        D:\Games\df\df_43_05_win/hack/scripts/view-item-info.lua:279: in global 'get_plant_reaction_products'
        D:\Games\df\df_43_05_win/hack/scripts/view-item-info.lua:296: in global 'GetFoodPropertiesStringList'
        D:\Games\df\df_43_05_win/hack/scripts/view-item-info.lua:347: in global 'get_all_uses_strings'
        D:\Games\df\df_43_05_win/hack/scripts/view-item-info.lua:402: in function <D:\Games\df\df_43_05_win/hack/scripts/view-item-info.lua:382>
```
`GetReactionProduct` return value used incorrectly at [278](https://github.com/DFHack/scripts/compare/master...OwnageIsMagic:patch-1#diff-3cbbb7dbf10255f7809c8745fc5ffa30R278) and [251](https://github.com/DFHack/scripts/compare/master...OwnageIsMagic:patch-1#diff-3cbbb7dbf10255f7809c8745fc5ffa30R251)