### PR TITLE
Changed width so a four-letter TZ name can fit

### DIFF
--- a/gui/load-screen.lua
+++ b/gui/load-screen.lua
@@ -369,7 +369,7 @@ function load_screen:onDismiss()
 end
 
 load_screen_options = gui.FramedScreen{
-    frame_width = 40,
+    frame_width = 42,
     frame_height = 6,
     frame_title = "",
     frame_inset = 1,


### PR DESCRIPTION
I noticed that whenever I selected a game to load, the timestamp had one letter truncated; in my case the box looked much like this:
![DwarfLoadCutout](https://user-images.githubusercontent.com/62885/85122627-fa1a4000-b27a-11ea-8546-1960717c29da.png)

The timestamp is meant to be NZST, not NZS.
