### PR TITLE
once-per-save.lua: like multicmd but only if not already ran

### DIFF
--- a/once-per-save.lua
+++ b/once-per-save.lua
@@ -1,0 +1,57 @@
+-- runs dfhack commands unless ran already in this save
+
+local HELP = [====[
+
+once-per-save
+=============
+Runs commands like ``multicmd``, but only unless
+not already ran once in current save.
+
+Use this in ``onMapLoad.ini`` with f.e. ``ban-cooking``::
+
+  once-per-save ban-cooking tallow; ban-cooking honey; ban-cooking oil; ban-cooking seeds; ban-cooking brew; ban-cooking fruit; ban-cooking mill; ban-cooking thread; ban-cooking milk;
+
+Only successfully ran commands are saved.
+
+Parameters:
+
+--help            display this help
+--rerun commands  ignore saved commands
+--reset           deleted saved commands
+
+]====]
+
+local STORAGEKEY = 'once-per-save'
+
+local args = {...}
+local rerun = false
+if args[1] == "--help" or args[1] == "-?" or args[1] == "?" then
+    print(HELP)
+    return
+elseif args[1] == "--rerun" then
+    rerun = true
+    table.remove(args, 1)
+elseif args[1] == "--reset" then
+    while dfhack.persistent.delete(STORAGEKEY) do end
+    table.remove(args, 1)
+end
+if #args == 0 then return end
+
+local once_run = {}
+if not rerun then
+    local entries = dfhack.persistent.get_all(STORAGEKEY) or {}
+    for i, entry in ipairs(entries) do
+        once_run[entry.value]=entry
+    end
+end
+
+for cmd in table.concat(args, ' '):gmatch("%s*([^;]+);?%s*") do
+    if not once_run[cmd] then
+        local ok = dfhack.run_command(cmd) == 0
+        if ok then
+            once_run[cmd] = dfhack.persistent.save({key = STORAGEKEY, value = cmd}, true)
+        elseif rerun and once_run[cmd] then
+            once_run[cmd]:delete()
+        end
+    end
+end

--- a/once-per-save.lua
+++ b/once-per-save.lua
@@ -4,9 +4,9 @@ local HELP = [====[
 
 once-per-save
 =============
-Runs commands like :ref:`multicmd`, but only unless
+Runs commands like `multicmd`, but only unless
 not already ran once in current save. You may actually
-want :ref:`on-new-fortress`.
+want `on-new-fortress`.
 
 Only successfully ran commands are saved.
 

--- a/once-per-save.lua
+++ b/once-per-save.lua
@@ -17,7 +17,7 @@ Parameters:
 
 --help            display this help
 --rerun commands  ignore saved commands
---reset           deleted saved commands
+--reset           deletes saved commands
 
 ]====]
 
@@ -28,9 +28,9 @@ local args = {...}
 local rerun = false
 
 local utils = require 'utils'
-local arg_help = utils.invert({"?", "-?", "-help", "--help"})
-local arg_rerun = utils.invert({"-rerun", "--rerun"})
-local arg_reset = utils.invert({"-reset", "--reset"})
+local arg_help = utils.invert{"?", "-?", "-help", "--help"}
+local arg_rerun = utils.invert{"-rerun", "--rerun"}
+local arg_reset = utils.invert{"-reset", "--reset"}
 if arg_help[args[1]] then
     print(HELP)
     return

--- a/once-per-save.lua
+++ b/once-per-save.lua
@@ -25,14 +25,19 @@ local STORAGEKEY = 'once-per-save'
 
 local args = {...}
 local rerun = false
-if args[1] == "--help" or args[1] == "-?" or args[1] == "?" then
+
+local utils = require 'utils'
+local arg_help = utils.invert({"?", "-?", "-help", "--help"})
+local arg_rerun = utils.invert({"-rerun", "--rerun"})
+local arg_reset = utils.invert({"-reset", "--reset"})
+if arg_help[args[1]] then
     print(HELP)
     return
-elseif args[1] == "--rerun" then
+elseif arg_rerun[args[1]] then
     rerun = true
     table.remove(args, 1)
-elseif args[1] == "--reset" then
-    while dfhack.persistent.delete(STORAGEKEY) do end
+elseif arg_reset[args[1]] then
+    while dfhack.persistent.delete(storagekey) do end
     table.remove(args, 1)
 end
 if #args == 0 then return end

--- a/once-per-save.lua
+++ b/once-per-save.lua
@@ -4,12 +4,9 @@ local HELP = [====[
 
 once-per-save
 =============
-Runs commands like ``multicmd``, but only unless
-not already ran once in current save.
-
-Use this in ``onMapLoad.init`` with f.e. ``ban-cooking``::
-
-  once-per-save ban-cooking tallow; ban-cooking honey; ban-cooking oil; ban-cooking seeds; ban-cooking brew; ban-cooking fruit; ban-cooking mill; ban-cooking thread; ban-cooking milk;
+Runs commands like :ref:`multicmd`, but only unless
+not already ran once in current save. You may actually
+want :ref:`on-new-fortress`.
 
 Only successfully ran commands are saved.
 

--- a/once-per-save.lua
+++ b/once-per-save.lua
@@ -7,7 +7,7 @@ once-per-save
 Runs commands like ``multicmd``, but only unless
 not already ran once in current save.
 
-Use this in ``onMapLoad.ini`` with f.e. ``ban-cooking``::
+Use this in ``onMapLoad.init`` with f.e. ``ban-cooking``::
 
   once-per-save ban-cooking tallow; ban-cooking honey; ban-cooking oil; ban-cooking seeds; ban-cooking brew; ban-cooking fruit; ban-cooking mill; ban-cooking thread; ban-cooking milk;
 


### PR DESCRIPTION
Runs commands the way `multicmd` does, but only unless not already ran once in current save.

Use this in `onMapLoad.ini` with f.e. `ban-cooking`

    once-per-save ban-cooking tallow; ban-cooking honey; ban-cooking oil; ban-cooking seeds; ban-cooking brew; ban-cooking fruit; ban-cooking mill; ban-cooking thread; ban-cooking milk;

Only successfully ran commands are saved.

I would love to make this per-fortress instead of per-save but have no idea how.