### PR TITLE
Adds tame.lua a script for taming/training animals

### DIFF
--- a/tame.lua
+++ b/tame.lua
@@ -1,0 +1,38 @@
+-- tame and train animals {set animals as Wild through to Masterfully Trained}
+
+local help=[====[
+tame
+====
+Tame and train animals.
+
+Usage: tame -set <level>
+
+:0: wild
+:1: trained
+:2: well-trained
+:3: skillfully trained
+:4: expertly trained
+:5: exceptionally trained
+:6: masterfully trained
+:7: tame
+:8: semi-wild
+]====]
+
+local utils = require('utils')
+local selected = dfhack.gui.getSelectedUnit()
+local validArgs = utils.invert({'set'})
+local args = utils.processArgs({...}, validArgs)
+--[
+if args.set and tonumber(args.set) then
+    local level = tonumber(args.set)
+    if level < 0 or level > 8 then
+        print(help)
+        error("range must be 0 to 9")
+    end
+    selected.flags1.tame = level ~= 0
+    selected.training_level = level
+else
+    print(help)
+end
+--]]
+

--- a/tame.lua
+++ b/tame.lua
@@ -5,9 +5,9 @@ tame
 ====
 Tame and train animals.
 
-Usage: tame -set <level>
+Usage: `tame -read` OR `tame -set <level>`
 
-:0: wild
+:0: semi-wild
 :1: trained
 :2: well-trained
 :3: skillfully trained
@@ -15,24 +15,35 @@ Usage: tame -set <level>
 :5: exceptionally trained
 :6: masterfully trained
 :7: tame
-:8: semi-wild
+:8: wild
+:9: wild
 ]====]
 
 local utils = require('utils')
 local selected = dfhack.gui.getSelectedUnit()
-local validArgs = utils.invert({'set'})
+local validArgs = utils.invert({'set','read'})
 local args = utils.processArgs({...}, validArgs)
---[
-if args.set and tonumber(args.set) then
-    local level = tonumber(args.set)
-    if level < 0 or level > 8 then
+
+if selected ~= nil then
+    if args.set and tonumber(args.set) then
+        local level = tonumber(args.set)
+        if level < 0 or level > 9 then
+            qerror("range must be 0 to 9")
+            print(help)
+        end
+        selected.flags1.tame = level ~= 8 and level ~= 9
+        if selected.flags1.tame then
+            selected.training_level = level
+        else
+            selected.training_level = 9
+        end
+    elseif args.read then
+        print("tame:",selected.flags1.tame)
+        print("training level:",selected.training_level)
+    else
         print(help)
-        error("range must be 0 to 9")
     end
-    selected.flags1.tame = level ~= 0
-    selected.training_level = level
 else
-    print(help)
+    qerror("select a valid unit")
 end
---]]
 

--- a/tame.lua
+++ b/tame.lua
@@ -5,7 +5,7 @@ tame
 ====
 Tame and train animals.
 
-Usage: `tame -read` OR `tame -set <level>`
+Usage: ``tame -read`` OR ``tame -set <level>``
 
 :0: semi-wild
 :1: trained


### PR DESCRIPTION
This script takes the highlighted unit and attempts to set the level of training, and toggles the `tame` flag as necessary.

```
tame
====
Tame and train animals.

Usage: `tame -read` OR `tame -set <level>`

:0: semi-wild
:1: trained
:2: well-trained
:3: skillfully trained
:4: expertly trained
:5: exceptionally trained
:6: masterfully trained
:7: tame
:8: wild
:9: wild
```