### PR TITLE
Dead misuse

### DIFF
--- a/adaptation.rb
+++ b/adaptation.rb
@@ -57,7 +57,7 @@ num_set = 0
 
 set_adaptation_value = lambda { |u,v|
     next if !df.unit_iscitizen(u)
-    next if u.flags1.dead
+    next if u.flags2.killed
     u.status.misc_traits.each { |t|
         if t.id == :CaveAdapt
             # TBD: expose the color_ostream console and color values of

--- a/devel/export-dt-ini.lua
+++ b/devel/export-dt-ini.lua
@@ -484,12 +484,12 @@ write_flags('valid_flags_2', {})
 write_flags('invalid_flags_1', {
     { 'a skeleton', { df.unit_flags1.skeleton } },
     { 'a merchant', { df.unit_flags1.merchant } },
-    { 'outpost liaison or diplomat', { df.unit_flags1.diplomat } },
+    { 'outpost liaison, diplomat, or artifact requesting visitor', { df.unit_flags1.diplomat } },
     { 'an invader or hostile', { df.unit_flags1.active_invader } },
     { 'an invader or hostile', { df.unit_flags1.invader_origin } },
     { 'resident, invader or ambusher', { df.unit_flags1.hidden_ambusher, df.unit_flags1.invades } },
     { 'part of a merchant caravan', { df.unit_flags1.forest } },
-    { 'Dead, Jim.', { df.unit_flags1.dead } },
+    { 'Inactive, currently not in play', { df.unit_flags1.dead } },
     { 'marauder', { df.unit_flags1.marauder } }
 });
 write_flags ('invalid_flags_2', {

--- a/emigration.lua
+++ b/emigration.lua
@@ -66,7 +66,7 @@ function canLeave(unit)
     
     return dfhack.units.isOwnRace(unit) and  --  Doubtful check. naturalized citizens
            dfhack.units.isOwnCiv(unit) and   --  might also want to leave.
-           not dfhack.units.isActive(unit) and
+           dfhack.units.isActive(unit) and
            not dfhack.units.isOpposedToLife(unit) and
            not unit.flags1.merchant and
            not unit.flags1.diplomat and

--- a/emigration.lua
+++ b/emigration.lua
@@ -56,25 +56,27 @@ function desert(u,method,civ)
 end
 
 function canLeave(unit)
+    if not unit.status.current_soul then
+        return false
+    end
+    
     for _, skill in pairs(unit.status.current_soul.skills) do
         if skill.rating > 14 then return false end
     end
-    if unit.flags1.caged
-        or unit.race ~= df.global.ui.race_id
-        or unit.civ_id ~= df.global.ui.civ_id
-        or dfhack.units.isDead(unit)
-        or dfhack.units.isOpposedToLife(unit)
-        or unit.flags1.merchant
-        or unit.flags1.diplomat
-        or unit.flags1.chained
-        or dfhack.units.getNoblePositions(unit) ~= nil
-        or unit.military.squad_id ~= -1
-        or dfhack.units.isCitizen(unit)
-        or dfhack.units.isSane(unit)
-        or unit.profession ~= 103
-        or not dfhack.units.isDead(unit)
-            then return false end
-    return true
+    
+    return dfhack.units.isOwnRace(unit) and  --  Doubtful check. naturalized citizens
+           dfhack.units.isOwnCiv(unit) and   --  might also want to leave.
+           not dfhack.units.isActive(unit) and
+           not dfhack.units.isOpposedToLife(unit) and
+           not unit.flags1.merchant and
+           not unit.flags1.diplomat and
+           not unit.flags1.chained and
+           dfhack.units.getNoblePositions(unit) == nil and
+           unit.military.squad_id == -1 and
+           dfhack.units.isCitizen(unit) and
+           dfhack.units.isSane(unit) and
+           not dfhack.units.isBaby(unit) and
+           not dfhack.units.isChild(unit)
 end
 
 function checkForDeserters(method,civ_id)
@@ -94,7 +96,7 @@ function checkmigrationnow()
     for i=0, #allUnits-1 do
         local unit = allUnits[i]
         if dfhack.units.isSane(unit)
-        and not dfhack.units.isDead(unit)
+        and dfhack.units.isActive(unit)
         and not dfhack.units.isOpposedToLife(unit)
         and not unit.flags1.tame
         then

--- a/exterminate.rb
+++ b/exterminate.rb
@@ -76,7 +76,7 @@ slayit = lambda { |u|
         # it's getting hot around here
         # !!WARNING!! do not call on a magma-safe creature
         ouh = df.onupdate_register("exterminate ensure #{u.id}", 1) {
-            if u.flags1.dead
+            if u.flags2.killed
                 df.onupdate_unregister(ouh)
             else
                 x, y, z = u.pos.x, u.pos.y, u.pos.z

--- a/fix/dead-units.lua
+++ b/fix/dead-units.lua
@@ -9,23 +9,34 @@ to around 3000 units, and this script reduces it back.
 
 ]====]
 local units = df.global.world.units.active
-local dwarf_race = df.global.ui.race_id
-local dwarf_civ = df.global.ui.civ_id
 local count = 0
+local month = 1200 * 28
+local year = month * 12
 
 for i=#units-1,0,-1 do
     local unit = units[i]
-    local flags1 = unit.flags1
-    local flags2 = unit.flags2
-    if flags1.dead and flags2.killed and unit.race ~= dwarf_race then
+    if dfhack.units.isDead(unit) and not dfhack.units.isOwnRace(unit) then
         local remove = false
-        if flags2.slaughter then
+        if dfhack.units.isMarkedForSlaughter(unit) then
             remove = true
-        elseif not unit.name.has_name then
+        elseif unit.hist_figure_id == -1 then
             remove = true
-        elseif unit.civ_id ~= dwarf_civ and
-               not (flags1.merchant or flags1.diplomat) then
+        elseif not dfhack.units.isOwnCiv(unit) and
+               not (dfhack.units.isMerchant(unit) or dfhack.units.isDiplomat(unit)) then
             remove = true
+        end
+        if remove and unit.counters.death_id ~= -1 then  --  Keep recent deaths around for a month before culling them. It's annoying to have that
+                                                         --  rampaging FB just be gone from both the other and dead lists, and you may want to keep
+                                                         --  killed wildlife around for a while too.
+                                                         --  We don't have a time of death for slaughtered units, so they go the first time.
+          local incident = df.incident.find(unit.counters.death_id)
+          if incident then
+            local incident_time = incident.event_year * year + incident.event_time
+            local now = df.global.cur_year * year + df.global.cur_year_tick
+            if now - incident_time < month then
+              remove = false  --  Wait a while before culling it.
+            end
+          end
         end
         if remove then
             count = count + 1

--- a/fix/feeding-timers.lua
+++ b/fix/feeding-timers.lua
@@ -17,7 +17,7 @@ end
 
 local fixcount = 0
 for _,unit in ipairs(df.global.world.units.all) do
- if dfhack.units.isCitizen(unit) and not (unit.flags1.dead) then
+ if dfhack.units.isCitizen(unit) and isActive(unit) then
   for _,v in pairs(unit.status.misc_traits) do
    local didfix = 0
    if v.id == 0 then -- I think this should have additional conditions...

--- a/fix/stuck-merchants.lua
+++ b/fix/stuck-merchants.lua
@@ -45,7 +45,7 @@ function dismissMerchants(args)
         end
     end
     for _,u in pairs(df.global.world.units.active) do
-        if u.flags1.merchant and u.flags1.dead then
+        if u.flags1.merchant and not dfhack.units.isActive (u) then
             print(('%s unit %d: %s (%s), civ %d (%s, %s)'):format(
                 dry_run and 'Would remove' or 'Removing',
                 u.id,

--- a/full-heal.lua
+++ b/full-heal.lua
@@ -25,7 +25,7 @@ the corpse - creepy!
 
 local utils = require('utils')
 
-validArgs = validArgs or utils.invert({
+local validArgs = utils.invert({
     'r',
     'help',
     'unit',

--- a/full-heal.lua
+++ b/full-heal.lua
@@ -25,7 +25,7 @@ the corpse - creepy!
 
 local utils = require('utils')
 
-validArgs = utils.invert({
+validArgs = validArgs or utils.invert({
     'r',
     'help',
     'unit',
@@ -54,7 +54,7 @@ end
 
 if unit then
     if args.r then
-        if unit.flags1.dead then
+        if unit.flags2.killed then
             --print("Resurrecting...")
             unit.flags2.slaughter = false
             unit.flags3.scuttle = false
@@ -187,7 +187,7 @@ if unit then
       --print("Clearing historical wounds...")
       histFig.info.wounds = nil
     end
-
+    
     local health = unit.health
     if health then
       for i = 0, #health.flags-1,1 do

--- a/gui/room-list.lua
+++ b/gui/room-list.lua
@@ -141,7 +141,7 @@ end
 
 function can_modify(sel_item)
     return sel_item and sel_item.owner
-       and sel_item.can_use and not sel_item.owner.flags1.dead
+       and sel_item.can_use and not sel_item.owner.flags2.killed
 end
 
 function RoomList:onRenderBody(dc)

--- a/gui/unit-info-viewer.lua
+++ b/gui/unit-info-viewer.lua
@@ -408,7 +408,7 @@ function Identity:init(args)
 
 
  ------------ death ------------
- self.dead = u.flags1.dead
+ self.dead = u.flags2.killed
  self.ghostly = u.flags3.ghostly
  self.undead = u.enemy.undead
 

--- a/warn-starving.lua
+++ b/warn-starving.lua
@@ -120,7 +120,7 @@ function doCheck()
     for i=#units-1, 0, -1 do
         local unit = units[i]
         local rraw = findRaceCaste(unit)
-        if rraw and not unit.flags1.dead and not dfhack.units.isOpposedToLife(unit) then
+        if rraw and dfhack.units.isActive(unit) and not dfhack.units.isOpposedToLife(unit) then
             table.insert(messages, checkVariable(unit.counters2.hunger_timer, 75000, 'starving', starvingUnits, unit))
             table.insert(messages, checkVariable(unit.counters2.thirst_timer, 50000, 'dehydrated', dehydratedUnits, unit))
             table.insert(messages, checkVariable(unit.counters2.sleepiness_timer, 150000, 'very drowsy', sleepyUnits, unit))


### PR DESCRIPTION
Adjusted usage of flags1.dead to use flags2.killed in scripts that appear to use the flag to target dead unit rather than inactive ones.
The DT script has updated the comments produced to better reflect the current understanding, but not any address info.

The scripts have gone through rudimentary testing to see that they still work (to e.g. catch typing errors), but not anything beyond that.

It can be noted that gui/unit-info-viewer.lua produced a nonsensical output of strength:agility being in cubic decimeters, resulting in a 1.5:1.1 cubic meter dwarf, but I don't intend to do anything about it beyond this comment.

Relates to df-structures issue 247.
Link:  DFHack/df-structures#247