### PR TITLE
onNewFortress: runs commands only in a newborn fortress

### DIFF
--- a/on-new-fortress.lua
+++ b/on-new-fortress.lua
@@ -4,9 +4,9 @@ local HELP = [====[
 
 on-new-fortress
 ===============
-Runs commands like ``multicmd``, but only in a newborn fortress.
+Runs commands like :ref:`multicmd`, but only in a newborn fortress.
 
-Use this in ``onMapLoad.init`` with f.e. ``ban-cooking``::
+Use this in ``onMapLoad.init`` with f.e. :ref:`ban-cooking`::
 
   on-new-fortress ban-cooking tallow; ban-cooking honey; ban-cooking oil; ban-cooking seeds; ban-cooking brew; ban-cooking fruit; ban-cooking mill; ban-cooking thread; ban-cooking milk;
 

--- a/on-new-fortress.lua
+++ b/on-new-fortress.lua
@@ -4,9 +4,9 @@ local HELP = [====[
 
 on-new-fortress
 ===============
-Runs commands like :ref:`multicmd`, but only in a newborn fortress.
+Runs commands like `multicmd`, but only in a newborn fortress.
 
-Use this in ``onMapLoad.init`` with f.e. :ref:`ban-cooking`::
+Use this in ``onMapLoad.init`` with f.e. `ban-cooking`::
 
   on-new-fortress ban-cooking tallow; ban-cooking honey; ban-cooking oil; ban-cooking seeds; ban-cooking brew; ban-cooking fruit; ban-cooking mill; ban-cooking thread; ban-cooking milk;
 

--- a/on-new-fortress.lua
+++ b/on-new-fortress.lua
@@ -2,13 +2,13 @@
 
 local HELP = [====[
 
-onNewFortress
-=============
+on-new-fortress
+===============
 Runs commands like ``multicmd``, but only in a newborn fortress.
 
 Use this in ``onMapLoad.init`` with f.e. ``ban-cooking``::
 
-  onNewFortress ban-cooking tallow; ban-cooking honey; ban-cooking oil; ban-cooking seeds; ban-cooking brew; ban-cooking fruit; ban-cooking mill; ban-cooking thread; ban-cooking milk;
+  on-new-fortress ban-cooking tallow; ban-cooking honey; ban-cooking oil; ban-cooking seeds; ban-cooking brew; ban-cooking fruit; ban-cooking mill; ban-cooking thread; ban-cooking milk;
 
 ]====]
 

--- a/on-new-fortress.lua
+++ b/on-new-fortress.lua
@@ -9,6 +9,7 @@ Runs commands like `multicmd`, but only in a newborn fortress.
 Use this in ``onMapLoad.init`` with f.e. `ban-cooking`::
 
   on-new-fortress ban-cooking tallow; ban-cooking honey; ban-cooking oil; ban-cooking seeds; ban-cooking brew; ban-cooking fruit; ban-cooking mill; ban-cooking thread; ban-cooking milk;
+  on-new-fortress 3dveins
 
 ]====]
 

--- a/on-new-fortress.lua
+++ b/on-new-fortress.lua
@@ -18,7 +18,7 @@ if not (...) then
     return
 end
 
-if df.global.ui.fortress_age ~= 0 then return end
+if not (dfhack.world.isFortressMode() and df.global.ui.fortress_age == 0) then return end
 
 for cmd in table.concat({...}, ' '):gmatch("%s*([^;]+);?%s*") do
     dfhack.run_command(cmd)

--- a/onNewFortress.lua
+++ b/onNewFortress.lua
@@ -1,0 +1,25 @@
+-- runs dfhack commands only in a newborn fortress
+
+local HELP = [====[
+
+onNewFortress
+=============
+Runs commands like ``multicmd``, but only in a newborn fortress.
+
+Use this in ``onMapLoad.init`` with f.e. ``ban-cooking``::
+
+  onNewFortress ban-cooking tallow; ban-cooking honey; ban-cooking oil; ban-cooking seeds; ban-cooking brew; ban-cooking fruit; ban-cooking mill; ban-cooking thread; ban-cooking milk;
+
+]====]
+
+
+if not (...) then
+    print(HELP)
+    return
+end
+
+if df.global.ui.fortress_age ~= 0 then return end
+
+for cmd in table.concat({...}, ' '):gmatch("%s*([^;]+);?%s*") do
+    dfhack.run_command(cmd)
+end


### PR DESCRIPTION
The script only checks if `df.global.ui.fortress_age` is `0` and if it isn't, does nothing.

Use this in `onMapLoad.init` with f.e. `ban-cooking`:

    onNewFortress ban-cooking tallow; ban-cooking honey; ban-cooking oil; ban-cooking seeds; ban-cooking brew; ban-cooking fruit; ban-cooking mill; ban-cooking thread; ban-cooking milk;

This may make #119 unnecessary.