### PR TITLE
exportlegends: export more details for entities and regions

### DIFF
--- a/exportlegends.lua
+++ b/exportlegends.lua
@@ -351,6 +351,11 @@ function export_more_legends_xml()
                 end
             end
         end
+        if entityV.type == df.historical_entity_type.Guild then -- Get profession
+           for professionK,professionV in pairs(entityV.guild_professions) do
+              file:write("\t\t<profession>"..df_enums.profession[professionV.profession]:lower().."</profession>\n")
+           end
+        end
         for id, link in pairs(entityV.entity_links) do
             file:write("\t\t<entity_link>\n")
                 for k, v in pairs(link) do

--- a/exportlegends.lua
+++ b/exportlegends.lua
@@ -161,13 +161,13 @@ function export_more_legends_xml()
            file:write(xVal..","..regionV.region_coords.y[xK].."|")
         end
         file:write("</coords>\n")
-		local evilness = "neutral"
+        local evilness = "neutral"
         if regionV.evil then
-		   evilness = "evil"
+           evilness = "evil"
         elseif regionV.good then
-		   evilness = "good"
+           evilness = "good"
         end
-		file:write("\t\t<evilness>"..evilness.."</evilness>\n")
+        file:write("\t\t<evilness>"..evilness.."</evilness>\n")
         for forceK, forceVal in ipairs(regionV.forces) do
            file:write("\t\t<force_id>"..forceVal.."</force_id>\n")
         end
@@ -354,10 +354,17 @@ function export_more_legends_xml()
             file:write("\t\t<race>"..(df.global.world.raws.creatures.all[entityV.race].creature_id):lower().."</race>\n")
         end
         file:write("\t\t<type>"..(df_enums.historical_entity_type[entityV.type]):lower().."</type>\n")
-        if entityV.type == df.historical_entity_type.Religion then -- Get worshipped figure
-            if (entityV.unknown1b ~= nil and entityV.unknown1b.worship ~= nil) then
-                for k,v in pairs(entityV.unknown1b.worship) do
+        if entityV.type == df.historical_entity_type.Religion or entityV.type == df.historical_entity_type.MilitaryUnit then -- Get worshipped figures
+            if (entityV.unknown1b ~= nil and entityV.unknown1b.deities ~= nil) then
+                for k,v in pairs(entityV.unknown1b.deities) do
                     file:write("\t\t<worship_id>"..v.."</worship_id>\n")
+                end
+            end
+        end
+        if entityV.type == df.historical_entity_type.MilitaryUnit then -- Get favorite weapons
+            if (entityV.resources ~= nil and entityV.resources.weapon_type ~= nil) then
+                for weaponK,weaponID in pairs(entityV.resources.weapon_type) do
+                    file:write("\t\t<weapon>"..getItemSubTypeName(df.item_type.WEAPON, weaponID).."</weapon>\n")
                 end
             end
         end

--- a/exportlegends.lua
+++ b/exportlegends.lua
@@ -157,10 +157,20 @@ function export_more_legends_xml()
         file:write("\t<region>\n")
         file:write("\t\t<id>"..regionV.index.."</id>\n")
         file:write("\t\t<coords>")
-            for xK, xVal in ipairs(regionV.region_coords.x) do
-                file:write(xVal..","..regionV.region_coords.y[xK].."|")
-            end
+        for xK, xVal in ipairs(regionV.region_coords.x) do
+           file:write(xVal..","..regionV.region_coords.y[xK].."|")
+        end
         file:write("</coords>\n")
+		local evilness = "neutral"
+        if regionV.evil then
+		   evilness = "evil"
+        elseif regionV.good then
+		   evilness = "good"
+        end
+		file:write("\t\t<evilness>"..evilness.."</evilness>\n")
+        for forceK, forceVal in ipairs(regionV.forces) do
+           file:write("\t\t<force_id>"..forceVal.."</force_id>\n")
+        end
         file:write("\t</region>\n")
     end
     file:write("</regions>\n")

--- a/exportlegends.lua
+++ b/exportlegends.lua
@@ -355,8 +355,8 @@ function export_more_legends_xml()
         end
         file:write("\t\t<type>"..(df_enums.historical_entity_type[entityV.type]):lower().."</type>\n")
         if entityV.type == df.historical_entity_type.Religion or entityV.type == df.historical_entity_type.MilitaryUnit then -- Get worshipped figures
-            if (entityV.unknown1b ~= nil and entityV.unknown1b.deities ~= nil) then
-                for k,v in pairs(entityV.unknown1b.deities) do
+            if (entityV.relations ~= nil and entityV.relations.deities ~= nil) then
+                for k,v in pairs(entityV.relations.deities) do
                     file:write("\t\t<worship_id>"..v.."</worship_id>\n")
                 end
             end


### PR DESCRIPTION
entities:
- deities are listed in historical_entity:unknown1b:deities rather than :worship
- export deities and weapons for entity type 'militaryunit' (= mercenary group)
- use new guild_professions from DFHack/df-structures@1cb6a65  

regions:
- evilness is good/evil/neutral
- force_id is hfid of the associated 'force'
