### PR TITLE
modtools/create-unit: added -duration, -locationRange, -locationType

### DIFF
--- a/modtools/create-unit.lua
+++ b/modtools/create-unit.lua
@@ -359,17 +359,20 @@ end
 
 function getLocationChoices(pos, offset_x, offset_y, offset_z)
   local spawnCoords = {}
-  local map = df.global.world.map
   local min_x = pos.x - offset_x
   local max_x = pos.x + offset_x
   local min_y = pos.y - offset_y
   local max_y = pos.y + offset_y
   local min_z = pos.z - offset_z
   local max_z = pos.z + offset_z
+  local map = df.global.world.map
+  local map_x = map.x_count-1 -- maximum local coordinates on the loaded map
+  local map_y = map.y_count-1
+  local map_z = map.z_count-1
 
-  for x = min_x >= 0 and min_x or 0, max_x <= map.x_count and max_x or map.x_count do
-    for y = min_y >= 0 and min_y or 0, max_y <= map.y_count and max_y or map.y_count do
-      for z = min_z >= 0 and min_z or 0, max_z <= map.z_count and max_z or map.z_count do
+  for x = min_x >= 0 and min_x or 0, max_x <= map_x and max_x or map_x do
+    for y = min_y >= 0 and min_y or 0, max_y <= map_y and max_y or map_y do
+      for z = min_z >= 0 and min_z or 0, max_z <= map_z and max_z or map_z do
         table.insert(spawnCoords,{x = x, y = y, z = z})
       end
     end

--- a/modtools/create-unit.lua
+++ b/modtools/create-unit.lua
@@ -98,12 +98,13 @@ Creates a unit.  Usage::
     -locationType type
         may be used with -locationRange
         to specify what counts as a valid tile for unit spawning
+        unit creation will not occur if no valid tiles are available
         replace "type" with one of the following:
             Walkable
                 units will only be placed on walkable ground tiles
                 this is the default used if -locationType is omitted
             Open
-                open spaces are valid spawn points
+                open spaces are also valid spawn points
                 this is intended for flying units
             Any
                 all tiles, including solid walls, are valid
@@ -272,18 +273,16 @@ function createUnitInner(race_id, caste_id, caste_id_choices, pos, locationChoic
     df.global.cursor.x = tonumber(pos.x)
     df.global.cursor.y = tonumber(pos.y)
     df.global.cursor.z = tonumber(pos.z)
-  else
-    local noValidLocationChoices = false
   end
 
   local createdUnits = {}
-  for n = 1,spawnNumber do -- loop here to avoid having to handle spawn data each time when creating multiple units
+  for n = 1, spawnNumber do -- loop here to avoid having to handle spawn data each time when creating multiple units
     if not caste_id then -- choose a random caste ID each time
       arenaSpawn.caste:insert(0, caste_id_choices[math.random(1, #caste_id_choices)])
     end
 
-    if locationChoices and not noValidLocationChoices then
-      -- select a random spawn position within the specified location range, if available
+    if locationChoices then
+--    select a random spawn position within the specified location range, if available
       local randomPos
       for n = 1, #locationChoices do
         local i = math.random(1, #locationChoices)
@@ -295,13 +294,12 @@ function createUnitInner(race_id, caste_id, caste_id_choices, pos, locationChoic
         end
       end
       if randomPos then
-        pos = randomPos -- if no valid tiles are found, the -location pos is used instead
+        df.global.cursor.x = tonumber(randomPos.x)
+        df.global.cursor.y = tonumber(randomPos.y)
+        df.global.cursor.z = tonumber(randomPos.z)
       else
-        noValidLocationChoices = true -- prevent futile searches in the next spawning sequence
+        break -- no valid tiles available; terminate the spawn loop without creating any units
       end
-      df.global.cursor.x = tonumber(pos.x)
-      df.global.cursor.y = tonumber(pos.y)
-      df.global.cursor.z = tonumber(pos.z)
     end
 
     gui.simulateInput(dwarfmodeScreen, 'D_LOOK_ARENA_CREATURE') -- open the arena spawning menu

--- a/modtools/create-unit.lua
+++ b/modtools/create-unit.lua
@@ -697,11 +697,11 @@ function setAge(unit, age)
 -- Turn into a child or baby if appropriate:
   local getAge = age or dfhack.units.getAge(unit,true)
   local cr = df.creature_raw.find(unit.race).caste[unit.caste]
-  if cr.flags.BABY and (getAge < cr.misc.baby_age) then
+  if cr.flags.HAS_BABYSTATE and (getAge < cr.misc.baby_age) then
     unit.profession = df.profession.BABY
     --unit.profession2 = df.profession.BABY
     unit.mood = df.mood_type.Baby
-  elseif cr.flags.CHILD and (getAge < cr.misc.child_age) then
+  elseif cr.flags.HAS_CHILDSTATE and (getAge < cr.misc.child_age) then
     unit.profession = df.profession.CHILD
     --unit.profession2 = df.profession.CHILD
   end
@@ -721,8 +721,8 @@ end
 
 function domesticateUnit(unit)
   -- If a friendly animal, make it domesticated.  From Boltgun & Dirst
-  local caste = df.creature_raw.find(unit.race).caste[unit.caste]
-  if not(caste.flags.CAN_SPEAK and caste.flags.CAN_LEARN) then
+  local casteFlags = unit.enemy.caste_flags
+  if not(casteFlags.CAN_SPEAK and casteFlags.CAN_LEARN) then
     -- Fix friendly animals (from Boltgun)
     unit.flags2.resident = false
     unit.population_id = -1
@@ -739,11 +739,11 @@ function domesticateUnit(unit)
 end
 
 function wildUnit(unit)
-  local caste = df.creature_raw.find(unit.race).caste[unit.caste]
+  local casteFlags = unit.enemy.caste_flags
   -- x = df.global.world.world_data.active_site[0].pos.x
   -- y = df.global.world.world_data.active_site[0].pos.y
   -- region = df.global.map.map_blocks[df.global.map.x_count_block*x+y]
-  if not(caste.flags.CAN_SPEAK and caste.flags.CAN_LEARN) then
+  if not(casteFlags.CAN_SPEAK and casteFlags.CAN_LEARN) then
     if #df.global.world.world_data.active_site > 0 then -- empty in adventure mode
       unit.animal.population.region_x = df.global.world.world_data.active_site[0].pos.x
       unit.animal.population.region_y = df.global.world.world_data.active_site[0].pos.y
@@ -762,7 +762,7 @@ function enableDefaultLabors(unit)
   if unit.profession == df.profession.BABY or unit.profession == df.profession.CHILD then
     return
   end
-  if df.creature_raw.find(unit.race).caste[unit.caste].flags.CAN_LEARN then
+  if unit.enemy.caste_flags.CAN_LEARN then
     local labors = unit.status.labors
     labors.HAUL_STONE = true
     labors.HAUL_WOOD = true


### PR DESCRIPTION
**new arg**: `-duration`
Enables the user to set a time limit on the existence of created units. The unit vanishes in a puff of smoke once the specified number of ticks has elapsed.

**new arg**: `-locationRange`
Randomly spawn the unit anywhere within a specified number of x, y, z tiles away from the target location, if possible.

**new arg**: `-locationType`
Enables users to specify what counts as a valid tile for unit spawning when used with `-locationRange`. Defaults to `Walkable`, also takes `Open` and `Any`. Units are not created if no valid tiles are present at the location indicated (I inititially made the script place units at the `-location` coordinates in this scenario, but I think that this makes more sense).

These additions are meant to emulate the `IE_TIME_RANGE` and `RANDOM_NEARBY_LOCATION` tokens available for the new summoning interactions as of 0.47.01.
