### PR TITLE
bodyswap: made script useable in arena mode

### DIFF
--- a/bodyswap.lua
+++ b/bodyswap.lua
@@ -39,7 +39,7 @@ if args.help then
   return
 end
 
-if not df.global.gamemode == df.game_mode.ADVENTURE then
+if df.global.gamemode ~= df.game_mode.ADVENTURE then
   qerror("This script can only be used in adventure mode!")
 end
 

--- a/bodyswap.lua
+++ b/bodyswap.lua
@@ -17,7 +17,7 @@ local usage = [====[
 bodyswap
 ========
 This script allows the player to take direct control of any unit present in
-adventure mode whilst losing control of their current adventurer.
+adventure mode whilst giving up control of their current player character.
 
 To specify the target unit, simply select it in the user interface,
 such as by opening the unit's status screen or viewing its description,
@@ -35,11 +35,11 @@ Arguments::
 ]====]
 
 if args.help then
- print(usage)
- return
+  print(usage)
+  return
 end
 
-if not dfhack.world.isAdventureMode() then
+if not df.global.gamemode == df.game_mode['ADVENTURE'] then
   qerror("This script can only be used in adventure mode!")
 end
 

--- a/bodyswap.lua
+++ b/bodyswap.lua
@@ -39,7 +39,7 @@ if args.help then
   return
 end
 
-if not df.global.gamemode == df.game_mode['ADVENTURE'] then
+if not df.global.gamemode == df.game_mode.ADVENTURE then
   qerror("This script can only be used in adventure mode!")
 end
 


### PR DESCRIPTION
As per the PR title, this minor change makes it possible to bodyswap in arena mode when controlling a unit. Testing has shown that this script can be used copiously in arena mode with no apparent ill effects. Also included is a trivial change in documentation.