### PR TITLE
Minor fix to modtools/create-unit

### DIFF
--- a/modtools/create-unit.lua
+++ b/modtools/create-unit.lua
@@ -330,7 +330,7 @@ function domesticate(uid, group_id)
     u.flags2.resident = false;
     u.flags3.body_temp_in_range = true;
     u.population_id = -1
-    u.status.current_soul.unit_id = u.id
+    u.status.current_soul.id = u.id
 
     u.animal.population.region_x = -1
     u.animal.population.region_y = -1


### PR DESCRIPTION
Fixed invalid reference to `current_soul.unit_id` in the `domesticate` function