### PR TITLE
Bugfix reaction-product-trigger

### DIFF
--- a/modtools/reaction-product-trigger.lua
+++ b/modtools/reaction-product-trigger.lua
@@ -79,7 +79,11 @@ end
 
 local function afterProduce(reaction,reaction_product,unit,input_items,input_reagents,output_items)
  --printall(unit.job.current_job)
- local _,buildingId = dfhack.script_environment('modtools/reaction-trigger').getWorkerAndBuilding(unit.job.current_job)
+ local _,buildingId = -1,-1
+ -- unit.job.current_job might be nil for Adventure mode
+ if unit.job.current_job then
+  _,buildingId = dfhack.script_environment('modtools/reaction-trigger').getWorkerAndBuilding(unit.job.current_job)
+ end
  for _,hook in ipairs(productHooks[reaction.code] or {}) do
   local command = hook.command
   local processed = processArgs(command, reaction, reaction_product, unit, input_items, input_reagents, output_items, buildingId)


### PR DESCRIPTION
The external function call getWorkerAndBuilding fails in Adventure mode when crafting outside of a building.  Requiring that unit.job.current_job not be 'nil' before calling the external function works around this issue.  These checks are carried out in 'modtools/reaction-trigger.lua' before calling the internal function.  So, changing reaction-product-trigger.lua, to follow the methodology present in reaction-trigger.lua, probably makes the most sense.