### PR TITLE
Exports legends into folders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ that repo.
 - `digfort`: documented that removing ramps, cutting trees, and gathering plants are indeed supported
 - `exportlegends`: changed some flags to be represented by self-closing tags instead of true/false strings (e.g. ``<is_volcano/>``) - note that this may require changes to other XML-parsing utilities
 - `exportlegends`: changed some enum values from numbers to their string representations
+- `exportlegends`: added ability to save all files to a subfolder, named after the region folder and date by default
 - `gui/advfort`: added support for specifying the entity used to determine available resources
 - `gui/gm-editor`: added support for automatically following ref-targets when pressing the ``i`` key
 - `modtools/moddable-gods`: added support for ``neuter`` gender

--- a/exportlegends.lua
+++ b/exportlegends.lua
@@ -1114,17 +1114,15 @@ end
 function create_folder(folder_name)
     if folder_name == "-00000-01-01" then
         qerror('"'..folder_name..'" is the default foldername, this folder will not be created as you are probably not in the legends screen.')
-        return false
     end
     -- check if it is a file, not a folder
     if dfhack.filesystem.isfile(folder_name) then
-      qerror(folder_name..' is a file, not a folder')
-      return false
+        qerror(folder_name..' is a file, not a folder')
     end
     if dfhack.filesystem.exists(folder_name) then
-      return true
+        return true
     else
-      return dfhack.filesystem.mkdir(folder_name)
+        return dfhack.filesystem.mkdir(folder_name)
     end
 end
 

--- a/exportlegends.lua
+++ b/exportlegends.lua
@@ -47,12 +47,6 @@ local MAPS = {
     "Diplomacy",
 }
 
--- Used for moving files, does NOT change the filenames
-local MAPS_POSTFIX = {
-    "-bm","-detailed","-dip","-drn","-el","-elw","-evil","-hyd","-nob",
-    "-rain","-sal","-sav","-str","-tmp","-trd","-veg","-vol"
-}
-
 -- check if a folder with this name could be created or already exists
 function get_world_date_str()
     local month = dfhack.world.ReadCurrentMonth() + 1 --days and months are 1-indexed

--- a/exportlegends.lua
+++ b/exportlegends.lua
@@ -20,9 +20,9 @@ Options:
 
 Argument:
 :folder_name: (optional) The name of the folder where all the files will be saved.
-                Default is to use the format: "regionX-YYYYY-MM-DD".
-                A path is also allowed although everything but the last folder has to exist.
-                If you export all the files in your current directory by using the file_name ".".
+Default is to use the format: "regionX-YYYYY-MM-DD".
+A path is also allowed although everything but the last folder has to exist.
+If you export all the files in your current directory by using the file_name ".".
 
 Usage:
     exportlegends all

--- a/exportlegends.lua
+++ b/exportlegends.lua
@@ -19,7 +19,7 @@ Options:
 :all:    Equivalent to calling all of the above, in that order
 
 Argument:
-:<folder_name>: (optional) The name of the folder where all the files will be saved.
+:folder_name: (optional) The name of the folder where all the files will be saved.
                 Default is to use the format: "regionX-YYYYY-MM-DD".
                 A path is also allowed although everything but the last folder has to exist.
                 If you export all the files in your current directory by using the file_name ".".
@@ -1044,7 +1044,7 @@ function export_detailed_maps()
                 -- Make sure this is always printed even when error occurs.
                 print("    Done exporting.")
             end,
-            -- Run script 
+            -- Run script
             function()
                 -- Loop over all the detailed maps and export them.
                 for i = 1, #MAPS do

--- a/exportlegends.lua
+++ b/exportlegends.lua
@@ -47,6 +47,39 @@ local MAPS = {
     "Diplomacy",
 }
 
+-- Used for moving files, does NOT change the filenames
+local MAPS_POSTFIX = {
+    "-bm","-detailed","-dip","-drn","-el","-elw","-evil","-hyd","-nob",
+    "-rain","-sal","-sav","-str","-tmp","-trd","-veg","-vol"
+}
+
+-- check if a folder with this name could be created or already exists
+function get_world_date_str()
+    local month = dfhack.world.ReadCurrentMonth() + 1 --days and months are 1-indexed
+    local day = dfhack.world.ReadCurrentDay()
+    local year_str = string.format('%0'..math.max(5, string.len(''..df.global.cur_year))..'d', df.global.cur_year)
+    local date_str = year_str..string.format('-%02d-%02d', month, day)
+    return date_str
+end
+
+-- set current directory as main folder
+local main_folder = dfhack.filesystem.getcwd()
+-- go back to root folder so dfhack does not break, returns true if successfully
+function move_back_to_main_folder()
+    -- return dfhack.filesystem.chdir(dfhack.getDFPath())
+    return dfhack.filesystem.chdir(main_folder)
+end
+
+-- set default folder name
+local folder_name = df.global.world.cur_savegame.save_dir.."-"..get_world_date_str()
+-- go to save folder, returns true if successfully
+function move_to_save_folder()
+    if move_back_to_main_folder() then
+        return dfhack.filesystem.chdir(folder_name)
+    end
+    return false
+end
+
 function getItemSubTypeName(itemType, subType)
     if (dfhack.items.getSubtypeCount(itemType)) <= 0 then
         return tostring(-1)
@@ -115,15 +148,14 @@ setmetatable(df_enums, {
 
 --create an extra legends xml with extra data, by Mason11987 for World Viewer
 function export_more_legends_xml()
-    local month = dfhack.world.ReadCurrentMonth() + 1 --days and months are 1-indexed
-    local day = dfhack.world.ReadCurrentDay()
-    local year_str = string.format('%0'..math.max(5, string.len(''..df.global.cur_year))..'d', df.global.cur_year)
-    local date_str = year_str..string.format('-%02d-%02d', month, day)
     local problem_elements = {}
 
-    local filename = df.global.world.cur_savegame.save_dir.."-"..date_str.."-legends_plus.xml"
+    local filename = df.global.world.cur_savegame.save_dir.."-"..get_world_date_str().."-legends_plus.xml"
     local file = io.open(filename, 'w')
-    if not file then qerror("could not open file: " .. filename) end
+    if not file then
+      move_back_to_main_folder()
+      qerror("could not open file: " .. filename)
+    end
 
     file:write("<?xml version=\"1.0\" encoding='UTF-8'?>\n")
     file:write("<df_world>\n")
@@ -988,20 +1020,34 @@ function export_detailed_maps()
             local vs = dfhack.gui.getViewscreenByType(df.viewscreen_export_graphical_mapst, 0)
             if not vs then
                 local legends_vs = dfhack.gui.getViewscreenByType(df.viewscreen_legendsst, 0)
-                    or qerror("Could not find legends screen")
+                if not legends_vs then
+                    move_back_to_main_folder()
+                    qerror("Could not find legends screen")
+                end
+
                 gui.simulateInput(legends_vs, 'LEGENDS_EXPORT_DETAILED_MAP')
             end
 
             vs = dfhack.gui.getViewscreenByType(df.viewscreen_export_graphical_mapst, 0)
-                or qerror("Could not find map export screen")
+            if not vs then
+                move_back_to_main_folder()
+                qerror("Could not find map export screen")
+            end
+            
             vs.sel_type = i - 1
             print('    Exporting map: ' .. MAPS[i])
+            if not move_to_save_folder() then
+                qerror('The '..folder_name..' folder was created successfully. But could not move into the folder')
+            end
             gui.simulateInput(vs, 'SELECT')
             while dfhack.gui.getCurViewscreen() == vs do
                 script.sleep(10, 'frames')
             end
+            move_back_to_main_folder()
         end
+        print("    Done exporting")
     end)
+
 end
 
 -- export site maps
@@ -1020,28 +1066,64 @@ function export_site_maps()
         end
         gui.simulateInput(vs, 'LEAVESCREEN')
     else
+        move_back_to_main_folder()
         qerror('this command can only be used in Legends mode')
+    end
+end
+
+-- check if a folder with this name could be created or already exists
+function create_folder(folder_name)
+    -- check if it is a file, not a folder
+    if dfhack.filesystem.isfile(folder_name) then
+      qerror(folder_name..' is a file, not a folder')
+      return false
+    end
+    if dfhack.filesystem.exists(folder_name) then
+      return true
+    else
+      return dfhack.filesystem.mkdir(folder_name)
     end
 end
 
 -- main()
 if dfhack.gui.getCurFocus() == "legends" or dfhack.gui.getCurFocus() == "dfhack/lua/legends" then
     -- either native legends mode, or using the open-legends.lua script
+    if #args >= 2 then
+        folder_name = args[2]
+    end
+    if not create_folder(folder_name) then
+        -- no valid folder name or could not create folder
+        qerror('The foldername '..folder_name..' could not be created')
+    end
+    -- Move into the export folder
+    if not move_to_save_folder() then
+        qerror('The '..folder_name..' folder was created successfully. But could not move into the folder')
+    end
+    -- Uncomment the line below if you want to test if it changed directory properly
+    -- print(dfhack.filesystem.getcwd())
+    print("    Writing all files in: "..folder_name)
     if args[1] == "all" then
         export_legends_info()
         export_site_maps()
+        move_back_to_main_folder() -- Move back out of the subfolder
         export_detailed_maps()
     elseif args[1] == "info" then
         export_legends_info()
+        move_back_to_main_folder() -- Move back out of the subfolder
     elseif args[1] == "custom" then
         export_more_legends_xml()
+        move_back_to_main_folder() -- Move back out of the subfolder
     elseif args[1] == "maps" then
+        move_back_to_main_folder() -- Move back out of the subfolder
         export_detailed_maps()
     elseif args[1] == "sites" then
         export_site_maps()
+        move_back_to_main_folder() -- Move back out of the subfolder
     else
+        move_back_to_main_folder()
         qerror('Valid arguments are "all", "info", "custom", "maps" or "sites"')
     end
+    print("    Exported files can be found in the \""..folder_name.."\" folder.")
 elseif args[1] == "maps" and dfhack.gui.getCurFocus() == "export_graphical_map" then
     export_detailed_maps()
 else

--- a/exportlegends.lua
+++ b/exportlegends.lua
@@ -10,7 +10,11 @@ The 'info' option exports more data than is possible in vanilla, to a
 :file:`region-date-legends_plus.xml` file developed to extend
 :forums:`World Viewer <128932>` and other legends utilities.
 
-Options:
+Usage::
+
+    exportlegends OPTION [FOLDER_NAME]
+
+Valid values for ``OPTION`` are:
 
 :info:   Exports the world/gen info, the legends XML, and a custom XML with more information
 :custom: Exports a custom XML with more information
@@ -18,17 +22,28 @@ Options:
 :maps:   Exports all seventeen detailed maps
 :all:    Equivalent to calling all of the above, in that order
 
-Argument:
-:folder_name: (optional) The name of the folder where all the files will be saved.
-Default is to use the format: "regionX-YYYYY-MM-DD".
-A path is also allowed although everything but the last folder has to exist.
-If you export all the files in your current directory by using the file_name ".".
+``FOLDER_NAME``, if specified, is the name of the folder where all the files
+will be saved. This defaults to the ``regionX-YYYYY-MM-DD`` format. A path is
+also allowed, although everything but the last folder has to exist. To export
+to the top-level DF folder, pass ``.`` for this argument.
 
-Usage:
+Examples:
+
+* Export all information to the ``regionX-YYYYY-MM-DD`` folder::
+
     exportlegends all
+
+* Export all information to the ``region6`` folder::
+
     exportlegends all region6
+
+* Export just the files included in ``info`` (above) to the ``regionX-YYYYY-MM-DD`` folder::
+
     exportlegends info
-    exportlegends info .
+
+* Export just the custom XML file to the DF folder (no subfolder)::
+
+    exportlegends custom .
 
 ]====]
 


### PR DESCRIPTION
Fixes https://github.com/DFHack/dfhack/issues/1416
If no folder name given, default is of similar pattern to `region1-00125-01-01`

`exportlegends all` will use default path
`exportlegends all myfolder_name` will create and use the 
"myfolder_name" folder
`exportlegends all .` will not put the files in a folder. (tested on 
linux)

This works for all arguments.

Tested on Linux and works fine.
**TODO: Test this on windows systems.** It should work but it should also be tested.