### PR TITLE
view-unit-reports: View combat reports for currently selected unit

### DIFF
--- a/view-unit-reports.lua
+++ b/view-unit-reports.lua
@@ -47,15 +47,6 @@ local function find_last_unit_with_combat_log_and_race(race_id)
    return output
 end
 
-local function find_unit(unit_id)
-   for _, unit in pairs(df.global.world.units.all) do
-      if unit.id == unit_id then
-         return unit
-      end
-   end
-   return nil
-end
-
 local function current_selected_unit()
    -- 'v' view, 'k' at unit, unit list view
    local unit = dfhack.gui.getSelectedUnit(true)
@@ -66,7 +57,7 @@ local function current_selected_unit()
    -- 'k' over a corpse
    local item = dfhack.gui.getSelectedItem(true)
    if df.item_corpsest:is_instance(item) then
-      return find_unit(item.unit_id)
+      return df.unit.find(item.unit_id)
    end
 
    -- 'k' over some spatter (e.g. blood)
@@ -77,7 +68,7 @@ local function current_selected_unit()
 
       -- spatter is related to historical figure
       if matinfo.figure then
-         return find_unit(matinfo.figure.unit_id)
+         return df.unit.find(matinfo.figure.unit_id)
       end
 
       -- spatter is only related to a race. find good unit with that race.

--- a/view-unit-reports.lua
+++ b/view-unit-reports.lua
@@ -1,0 +1,95 @@
+-- View combat reports for currently selected unit
+--[====[
+
+view-unit-reports
+=================
+Show combat reports for the current unit.
+
+Current unit is unit near cursor in 'v', selected in 'u' list,
+unit/corpse/splatter at cursor in 'k'. And newest unit with race when
+'k' at race-specific blood spatter.
+
+keybinding add Ctrl-Shift-R view-unit-reports
+
+]====]
+
+local function get_combat_logs(unit)
+   local output = {}
+   for _,report_id in pairs(unit.reports.log.Combat) do
+      local report = df.report.find(report_id)
+      if report then
+         output[#output + 1] = report
+      end
+   end
+   return output
+end
+
+local function view_unit_report(unit)
+   local report_view = df.viewscreen_announcelistst:new()
+   report_view.unit = unit
+
+   for _,report in pairs(get_combat_logs(unit)) do
+      report_view.reports:insert('#', report)
+   end
+   
+   report_view.sel_idx = #report_view.reports - 1
+
+   dfhack.screen.show(report_view)
+end
+
+local function find_last_unit_with_combat_log_and_race(race_id)
+   local output = nil
+   for _, unit in pairs(df.global.world.units.all) do
+      if unit.race == race_id and #get_combat_logs(unit) >= 1 then
+         output = unit
+      end
+   end
+   return output
+end
+
+local function find_unit(unit_id)
+   for _, unit in pairs(df.global.world.units.all) do
+      if unit.id == unit_id then
+         return unit
+      end
+   end
+   return nil
+end
+
+local function current_selected_unit()
+   -- 'v' view, 'k' at unit, unit list view
+   local unit = dfhack.gui.getSelectedUnit(true)
+   if unit then
+      return unit
+   end
+
+   -- 'k' over a corpse
+   local item = dfhack.gui.getSelectedItem(true)
+   if df.item_corpsest:is_instance(item) then
+      return find_unit(item.unit_id)
+   end
+
+   -- 'k' over some spatter (e.g. blood)
+   local screen_string = dfhack.gui.getFocusString(dfhack.gui.getCurViewscreen())
+   if screen_string == "dwarfmode/LookAround/Spatter" then
+      local look_at = df.global.ui_look_list.items[df.global.ui_look_cursor]
+      local matinfo = dfhack.matinfo.decode(look_at.spatter_mat_type, look_at.spatter_mat_index)
+
+      -- spatter is related to historical figure
+      if matinfo.figure then
+         return find_unit(matinfo.figure.unit_id)
+      end
+
+      -- spatter is only related to a race. find good unit with that race.
+      if matinfo.creature then
+         return find_last_unit_with_combat_log_and_race(matinfo.index)
+      end
+   end
+
+   return nil
+end
+
+local unit = current_selected_unit()
+if unit then
+   view_unit_report(unit)
+end


### PR DESCRIPTION
Script to solve the problem of having to manually find combat reports in 'r' for specific unit.

Current unit is unit near cursor in 'v', selected in 'u' list,
unit/corpse/splatter at cursor in 'k'. And newest unit with race when
'k' at race-specific blood spatter.

If this is considered useful enough it can be added to dfhack.init-example in the following scopes (I would prefer it as a single keybinding since 4 lines is too much clutter)
```
# show battle report for selected unit
keybinding add Ctrl-Shift-R@dwarfmode/ViewUnits view-unit-reports
keybinding add Ctrl-Shift-R@unitlist view-unit-reports
keybinding add Ctrl-Shift-R@dwarfmode/LookAround view-unit-reports
keybinding add Ctrl-Shift-R@textviewer view-unit-reports
```