### PR TITLE
modtools/create-item.lua include quality arg in help

### DIFF
--- a/modtools/create-item.lua
+++ b/modtools/create-item.lua
@@ -26,6 +26,12 @@ Arguments::
         specify the itemdef of the item to be created
         examples:
             WEAPON:ITEM_WEAPON_PICK
+    -quality qualitystr
+        specify the quality level of the item to be created
+        examples:
+            0 - ordinary
+            1 - wellcrafted
+            5 - masterwork
     -matchingShoes
         create two of this item
     -matchingGloves


### PR DESCRIPTION
Fairly important argument to the script that isn't shown in the repl help and is easy to add in.