### PR TITLE
Removed unneeded tabs in xml

### DIFF
--- a/exportlegends.lua
+++ b/exportlegends.lua
@@ -421,7 +421,7 @@ function export_more_legends_xml()
         for xK, xVal in ipairs(entityV.claims.border.x) do
             file:write(xVal..","..entityV.claims.border.y[xK].."|")
         end
-        file:write("\t\t</claims>\n")
+        file:write("</claims>\n")
 
         if (table_containskey(entityV,"occasion_info") and entityV.occasion_info ~= nil) then
             for occasionK, occasionV in pairs(entityV.occasion_info.occasions) do


### PR DESCRIPTION
The claims-tag closes on the same line.

Examples from before change:
```
<claims>                </claims>
```
or
```
<claims>20,7|20,9|21,7|21,9|21,10|           </claims>
```