### PR TITLE
export-dt-ini: change offset name to reflect changed type

### DIFF
--- a/devel/export-dt-ini.lua
+++ b/devel/export-dt-ini.lua
@@ -356,7 +356,7 @@ address('cie_first_perc',df.creature_interaction_effect_phys_att_changest,'phys_
 address('cie_phys',df.creature_interaction_effect_phys_att_changest,'phys_att_add')
 address('cie_ment',df.creature_interaction_effect_ment_att_changest,'ment_att_add')
 address('syn_classes_vector',df.syndrome,'syn_class')
-address('trans_race_id',df.creature_interaction_effect_body_transformationst,'race')
+address('trans_race_vec',df.creature_interaction_effect_body_transformationst,'race')
 
 header('unit_wound_offsets')
 address('parts',df.unit_wound,'parts')


### PR DESCRIPTION
https://github.com/DFHack/df-structures/pull/366 re-add creature_interaction_effect_body_transformationst.race which was removed in https://github.com/DFHack/df-structures/commit/c18cbeb28a8fb4f67e63db0547ac4b221c6903b6 but as a vector instead of an int32_t. Change the name of the offset so DT can see the changed type and adapt.