### PR TITLE
Deathcause

### DIFF
--- a/deathcause.rb
+++ b/deathcause.rb
@@ -19,9 +19,10 @@ def display_death_event(e)
 end
 
 def display_death_unit(u)
+    str = "The #{u.race_tg.name[0]}"
+    str << " #{u.name}" if u.name.has_name
+    
     if not u.flags2.killed and not u.flags3.ghostly
-        str = "The #{u.race_tg.name[0]}"
-        str << " #{u.name}" if u.name.has_name
         str << " is not dead yet !"
         
         puts str.chomp(',')
@@ -29,8 +30,6 @@ def display_death_unit(u)
         death_info = u.counters.death_tg
         killer = death_info.killer_tg if death_info
 
-        str = "The #{u.race_tg.name[0]}"
-        str << " #{u.name}" if u.name.has_name
         str << " died"
         str << " in year #{death_info.event_year}" if death_info
         str << " (cause: #{u.counters.death_cause.to_s.downcase})," if u.counters.death_cause != -1

--- a/deathcause.rb
+++ b/deathcause.rb
@@ -30,7 +30,9 @@ def display_death_unit(u)
         death_info = u.counters.death_tg
         killer = death_info.killer_tg if death_info
 
-        str << " died"
+        str << " died" if !u.flags2.slaughter
+        str << " was slaughtered" if u.flags2.slaughter
+        
         str << " in year #{death_info.event_year}" if death_info
         str << " (cause: #{u.counters.death_cause.to_s.downcase})," if u.counters.death_cause != -1
         str << " killed by the #{killer.race_tg.name[0]} #{killer.name}" if killer
@@ -42,7 +44,7 @@ end
 item = df.item_find(:selected)
 unit = df.unit_find(:selected)
 
-if !item or !item.kind_of?(DFHack::ItemBodyComponent)
+if !unit and (!item or !item.kind_of?(DFHack::ItemBodyComponent))
     item = df.world.items.other[:ANY_CORPSE].find { |i| df.at_cursor?(i) }
 end
 

--- a/deathcause.rb
+++ b/deathcause.rb
@@ -19,17 +19,22 @@ def display_death_event(e)
 end
 
 def display_death_unit(u)
-    death_info = u.counters.death_tg
-    killer = death_info.killer_tg if death_info
+    if not u.flags2.killed and not u.flags3.ghostly
+        puts "#{u.name} is not dead yet !"
+        
+    else
+        death_info = u.counters.death_tg
+        killer = death_info.killer_tg if death_info
 
-    str = "The #{u.race_tg.name[0]}"
-    str << " #{u.name}" if u.name.has_name
-    str << " died"
-    str << " in year #{death_info.event_year}" if death_info
-    str << " (cause: #{u.counters.death_cause.to_s.downcase})," if u.counters.death_cause != -1
-    str << " killed by the #{killer.race_tg.name[0]} #{killer.name}" if killer
+        str = "The #{u.race_tg.name[0]}"
+        str << " #{u.name}" if u.name.has_name
+        str << " died"
+        str << " in year #{death_info.event_year}" if death_info
+        str << " (cause: #{u.counters.death_cause.to_s.downcase})," if u.counters.death_cause != -1
+        str << " killed by the #{killer.race_tg.name[0]} #{killer.name}" if killer
 
-    puts str.chomp(',') + '.'
+        puts str.chomp(',') + '.'
+    end
 end
 
 item = df.item_find(:selected)

--- a/deathcause.rb
+++ b/deathcause.rb
@@ -20,8 +20,11 @@ end
 
 def display_death_unit(u)
     if not u.flags2.killed and not u.flags3.ghostly
-        puts "#{u.name} is not dead yet !"
+        str = "The #{u.race_tg.name[0]}"
+        str << " #{u.name}" if u.name.has_name
+        str << " is not dead yet !"
         
+        puts str.chomp(',')
     else
         death_info = u.counters.death_tg
         killer = death_info.killer_tg if death_info

--- a/deathcause.rb
+++ b/deathcause.rb
@@ -52,13 +52,13 @@ elsif hf == -1
     if unit ||= item.unit_tg
         display_death_unit(unit)
     else
-        puts "Not a historical figure, cannot death find info"
+        puts "Not a historical figure, cannot find death info"
     end
 
 else
     histfig = df.world.history.figures.binsearch(hf)
     unit = histfig ? df.unit_find(histfig.unit_id) : nil
-    if unit and not unit.flags1.dead and not unit.flags3.ghostly
+    if unit and not unit.flags2.killed and not unit.flags3.ghostly
         puts "#{unit.name} is not dead yet !"
 
     else


### PR DESCRIPTION
One case of df-structures issue 247 (although no list has been seen yet...).
I've tested it on a random DFFD fortress and have seen it behave the same as the original version on most of the things in the refuse/corpse stockpile as well as on the dead units list.

The "not at hist fig" message wasn't produced in any of the cases, however, nor did I find any body parts belonging to living creatures to actually test the flag change.

However, during the testing I found using deathcause on a living unit resulted in it being dead due to an unknown cause, which led to the changes to the display_death_unit operation, and that change worked correctly, i.e. claiming the unit wasn't dead, compared to the original, which (still, of course), claimed an unknown death cause. Given that the flag change was applied in that branch, it's likely it works for body parts of live units as well. The live unit body part text could benefit from the addition of race, given that it's present everywhere else, but I don't want to mess with that part of the script since I don't have a case to test it on.