### PR TITLE
modtools/create-unit: added -equip

### DIFF
--- a/modtools/create-unit.lua
+++ b/modtools/create-unit.lua
@@ -987,7 +987,7 @@ local validArgs = utils.invert({
   'duration',
   'locationRange',
   'locationType',
-  'equip'
+  'equip',
 })
 
 if moduleMode then


### PR DESCRIPTION
Improvement:
- added `-equip`, which allows items to be created and automatically equipped onto units as part of the spawning process.

This lets arena mode logic handle everything. Item sizes, which body part a particular item should be placed on, the handedness of gloves/footwear, the way clothes are layered relative to one another, assessing whether or not a unit is physically able to equip a particular item, etc. As such, this approach has clear advtanges over `modtools/create-item` + `modtools/equip-item`, at least with respect to equipping newly spawned units. Arena mode does however come with some limitations at present, such as an inability to set item quality or to place arrows into quivers.

I tried to make this work in a manner that should be easy for raw modders to understand, but the resultant code isn't particularly elegant. A review would be useful.