### PR TITLE
digfort: compat with exported .csv, fix y incr

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,9 +14,12 @@ that repo.
 # Future
 
 ## Fixes
+- `digfort`: fixed y-line tracking when .csv files contain lines with only commas
 - `gui/load-screen`: fixed an issue causing longer timezones to be cut off
 
 ## Misc Improvements
+- `digfort`: handle double quotes (") at the start of a string; this allows .csv files exported from spreadsheets to work without manual modification
+- `digfort`: document that removing ramps, cutting trees, and gathering plants is indeed supported
 - `workorder`: changed default frequency from "Daily" to "OneTime"
 
 # 0.47.04-r1

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,8 +18,8 @@ that repo.
 - `gui/load-screen`: fixed an issue causing longer timezones to be cut off
 
 ## Misc Improvements
-- `digfort`: handle double quotes (") at the start of a string; this allows .csv files exported from spreadsheets to work without manual modification
-- `digfort`: document that removing ramps, cutting trees, and gathering plants is indeed supported
+- `digfort`: handled double quotes (") at the start of a string, allowing .csv files exported from spreadsheets to work without manual modification
+- `digfort`: documented that removing ramps, cutting trees, and gathering plants are indeed supported
 - `workorder`: changed default frequency from "Daily" to "OneTime"
 
 # 0.47.04-r1


### PR DESCRIPTION
- rewrite docs to prefer ',' over ';' as the csv separator to align with fortplan implementation (both separators still work).
- document interpretation of 'd' according to the current implementation
- remove initial double quote characters to allow .csv files that contain comments and were exported from spreadsheets to work
- replace Windows-specific "Dwarf Fortress.exe" in docs with platform-neutral "dfhack.init" as a "you're in the right directory" marker
- properly increment the y count for lines that only include commas