### PR TITLE
Add tools to add-recipe, some error message improvements

### DIFF
--- a/add-recipe.lua
+++ b/add-recipe.lua
@@ -149,7 +149,6 @@ function addSingleItem(itemstring)
   
   if (itemstring ~= nil) then
     itemType, itemId = string.match(itemstring, "(.*):(.*)")
-	if(verbose) then print("Item to add: " .. itemType .. ":" .. itemId) end
   else
     print("Usage: add-recipe single <item name> | Example: add-recipe single SHOES:ITEM_SHOES_BOOTS")
     return end
@@ -163,9 +162,7 @@ function addSingleItem(itemstring)
   
   local addedItem = nil
   --assume the user knows what they're doing, so no need for sanity checks
-  if (verbose) then print("Searching items in category " .. itemType) end
   for _, item in ipairs(all) do
-    if (verbose) then print(_ .. "|" .. item.id) end
     if (item.id == itemId) then
       known:insert('#', item.subtype)
       addedItem = item
@@ -184,11 +181,6 @@ end
 local args = {...}
 local cmd = args[1]
 
-if (args[3] == "-v") then
-  verbose = true
-else
-  verbose = false
-end
 if (cmd == "all") then
   addAllItems(true)
 elseif (cmd == "native") then
@@ -201,6 +193,5 @@ else
         .."native: adds only unknown native recipes (eg. high boots for "
         .."some dwarves)\n"
         .."single: adds a specific item by itemstring (eg. "
-        .."SHOES:ITEM_SHOES_BOOTS)\n"
-		.."-v: DEBUG: activate verbose debugging")
+        .."SHOES:ITEM_SHOES_BOOTS)")
 end

--- a/add-recipe.lua
+++ b/add-recipe.lua
@@ -144,7 +144,11 @@ function addAllItems(exotic)
 end
 
 function addSingleItem(itemstring)
-  local itemType, itemId = string.match(itemstring, "(.*):(.*)")
+  if (itemstring ~= nil) then
+    local itemType, itemId = string.match(itemstring, "(.*):(.*)")
+  else
+    print("Usage: add-recipe single <item name> | Example: add-recipe single SHOES:ITEM_SHOES_BOOTS")
+  end
   if (itemType == nil or itemId == nil) then return end
   local category = categories[string.lower(itemType)]
   if (category == nil) then return end

--- a/add-recipe.lua
+++ b/add-recipe.lua
@@ -144,12 +144,18 @@ function addAllItems(exotic)
 end
 
 function addSingleItem(itemstring)
+  local itemType = nil  --The category of the item, the word before the ":"
+  local itemId = nil    --The item within that category, what goes after the ":"
+  
   if (itemstring ~= nil) then
-    local itemType, itemId = string.match(itemstring, "(.*):(.*)")
+    itemType, itemId = string.match(itemstring, "(.*):(.*)")
+	if(verbose) then print("Item to add: " .. itemType .. ":" .. itemId) end
   else
     print("Usage: add-recipe single <item name> | Example: add-recipe single SHOES:ITEM_SHOES_BOOTS")
-  end
-  if (itemType == nil or itemId == nil) then return end
+    return end
+  if (itemType == nil or itemId == nil) then
+    print("Usage: add-recipe single <item name> | Example: add-recipe single SHOES:ITEM_SHOES_BOOTS")
+    return end
   local category = categories[string.lower(itemType)]
   if (category == nil) then return end
   local known = category[1]

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,8 @@ that repo.
 - `modtools/moddable-gods`: made ``-depictedAs`` argument work
 
 ## Misc Improvements
+- `add-recipe`: added tool recipes (minecarts, wheelbarrows, stepladders, etc.)
+- `add-recipe`: added a command explanation or error message when entering an invalid command
 - `digfort`: handled double quotes (") at the start of a string, allowing .csv files exported from spreadsheets to work without manual modification
 - `digfort`: documented that removing ramps, cutting trees, and gathering plants are indeed supported
 - `exportlegends`: changed some flags to be represented by self-closing tags instead of true/false strings (e.g. ``<is_volcano/>``) - note that this may require changes to other XML-parsing utilities


### PR DESCRIPTION
Right now add-recipe only lets you add recipes for weapons or armor, but not tools. I see no reason why this script shouldn't let you add recipes for tools, so I did just that.

It's particularly useful when you're playing with a modded civ, and then you find out only after starting a new fortress that you don't have stuff like minecarts or stepladders when you want them. It can also let you add recipes for procedurally-generated instruments.

Plus, I took the chance to improve the error messages a bit. Instead of letting the script throw normal LUA error messages when you give it bad arguments, I made it print how to use the script. Or a short error message when you get the name of an item wrong, so you at least know the script ran.

Also, I'm a noob at this, so sorry in advance if I screwed up something or if I didn't follow some guidelines I didn't know about