### PR TITLE
Add special case to exterminate to only target hostile members of a race

### DIFF
--- a/exterminate.rb
+++ b/exterminate.rb
@@ -188,7 +188,7 @@ else
     df.world.units.active.each do |u|
         if u.race == race_nr and checkunit[u]
             if caste_nr
-                next if caste == "enemy" && !df.unit_hostile(u)
+                next if caste == "enemy" && !df.unit_ishostile(u)
                 next if caste != "enemy" && u.caste != caste_nr
             end
             slayit[u]

--- a/exterminate.rb
+++ b/exterminate.rb
@@ -188,7 +188,7 @@ else
     df.world.units.active.each do |u|
         if u.race == race_nr and checkunit[u]
             if caste_nr
-                next if caste == "enemy" && df.unit_hostile(u)
+                next if caste == "enemy" && !df.unit_hostile(u)
                 next if caste != "enemy" && u.caste != caste_nr
             end
             slayit[u]


### PR DESCRIPTION
Add a new special case caste called `enemy` so one can target non-fortress guests i.e. goblin invaders  without the tedium of doing 1 by 1 or killing citizens of your fort that happen to be goblins.

I have done limited testing of this with invaders and undead and things but this is feature complete I think.

Also it updates the help text to indicate how to use this feature.