### PR TITLE
Add `list` option to repeat.lua

### DIFF
--- a/repeat.lua
+++ b/repeat.lua
@@ -14,6 +14,7 @@ Usage examples::
 
     repeat -name jim -time delay -timeUnits units -command [ printArgs 3 1 2 ]
     repeat -time 1 -timeUnits months -command [ multicmd cleanowned scattered x; clean all ] -name clean
+    repeat list
 
 The first example is abstract; the second will regularly remove all contaminants
 and worn items from the game.
@@ -33,6 +34,8 @@ Arguments:
     ``...`` specifies the command to be run
 ``-cancel NAME``
     cancels the repetition with the name NAME
+``list``
+    prints names of scheduled commands
 
 ]====]
 
@@ -47,6 +50,13 @@ local validArgs = utils.invert({
  'timeUnits',
  'command'
 })
+
+if (...) == 'list' then
+    for k in pairs(repeatUtil.repeating) do
+        print(k)
+    end
+    return
+end
 
 local args = utils.processArgs({...}, validArgs)
 

--- a/repeat.lua
+++ b/repeat.lua
@@ -14,7 +14,7 @@ Usage examples::
 
     repeat -name jim -time delay -timeUnits units -command [ printArgs 3 1 2 ]
     repeat -time 1 -timeUnits months -command [ multicmd cleanowned scattered x; clean all ] -name clean
-    repeat list
+    repeat -list
 
 The first example is abstract; the second will regularly remove all contaminants
 and worn items from the game.
@@ -34,7 +34,7 @@ Arguments:
     ``...`` specifies the command to be run
 ``-cancel NAME``
     cancels the repetition with the name NAME
-``list``
+``-list``
     prints names of scheduled commands
 
 ]====]
@@ -48,15 +48,9 @@ local validArgs = utils.invert({
  'name',
  'time',
  'timeUnits',
- 'command'
+ 'command',
+ 'list'
 })
-
-if (...) == 'list' then
-    for k in pairs(repeatUtil.repeating) do
-        print(k)
-    end
-    return
-end
 
 local args = utils.processArgs({...}, validArgs)
 
@@ -70,22 +64,27 @@ if args.cancel then
  if args.name then
   repeatUtil.cancel(args.name)
  end
+elseif args.command then
+ local time = tonumber(args.time)
+
+ if not args.name then
+  args.name = args.command[1]
+ end
+
+ if not args.timeUnits then
+  args.timeUnits = 'ticks'
+ end
+
+ local callCommand = function()
+  dfhack.run_command(table.unpack(args.command))
+ end
+
+ repeatUtil.scheduleEvery(args.name,time,args.timeUnits,callCommand)
+end
+
+if args.list then
+ for k in pairs(repeatUtil.repeating) do
+  print(k)
+ end
  return
 end
-
-local time = tonumber(args.time)
-
-if not args.name then
- args.name = args.command[1]
-end
-
-if not args.timeUnits then
- args.timeUnits = 'ticks'
-end
-
-local callCommand = function()
- dfhack.run_command(table.unpack(args.command))
-end
-
-repeatUtil.scheduleEvery(args.name,time,args.timeUnits,callCommand)
-


### PR DESCRIPTION
This allows viewing what commands are set to repeat (by their names).

The idea is to help novice users (like me) to explore what a preinstalled `dfhack` (like from _Lazy Newb Pack_) is doing.