### PR TITLE
Don't assume that List:setChoices takes reference

### DIFF
--- a/gui/advfort_items.lua
+++ b/gui/advfort_items.lua
@@ -89,8 +89,8 @@ function jobitemEditor:init(args)
     end
 end
 function jobitemEditor:get_slot()
-    local idx,choice=self.subviews.itemList:getSelected()
-    return choice
+    local idx=self.subviews.itemList:getSelected()
+    return self.slots[idx]
 end
 function jobitemEditor:can_add()
     local slot=self:get_slot()

--- a/gui/gm-unit.lua
+++ b/gui/gm-unit.lua
@@ -228,9 +228,8 @@ function CivBox:update_choices()
             table.insert(choices,{text=text,raw=v,num=i})
         end
     end
-    self.choices=choices
     if self.subviews.list then
-        self.subviews.list:setChoices(self.choices)
+        self.subviews.list:setChoices(choices)
     end
 end
 function CivBox:update_race_filter(id)
@@ -546,7 +545,6 @@ function editor_wounds:update_wounds()
         table.insert(ret,{text=format_wound(i, v,self.target_unit),wound=v})
     end
     self.subviews.wounds:setChoices(ret)
-    self.wound_list=ret
 end
 function editor_wounds:dirty_unit()
     self.target_unit.flags2={calculated_nerves=false,calculated_bodyparts=false,calculated_insulation=false}


### PR DESCRIPTION
This is a quick fix to scripts that seem to assume List:setChoices takes
reference of the choices table.

This is preparations for gui.widgets List::setChoices change where it copies choices to an internal table.