### PR TITLE
Quickfort build

### DIFF
--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -588,8 +588,9 @@ for _, v in pairs(building_db) do
     end
 end
 
--- case insensitive aliases for keys in the db (compat with python quickfort)
-local aliases = {
+-- case insensitive aliases for keys in the db
+-- this allows us to keep compatibility with the old python quickfort
+local building_aliases = {
     rollerh='Mrs',
     rollerv='Mr',
     rollerns='Mr',
@@ -716,7 +717,7 @@ function do_run(zlevel, grid)
 
     local buildings = {}
     stats.invalid_keys.value = quickfort_building.init_buildings(
-        zlevel, grid, buildings, building_db)
+        zlevel, grid, buildings, building_db, building_aliases)
     stats.out_of_bounds.value = quickfort_building.crop_to_bounds(
         buildings, building_db)
     stats.unsuitable.value = quickfort_building.check_tiles_and_extents(
@@ -755,7 +756,7 @@ function do_undo(zlevel, grid)
 
     local buildings = {}
     stats.invalid_keys.value = quickfort_building.init_buildings(
-        zlevel, grid, buildings, building_db)
+        zlevel, grid, buildings, building_db, building_aliases)
 
     for _, s in ipairs(buildings) do
         for extent_x, col in ipairs(s.extent_grid) do

--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -6,11 +6,547 @@ if not dfhack_flags.module then
 end
 
 local quickfort_common = reqscript('internal/quickfort/common')
+local quickfort_building = reqscript('internal/quickfort/building')
 local log = quickfort_common.log
 
+local function is_valid_tile_dirt(pos)
+    local tileattrs = df.tiletype.attrs[dfhack.maps.getTileType(pos)]
+    local shape = tileattrs.shape
+    local mat = tileattrs.material
+    local good_shape =
+            shape == df.tiletype_shape.FLOOR or
+            shape == df.tiletype_shape.TWIG or
+            shape == df.tiletype_shape.SAPLING or
+            shape == df.tiletype_shape.SHRUB
+    local good_material =
+            mat == df.tiletype_material.SOIL or
+            mat == df.tiletype_material.GRASS_LIGHT or
+            mat == df.tiletype_material.GRASS_DARK or
+            mat == df.tiletype_material.GRASS_DRY or
+            mat == df.tiletype_material.GRASS_DEAD or
+            mat == df.tiletype_material.PLANT or
+            -- below here need to verify
+            mat == df.tiletype_material.DRIFTWOOD
+end
+
+local function is_valid_tile_construction(pos)
+    local flags, occupancy = dfhack.maps.getTileFlags(pos)
+    if flags.hidden or occupancy.building ~= 0 then return false end
+    local shape = df.tiletype.attrs[dfhack.maps.getTileType(pos)].shape
+    return shape == df.tiletype_shape.FLOOR or
+            shape == df.tiletype_shape.BOULDER or
+            shape == df.tiletype_shape.PEBBLES or
+            shape == df.tiletype_shape.TWIG or
+            shape == df.tiletype_shape.SAPLING or
+            shape == df.tiletype_shape.SHRUB
+end
+
+local function is_valid_tile_bridge(pos)
+    local shape = df.tiletype.attrs[dfhack.maps.getTileType(pos)].shape
+    return is_valid_tile_construction(pos) or
+            shape == df.tiletype_shape.EMPTY
+end
+
+local function flood_extent(extent_grid, x, y, reachable_grid)
+    if reachable_grid[x] and reachable_grid[x][y] then return end
+    if not extent_grid[x] or not extent_grid[x][y] then return end
+    reachable_grid[x][y] = true
+    -- diagonal connections count
+    flood_extent(extent_grid, x-1, y-1, reachable_grid)
+    flood_extent(extent_grid, x-1, y, reachable_grid)
+    flood_extent(extent_grid, x-1, y+1, reachable_grid)
+    flood_extent(extent_grid, x, y-1, reachable_grid)
+    flood_extent(extent_grid, x, y+1, reachable_grid)
+    flood_extent(extent_grid, x+1, y-1, reachable_grid)
+    flood_extent(extent_grid, x+1, y, reachable_grid)
+    flood_extent(extent_grid, x+1, y+1, reachable_grid)
+end
+
+-- extent checking functions assume valid, non-zero width or height extents
+local function is_extent_connected(b)
+    local extent_grid = b.extent_grid
+    local reachable_grid = {}
+    for x, col in ipairs(extent_grid) do
+        reachable_grid[x] = {}
+        for y, _ in ipairs(col) do reachable_grid[x][y] = false end
+    end
+    local done = false
+    for x, col in ipairs(extent_grid) do
+        for y, in_extent in ipairs(col) do
+            if in_extent then
+                -- flood from any tile in the extent
+                flood_extent(extent_grid, x, y, reachable_grid)
+                done = true
+            end
+        end
+        if done then break end
+    end
+    for x, col in ipairs(extent_grid) do
+        for y, _ in ipairs(col) do
+            if extent_grid[x][y] ~= reachable_grid[x][y] then return false end
+        end
+    end
+    return true
+end
+
+local function is_extent_solid(b)
+    local area = b.width * b.height
+    local num_tiles = 0
+    for extent_x, col in ipairs(b.extent_grid) do
+        for extent_y, in_extent in ipairs(col) do
+            if in_extent then num_tiles = num_tiles + 1 end
+        end
+    end
+    return num_tiles == area
+end
+
+local function is_extent_nonempty(b)
+    for extent_x, col in ipairs(b.extent_grid) do
+        for extent_y, in_extent in ipairs(col) do
+            if in_extent then return true end
+        end
+    end
+    return false
+end
+
+local function is_extent_solid_and_supported(b)
+    print("TODO: check that bridges are supported")
+    return is_extent_solid(b)
+end
+
+-- grouped by type, generally in ui order
+local building_db = {
+    -- basic building types
+    a={label='Armor Stand', type=df.building_type.Armorstand},
+    b={label='Bed', type=df.building_type.Bed},
+    c={label='Seat', type=df.building_type.Chair},
+    n={label='Burial Receptacle', type=df.building_type.Coffin},
+    d={label='Door', type=df.building_type.Door},
+    x={label='Floodgate', type=df.building_type.Floodgate},
+    H={label='Floor Hatch', type=df.building_type.Hatch},
+    W={label='Wall Grate', type=df.building_type.GrateWall},
+    G={label='Floor Grate', type=df.building_type.GrateFloor},
+    B={label='Vertical Bars', type=df.building_type.BarsVertical},
+    ['{Alt}b']={label='Floor Bars', type=df.building_type.BarsFloor},
+    f={label='Cabinet', type=df.building_type.Cabinet},
+    h={label='Container', type=df.building_type.Box},
+    r={label='Weapon Rack', type=df.building_type.Weaponrack},
+    s={label='Statue', type=df.building_type.Statue},
+    ['{Alt}s']={label='Slab', type=df.building_type.Slab},
+    t={label='Table', type=df.building_type.Table},
+    g={label='Bridge',
+       type=df.building_type.Bridge,
+       min_width=1, max_width=10, min_height=1, max_height=10,
+       is_valid_tile_fn=is_valid_tile_bridge,
+       is_valid_extent_fn=is_extent_solid_and_supported},
+    l={label='Well', type=df.building_type.Well},
+    y={label='Glass Window', type=df.building_type.WindowGlass},
+    Y={label='Gem Window', type=df.building_type.WindowGem},
+    D={label='Trade Depot', type=df.building_type.TradeDepot,
+       min_width=5, max_width=5, min_height=5, max_height=5},
+    Ms={label='Screw Pump (Pump From North)', type=df.building_type.ScrewPump,
+        min_width=1, max_width=1, min_height=2, max_height=2,
+        fields={direction=df.screw_pump_direction.FromNorth}},
+    Msu={label='Screw Pump (Pump From North)', type=df.building_type.ScrewPump,
+         min_width=1, max_width=1, min_height=2, max_height=2,
+         fields={direction=df.screw_pump_direction.FromNorth}},
+    Msk={label='Screw Pump (Pump From East)', type=df.building_type.ScrewPump,
+         min_width=2, max_width=2, min_height=1, max_height=1,
+         fields={direction=df.screw_pump_direction.FromEast}},
+    Msm={label='Screw Pump (Pump From South)', type=df.building_type.ScrewPump,
+         min_width=1, max_width=1, min_height=2, max_height=2,
+         fields={direction=df.screw_pump_direction.FromSouth}},
+    Msh={label='Screw Pump (Pump From West)', type=df.building_type.ScrewPump,
+         min_width=2, max_width=2, min_height=1, max_height=1,
+         fields={direction=df.screw_pump_direction.FromWest}},
+    Mw={label='Water Wheel (N/S)', type=df.building_type.WaterWheel,
+        min_width=1, max_width=1, min_height=3, max_height=3,
+        fields={is_vertical=true}},
+    Mws={label='Water Wheel (E/W)', type=df.building_type.WaterWheel,
+         min_width=3, max_width=3, min_height=1, max_height=1},
+    Mg={label='Gear Assembly', type=df.building_type.GearAssembly},
+    Mh={label='Horizontal Axle (E/W)', type=df.building_type.AxleHorizontal,
+        min_width=1, max_width=10, min_height=1, max_height=1},
+    Mhs={label='Horizontal Axle (N/S)', type=df.building_type.AxleHorizontal,
+         min_width=1, max_width=1, min_height=1, max_height=10,
+         fields={is_vertical=true}},
+    Mv={label='Vertical Axle', type=df.building_type.AxleVertical},
+    -- TODO: handle q* suffixes to set the speed
+    Mr={label='Rollers (N->S)', type=df.building_type.Rollers,
+        min_width=1, max_width=1, min_height=1, max_height=10,
+        fields={direction=df.screw_pump_direction.FromNorth}},
+    Mrs={label='Rollers (E->W)', type=df.building_type.Rollers,
+         min_width=1, max_width=10, min_height=1, max_height=1,
+         fields={direction=df.screw_pump_direction.FromEast}},
+    Mrss={label='Rollers (S->N)', type=df.building_type.Rollers,
+          min_width=1, max_width=1, min_height=1, max_height=10,
+          fields={direction=df.screw_pump_direction.FromSouth}},
+    Mrsss={label='Rollers (W->E)', type=df.building_type.Rollers,
+           min_width=1, max_width=10, min_height=1, max_height=1,
+           fields={direction=df.screw_pump_direction.FromWest}},
+    I={label='Instrument', type=df.building_type.Instrument},
+    S={label='Support', type=df.building_type.Support},
+    m={label='Animal Trap', type=df.building_type.AnimalTrap},
+    v={label='Restraint', type=df.building_type.Chain},
+    j={label='Cage', type=df.building_type.Cage},
+    A={label='Archery Target', type=df.building_type.ArcheryTarget},
+    R={label='Traction Bench', type=df.building_type.TractionBench},
+    N={label='Nest Box', type=df.building_type.NextBox},
+    ['{Alt}h']={label='Hive', type=df.building_type.Hive},
+    ['{Alt}a']={label='Offering Place', type=df.building_type.OfferingPlace},
+    ['{Alt}c']={label='Bookcase', type=df.building_type.Bookcase},
+    F={label='Display Furniture', type=df.building_type.DisplayFurniture},
+    -- basic building types with extents
+    p={label='Farm Plot',
+       type=df.building_type.FarmPlot, has_extents=true,
+       no_extents_if_solid=true,
+       is_valid_tile_fn=is_valid_tile_dirt,
+       is_valid_extent_fn=is_extent_nonempty},
+    o={label='Paved Road',
+       type=df.building_type.RoadPaved, has_extents=true,
+       no_extents_if_solid=true, is_valid_extent_fn=is_extent_connected},
+    O={label='Dirt Road',
+       type=df.building_type.RoadDirt, has_extents=true,
+       no_extents_if_solid=true,
+       is_valid_tile_fn=is_valid_tile_dirt,
+       is_valid_extent_fn=is_extent_connected},
+    -- workshops
+    k={label='Kennels',
+       type=df.building_type.Workshop, subtype=df.workshop_type.Kennels},
+    we={label='Leather Works',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Leatherworks},
+    wq={label='Quern',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Quern,
+        min_width=1, max_width=1, min_height=1, max_height=1},
+    wM={label='Millstone',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Millstone},
+    wo={label='Loom',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Loom},
+    wk={label='Clothier\'s shop',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Clotheirs},
+    wb={label='Bowyer\'s Workshop',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Bowyers},
+    wc={label='Carpenter\'s Workshop',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Carpenters},
+    wf={label='Metalsmith\'s Forge',
+        type=df.building_type.Workshop,
+        subtype=df.workshop_type.MetalsmithsForge},
+    wv={label='Magma Forge',
+        type=df.building_type.Workshop, subtype=df.workshop_type.MagmaForge},
+    wj={label='Jeweler\'s Workshop',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Jewelers},
+    wm={label='Mason\'s Workshop',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Masons},
+    wu={label='Butcher\'s Shop',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Butchers},
+    wn={label='Tanner\'s Shop',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Tanners},
+    wr={label='Craftsdwarf\'s Workshop',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Craftdwarfs},
+    ws={label='Siege Workshop',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Siege},
+    wt={label='Mechanic\'s Workshop',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Mechanics},
+    wl={label='Still',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Still},
+    ww={label='Farmer\'s Workshop',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Farmers},
+    wz={label='Kitchen',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Kitchen},
+    wh={label='Fishery',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Fishery},
+    wy={label='Ashery',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Ashery},
+    wd={label='Dyer\'s Shop',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Dyers},
+    wS={label='Soap Maker\'s Workshop',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Custom},
+    wp={label='Screw Press',
+        type=df.building_type.Workshop, subtype=df.workshop_type.Tool},
+    -- furnaces
+    ew={label='Wood Furnace',
+        type=df.building_type.Furnace, subtype=df.siegeengine_type.WoodFurnace},
+    es={label='Smelter',
+        type=df.building_type.Furnace, subtype=df.siegeengine_type.Smelter},
+    el={label='Magma Smelter',
+        type=df.building_type.Furnace, subtype=df.siegeengine_type.MagmaSmelter},
+    eg={label='Glass Furnace',
+        type=df.building_type.Furnace, subtype=df.siegeengine_type.GlassFurnace},
+    ea={label='Magma Glass Furnace',
+        type=df.building_type.Furnace,
+        subtype=df.siegeengine_type.MagmaGlassFurnace},
+    ek={label='Kiln',
+        type=df.building_type.Furnace, subtype=df.siegeengine_type.Kiln},
+    en={label='Magma Kiln',
+        type=df.building_type.Furnace, subtype=df.siegeengine_type.MagmaKiln},
+    -- siege engines
+    ib={label='Ballista',
+        type=df.building_type.SiegeEngine,
+        subtype=df.siegeengine_type.Ballista},
+    ic={label='Catapult',
+        type=df.building_type.SiegeEngine,
+        subtype=df.siegeengine_type.Catapult},
+    -- constructions
+    Cw={label='Wall',
+        type=df.building_type.Construction, subtype=df.construction_type.Wall},
+    Cf={label='Floor',
+        type=df.building_type.Construction, subtype=df.construction_type.Floor},
+    Cr={label='Ramp',
+        type=df.building_type.Construction, subtype=df.construction_type.Ramp},
+    Cu={label='Up Stair',
+        type=df.building_type.Construction,
+        subtype=df.construction_type.UpStair},
+    Cd={label='Down Stair',
+        type=df.building_type.Construction,
+        subtype=df.construction_type.DownStair},
+    Cx={label='Up/Down Stair',
+        type=df.building_type.Construction,
+        subtype=df.construction_type.UpDownStair},
+    CF={label='Fortification',
+        type=df.building_type.Construction,
+        subtype=df.construction_type.Fortification},
+    -- traps
+    -- TODO: CSd*a* for friction options; high=10000
+    CS={label='Track Stop (No Dump)',
+        type=df.building_type.Trap, subtype=df.trap_type.TrackStop},
+    CSd={label='Track Stop (Dump North)',
+         type=df.building_type.Trap, subtype=df.trap_type.TrackStop,
+         fields={use_dump=true, dump_y_shift=-1}},
+    CSdd={label='Track Stop (Dump South)',
+          type=df.building_type.Trap, subtype=df.trap_type.TrackStop,
+          fields={use_dump=true, dump_y_shift=1}},
+    CSddd={label='Track Stop (Dump East)',
+           type=df.building_type.Trap, subtype=df.trap_type.TrackStop,
+           fields={use_dump=true, dump_x_shift=1}},
+    CSdddd={label='Track Stop (Dump West)',
+            type=df.building_type.Trap, subtype=df.trap_type.TrackStop,
+            fields={use_dump=true, dump_x_shift=-1}},
+    Ts={label='Stone-Fall Trap',
+        type=df.building_type.Trap, subtype=df.trap_type.StoneFallTrap},
+    Tw={label='Weapon Trap',
+        type=df.building_type.Trap, subtype=df.trap_type.WeaponTrap},
+    Tl={label='Lever',
+        type=df.building_type.Trap, subtype=df.trap_type.Lever},
+    Tp={label='Pressure Plate',
+        type=df.building_type.Trap, subtype=df.trap_type.PressurePlate},
+    Tc={label='Cage Trap',
+        type=df.building_type.Trap, subtype=df.trap_type.CateTrap},
+    -- TODO: maybe TS1 through TS10 for how many weapons?
+    TS={label='Upright Spear/Spike',
+        type=df.building_type.Weapon, subtype=df.trap_type.StoneFallTrap},
+    -- tracks (CT...)
+    trackN={label='Track (N)',
+            type=df.building_type.Construction,
+            subtype=df.construction_type.TrackN},
+    trackS={label='Track (S)',
+            type=df.building_type.Construction,
+            subtype=df.construction_type.TrackS},
+    trackE={label='Track (E)',
+            type=df.building_type.Construction,
+            subtype=df.construction_type.TrackE},
+    trackW={label='Track (W)',
+            type=df.building_type.Construction,
+            subtype=df.construction_type.TrackW},
+    trackNS={label='Track (NS)',
+             type=df.building_type.Construction,
+             subtype=df.construction_type.TrackNS},
+    trackNE={label='Track (NE)',
+             type=df.building_type.Construction,
+             subtype=df.construction_type.TrackNE},
+    trackNW={label='Track (NW)',
+             type=df.building_type.Construction,
+             subtype=df.construction_type.TrackNW},
+    trackSE={label='Track (SE)',
+             type=df.building_type.Construction,
+             subtype=df.construction_type.TrackSE},
+    trackSW={label='Track (SW)',
+             type=df.building_type.Construction,
+             subtype=df.construction_type.TrackSW},
+    trackEW={label='Track (EW)',
+             type=df.building_type.Construction,
+             subtype=df.construction_type.TrackEW},
+    trackNSE={label='Track (NSE)',
+              type=df.building_type.Construction,
+              subtype=df.construction_type.TrackNSE},
+    trackNSW={label='Track (NSW)',
+              type=df.building_type.Construction,
+              subtype=df.construction_type.TrackNSW},
+    trackNEW={label='Track (NEW)',
+              type=df.building_type.Construction,
+              subtype=df.construction_type.TrackNEW},
+    trackSEW={label='Track (SEW)',
+              type=df.building_type.Construction,
+              subtype=df.construction_type.TrackSEW},
+    trackNSEW={label='Track (NSEW)',
+               type=df.building_type.Construction,
+               subtype=df.construction_type.TrackNSEW},
+    trackrampN={label='Track/Ramp (N)',
+                type=df.building_type.Construction,
+                subtype=df.construction_type.TrackRampN},
+    trackrampS={label='Track/Ramp (S)',
+                type=df.building_type.Construction,
+                subtype=df.construction_type.TrackRampS},
+    trackrampE={label='Track/Ramp (E)',
+                type=df.building_type.Construction,
+                subtype=df.construction_type.TrackRampE},
+    trackrampW={label='Track/Ramp (W)',
+                type=df.building_type.Construction,
+                subtype=df.construction_type.TrackRampW},
+    trackrampNS={label='Track/Ramp (NS)',
+                 type=df.building_type.Construction,
+                 subtype=df.construction_type.TrackRampNS},
+    trackrampNE={label='Track/Ramp (NE)',
+                 type=df.building_type.Construction,
+                 subtype=df.construction_type.TrackRampNE},
+    trackrampNW={label='Track/Ramp (NW)',
+                 type=df.building_type.Construction,
+                 subtype=df.construction_type.TrackRampNW},
+    trackrampSE={label='Track/Ramp (SE)',
+                 type=df.building_type.Construction,
+                 subtype=df.construction_type.TrackRampSE},
+    trackrampSW={label='Track/Ramp (SW)',
+                 type=df.building_type.Construction,
+                 subtype=df.construction_type.TrackRampSW},
+    trackrampEW={label='Track/Ramp (EW)',
+                 type=df.building_type.Construction,
+                 subtype=df.construction_type.TrackRampEW},
+    trackrampNSE={label='Track/Ramp (NSE)',
+                  type=df.building_type.Construction,
+                  subtype=df.construction_type.TrackRampNSE},
+    trackrampNSW={label='Track/Ramp (NSW)',
+                  type=df.building_type.Construction,
+                  subtype=df.construction_type.TrackRampNSW},
+    trackrampNEW={label='Track/Ramp (NEW)',
+                  type=df.building_type.Construction,
+                  subtype=df.construction_type.TrackRampNEW},
+    trackrampSEW={label='Track/Ramp (SEW)',
+                  type=df.building_type.Construction,
+                  subtype=df.construction_type.TrackRampSEW},
+    trackrampNSEW={label='Track/Ramp (NSEW)',
+                   type=df.building_type.Construction,
+                   subtype=df.construction_type.TrackRampNSEW},
+}
+
+-- fill in default values if they're not already specified
+for _, v in pairs(building_db) do
+    if v.has_extents then
+        if not v.min_width then
+            v.min_width = 1
+            v.max_width = 10
+            v.min_height = 1
+            v.max_height = 10
+        end
+    elseif v.type == df.building_type.Workshop or
+            v.type == df.building_type.SiegeEngine then
+        if not v.min_width then
+            v.min_width = 3
+            v.max_width = 3
+            v.min_height = 3
+            v.max_height = 3
+        end
+    else
+        if not v.min_width then
+            v.min_width = 1
+            v.max_width = 1
+            v.min_height = 1
+            v.max_height = 1
+        end
+    end
+    if not v.is_valid_tile_fn then
+        v.is_valid_tile_fn = is_valid_tile_construction
+    end
+    if not v.is_valid_extent_fn then
+        v.is_valid_extent_fn = is_extent_solid
+    end
+end
+
+-- case insensitive aliases for tricky keys in the db
+local aliases = {
+    trackstopn='CSd',
+    trackstops='CSdd',
+    trackstope='CSddd',
+    trackstopw='CSdddd',
+    trackn='trackN',
+    tracks='trackS',
+    tracke='trackE',
+    trackw='trackW',
+    trackns='trackNS',
+    trackne='trackNE',
+    tracknw='trackNW',
+    trackse='trackSE',
+    tracksw='trackSW',
+    trackew='trackEW',
+    tracknse='trackNSE',
+    tracknsw='trackNSW',
+    tracknew='trackNEW',
+    tracksew='trackSEW',
+    tracknsew='trackNSEW',
+    trackrampn='trackrampN',
+    trackramps='trackrampS',
+    trackrampe='trackrampE',
+    trackrampw='trackrampW',
+    trackrampns='trackrampNS',
+    trackrampne='trackrampNE',
+    trackrampnw='trackrampNW',
+    trackrampse='trackrampSE',
+    trackrampsw='trackrampSW',
+    trackrampew='trackrampEW',
+    trackrampnse='trackrampNSE',
+    trackrampnsw='trackrampNSW',
+    trackrampnew='trackrampNEW',
+    trackrampsew='trackrampSEW',
+    trackrampnsew='trackrampNSEW',
+}
+
+local function create_building(b)
+    db_entry = building_db[b.type]
+    log('creating %s at map coordinates (%d, %d, %d), defined from ' ..
+        'spreadsheet cells: %s',
+        db_entry.label, b.pos.x, b.pos.y, b.pos.z,
+        table.concat(b.cells, ', '))
+    local extents, room = nil, nil
+    if db_entry.has_extents then
+        extents = quickfort_building.make_extents(b, building_db)
+        room = {x=b.pos.x, y=b.pos.y, width=b.width, height=b.height}
+    end
+    local bld, err = dfhack.buildings.constructBuilding{
+        type=db_entry.type, subtype=db_entry.subtype, pos=b.pos,
+        width=b.width, height=b.height, fields={room=room}}
+    if not bld then
+        if extents then df.delete(extents) end
+        -- this is an error instead of a qerror since our validity checking
+        -- is supposed to prevent this from ever happening
+        error(string.format('unable to place %s: %s', db_entry.label, err))
+    end
+    -- constructBuilding deallocates extents, so we have to assign it after
+    if db_entry.has_extents then
+        bld.room.extents = extents
+    end
+end
+
 function do_run(zlevel, grid)
-    local stats = nil
-    print('"quickfort run" not yet implemented for mode: build')
+    local stats = {
+        designated={label='Buildings designated', value=0, always=true},
+        occupied={label='Buildings skipped (tile occupied)', value=0},
+        out_of_bounds={label='Buildings skipped (outside map boundary)',
+                       value=0},
+        invalid_keys={label='Invalid key sequences', value=0},
+    }
+
+    local buildings = {}
+    stats.invalid_keys.value = quickfort_building.init_buildings(
+        zlevel, grid, buildings, building_db)
+    stats.out_of_bounds.value = quickfort_building.crop_to_bounds(
+        buildings, building_db)
+    stats.occupied.value = quickfort_building.check_tiles_and_extents(
+        buildings, building_db)
+
+    for _, b in ipairs(buildings) do
+        if b.pos then
+            create_building(b)
+            stats.designated.value = stats.designated.value + 1
+        end
+    end
     return stats
 end
 
@@ -20,8 +556,44 @@ function do_orders(zlevel, grid)
     return stats
 end
 
+local function is_queued_for_destruction(bld)
+    for k,v in ipairs(bld.jobs) do
+        if v.job_type == df.job_type.DestroyBuilding then
+            return true
+        end
+    end
+    return false
+end
+
 function do_undo(zlevel, grid)
-    local stats = nil
-    print('"quickfort undo" not yet implemented for mode: build')
+    local stats = {
+        removed={label='Planned buildings removed', value=0, always=true},
+        marked={label='Buildings marked for removal', value=0},
+        invalid_keys={label='Invalid key sequences', value=0},
+    }
+
+    local buildings = {}
+    stats.invalid_keys.value = quickfort_building.init_buildings(
+        zlevel, grid, buildings, building_db)
+
+    for _, s in ipairs(buildings) do
+        for extent_x, col in ipairs(s.extent_grid) do
+            for extent_y, in_extent in ipairs(col) do
+                if not s.extent_grid[extent_x][extent_y] then goto continue end
+                local pos =
+                        xyz2pos(s.pos.x+extent_x-1, s.pos.y+extent_y-1, s.pos.z)
+                local bld = dfhack.buildings.findAtTile(pos)
+                if bld and bld:getType() ~= df.building_type.Stockpile and
+                        not is_queued_for_destruction(bld) then
+                    if dfhack.buildings.deconstruct(bld) then
+                        stats.removed.value = stats.removed.value + 1
+                    else
+                        stats.marked.value = stats.marked.value + 1
+                    end
+                end
+                ::continue::
+            end
+        end
+    end
     return stats
 end

--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -448,20 +448,24 @@ local building_db = {
     CSddddaaaa=make_trackstop_entry({dump_x_shift=-1}, 10),
     Ts={label='Stone-Fall Trap',
         type=df.building_type.Trap, subtype=df.trap_type.StoneFallTrap},
-    -- TODO: maybe TwS1 through Tw10 for how many weapons?
+    -- TODO: by default a weapon trap is configured with a single weapon.
+    -- maybe add Tw1 through Tw10 for choosing how many weapons?
+    -- material preferences can help here for choosing weapon types.
     Tw={label='Weapon Trap',
         type=df.building_type.Trap, subtype=df.trap_type.WeaponTrap},
     Tl={label='Lever',
         type=df.building_type.Trap, subtype=df.trap_type.Lever},
-    -- TODO: lots of configuration here
+    -- TODO: lots of configuration here with no natural order. may need
+    -- special-case logic when we read the keys.
     Tp={label='Pressure Plate',
         type=df.building_type.Trap, subtype=df.trap_type.PressurePlate},
     Tc={label='Cage Trap',
         type=df.building_type.Trap, subtype=df.trap_type.CageTrap},
-    -- TODO: maybe TS1 through TS10 for how many weapons?
+    -- TODO: Same as weapon trap above
     TS={label='Upright Spear/Spike',
         type=df.building_type.Weapon, subtype=df.trap_type.StoneFallTrap},
-    -- tracks (CT...)
+    -- tracks (CT...). there aren't any shortcut keys in the UI so we use the
+    -- aliases from python quickfort
     trackN={label='Track (N)',
             type=df.building_type.Construction,
             subtype=df.construction_type.TrackN},
@@ -589,7 +593,8 @@ for _, v in pairs(building_db) do
 end
 
 -- case insensitive aliases for keys in the db
--- this allows us to keep compatibility with the old python quickfort
+-- this allows us to keep compatibility with the old python quickfort and makes
+-- us a little more forgiving for some of the trickier keys in the db.
 local building_aliases = {
     rollerh='Mrs',
     rollerv='Mr',

--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -6,9 +6,9 @@ buildings (e.g. beds have to be inside, doors have to be adjacent to a wall,
 etc.). A notable exception is that we allow constructions and machine components
 to be designated regardless of whether they are reachable or currently
 supported. This allows the user to designate an entire floor of an above-ground
-building or an entire power train without micromanagement. We also don't enforce
-that materials are accessible from the designation location. That is something
-that the player can manage.
+building or an entire power system without micromanagement. We also don't
+enforce that materials are accessible from the designation location. That is
+something that the player can manage.
 ]]
 
 
@@ -91,14 +91,16 @@ local function is_shape_at(pos, allowed_shapes)
 end
 
 -- for doors
+local allowed_door_shapes = utils.invert({
+    df.tiletype_shape.WALL,
+    df.tiletype_shape.FORTIFICATION
+})
 local function is_tile_generic_and_wall_adjacent(pos)
     if not is_valid_tile_generic(pos) then return false end
-    -- TODO: are fortifications ok? Any other shapes?
-    local allowed_shapes = utils.invert({df.tiletypes_shape.WALL})
-    return is_shape_at(xyz2pos(pos.x+1, pos.y, pos.z), allowed_shapes) or
-            is_shape_at(xyz2pos(pos.x-1, pos.y, pos.z), allowed_shapes) or
-            is_shape_at(xyz2pos(pos.x, pos.y+1, pos.z), allowed_shapes) or
-            is_shape_at(xyz2pos(pos.x, pos.y-1, pos.z), allowed_shapes)
+    return is_shape_at(xyz2pos(pos.x+1, pos.y, pos.z), allowed_door_shapes) or
+            is_shape_at(xyz2pos(pos.x-1, pos.y, pos.z), allowed_door_shapes) or
+            is_shape_at(xyz2pos(pos.x, pos.y+1, pos.z), allowed_door_shapes) or
+            is_shape_at(xyz2pos(pos.x, pos.y-1, pos.z), allowed_door_shapes)
 end
 
 -- for wells
@@ -308,8 +310,12 @@ local building_db = {
     ['{Alt}c']={label='Bookcase', type=df.building_type.Bookcase},
     F={label='Display Furniture', type=df.building_type.DisplayFurniture},
     -- basic building types with extents
-    -- in the UI, these are required to be connected regions, but for
-    -- player convenience we remove that restriction
+    -- in the UI, these are required to be connected regions, which we could
+    -- easily enforce with a flood fill check. However, requiring connected
+    -- regions can make tested blueprints fail if, for example, you happen to
+    -- try to put a farm plot where there is some surface rock. There is no
+    -- technical issue with allowing disconnected regions, and so for player
+    -- convenience we allow them.
     p={label='Farm Plot',
        type=df.building_type.FarmPlot, has_extents=true,
        no_extents_if_solid=true,

--- a/internal/quickfort/building.lua
+++ b/internal/quickfort/building.lua
@@ -1,0 +1,374 @@
+-- building-related logic for the quickfort build and place modules
+--@ module = true
+
+if not dfhack_flags.module then
+    qerror('this script cannot be called directly')
+end
+
+local quickfort_common = reqscript('internal/quickfort/common')
+local log = quickfort_common.log
+local logfn = quickfort_common.logfn
+
+-- maps building boundaries, returns number of invalid keys seen
+-- populates seen_grid coordinates with the building id so we can build an
+-- extent_grid later. spreadsheet cells that define extents (e.g. a(5x5)) create
+-- buildings separate from adjacent cells, even if they have the same type.
+local function flood_fill(grid, x, y, seen_grid, data, db)
+    if seen_grid[x] and seen_grid[x][y] then return 0 end
+    if not grid[y] or not grid[y][x] then return 0 end
+    local cell, text = grid[y][x].cell, grid[y][x].text
+    local keys, extent = quickfort_common.parse_cell(text)
+    if not db[keys] then
+        if not seen_grid[x] then seen_grid[x] = {} end
+        seen_grid[x][y] = true -- seen, but not part of any stockpile
+        print(string.format('invalid key sequence in cell %s: "%s"',
+                            cell, text))
+        return 1
+    end
+    if data.type and (data.type ~= keys or extent.specified) then return 0 end
+    log('mapping spreadsheet cell %s with text "%s"', cell, text)
+    if not data.type then data.type = keys end
+    table.insert(data.cells, cell)
+    for target_x=x,x+extent.width-1 do
+        for target_y=y,y+extent.height-1 do
+            if not seen_grid[target_x] then seen_grid[target_x] = {} end
+            -- this may overlap with another building, but that's handled later
+            seen_grid[target_x][target_y] = data.id
+            if target_x < data.x_min then data.x_min = target_x end
+            if target_x > data.x_max then data.x_max = target_x end
+            if target_y < data.y_min then data.y_min = target_y end
+            if target_y > data.y_max then data.y_max = target_y end
+        end
+    end
+    if not extent.specified then
+        return flood_fill(grid, x-1, y, seen_grid, data, db) +
+                flood_fill(grid, x+1, y, seen_grid, data, db) +
+                flood_fill(grid, x, y-1, seen_grid, data, db) +
+                flood_fill(grid, x, y+1, seen_grid, data, db)
+    end
+    return 0
+end
+
+local function swap_id(data, seen_grid, from_id)
+    for x=data.x_min,data.x_max do
+        for y=data.y_min,data.y_max do
+            if seen_grid[x][y] == from_id then
+                seen_grid[x][y] = data.id
+            end
+        end
+    end
+end
+
+-- split extents that are larger than their max_width into parts
+local function split_by_width(data_tables, seen_grid, db)
+    local trimmings = {}
+    for _, data in ipairs(data_tables) do
+        local width = data.x_max - data.x_min + 1
+        local max_width = db[data.type].max_width
+        local cuts = 0
+        while width > max_width do
+            cuts = cuts + 1
+            local data_copy = copyall(data)
+            data_copy.id = #data_tables + #trimmings + 1
+            data_copy.x_max = data.x_min + max_width - 1
+            data.x_min = data_copy.x_max + 1
+            swap_id(data_copy, seen_grid, data.id)
+            table.insert(trimmings, data_copy)
+            width = width - max_width
+        end
+        if cuts > 0 then
+            log('building/stockpile too wide; splitting into %d parts ' ..
+                '(defined in spreadsheet cells %s)',
+                cuts+1, table.concat(data.cells, ', '))
+        end
+    end
+    for _, v in ipairs(trimmings) do table.insert(data_tables, v) end
+end
+
+-- split extents that are larger than their max_height into parts
+local function split_by_height(data_tables, seen_grid, db)
+    trimmings = {}
+    for _, data in ipairs(data_tables) do
+        local height = data.y_max - data.y_min + 1
+        local max_height = db[data.type].max_height
+        local cuts = 0
+        while height > max_height do
+            cuts = cuts + 1
+            local data_copy = copyall(data)
+            data_copy.id = #data_tables + #trimmings + 1
+            data_copy.y_max = data.y_min + max_height - 1
+            data.y_min = data_copy.y_max + 1
+            swap_id(data_copy, seen_grid, data.id)
+            table.insert(trimmings, data_copy)
+            height = height - max_height
+        end
+        if cuts > 0 then
+            log('building/stockpile too tall; splitting into %d parts ' ..
+                '(defined in spreadsheet cells %s)',
+                cuts+1, table.concat(data.cells, ', '))
+        end
+    end
+    for _, v in ipairs(trimmings) do table.insert(data_tables, v) end
+end
+
+-- expand multi-tile buildings that are less than their min dimensions around
+-- their current center
+local function expand_buildings(data_tables, seen_grid, db)
+    for _, data in ipairs(data_tables) do
+        if db[data.type].has_extents then goto continue end
+        local width = data.x_max - data.x_min + 1
+        local height = data.y_max - data.y_min + 1
+        local min_width = db[data.type].min_width
+        local min_height = db[data.type].min_height
+        if width < min_width then
+            local center_x = math.floor((data.x_min + data.x_max) / 2)
+            data.x_min = math.ceil(center_x - min_width / 2)
+            data.x_max = data.x_min + min_width - 1
+        end
+        if height < min_height then
+            local center_y = math.floor((data.y_min + data.y_max) / 2)
+            data.y_min = math.ceil(center_y - min_height / 2)
+            data.y_max = data.y_min + min_height - 1
+        end
+        for x=data.x_min,data.x_max do
+            if not seen_grid[x] then seen_grid[x] = {} end
+            for y=data.y_min,data.y_max do
+                -- expand into unclaimed tiles
+                if not seen_grid[x][y] then seen_grid[x][y] = data.id end
+            end
+        end
+        ::continue::
+    end
+end
+
+local function get_digit_count(num)
+    local num_digits = 1
+    while num >= 10 do
+        num = num / 10
+        num_digits = num_digits + 1
+    end
+    return num_digits
+end
+
+local function left_pad(num, width)
+    local num_digit_count = get_digit_count(num)
+    local ret = ''
+    for i=num_digit_count,width do
+        ret = ret .. ' '
+    end
+    return ret .. tostring(num)
+end
+
+-- pretty-prints the populated range of the seen_grid
+local function dump_seen_grid(args)
+    local seen_grid, max_id = args[1], args[2]
+    local x_min, x_max, y_min, y_max = 30000, -30000, 30000, -30000
+    for x, row in pairs(seen_grid) do
+        if x < x_min then x_min = x end
+        if x > x_max then x_max = x end
+        for y, _ in pairs(row) do
+            if y < y_min then y_min = y end
+            if y > y_max then y_max = y end
+        end
+    end
+    print('building/stockpile boundary map:')
+    local field_width = get_digit_count(max_id)
+    local blank = string.rep(' ', field_width+1)
+    for y=y_min,y_max do
+        local line = ''
+        for x=x_min,x_max do
+            if seen_grid[x] and tonumber(seen_grid[x][y]) then
+                line = line .. left_pad(seen_grid[x][y], field_width)
+            else
+                line = line .. blank
+            end
+        end
+        print(line)
+    end
+end
+
+local function build_extent_grid(seen_grid, data)
+    local extent_grid, num_tiles = {}, 0
+    for x=data.x_min,data.x_max do
+        local extent_x = x - data.x_min + 1
+        extent_grid[extent_x] = {}
+        for y=data.y_min,data.y_max do
+            local extent_y = y - data.y_min + 1
+            extent_grid[extent_x][extent_y] = seen_grid[x][y] == data.id
+            if extent_grid[extent_x][extent_y] then
+                num_tiles = num_tiles + 1
+            end
+        end
+    end
+    local width = data.x_max - data.x_min + 1
+    local height = data.y_max - data.y_min + 1
+    return num_tiles > 0 and extent_grid or nil,
+            num_tiles == width * height
+end
+
+-- build boundaries and extent maps from blueprint grid input
+function init_buildings(zlevel, grid, buildings, db)
+    local invalid_keys = 0
+    local data_tables = {}
+    local seen_grid = {} -- [x][y] -> id
+    for y, row in pairs(grid) do
+        for x, cell_and_text in pairs(row) do
+            if seen_grid[x] and seen_grid[x][y] then goto continue end
+            local data = {
+                id=#data_tables+1, type=nil, cells={},
+                x_min=30000, x_max=-30000, y_min=30000, y_max=-30000
+            }
+            invalid_keys = invalid_keys +
+                    flood_fill(grid, x, y, seen_grid, data, db)
+            if data.type then table.insert(data_tables, data) end
+            ::continue::
+        end
+    end
+    split_by_width(data_tables, seen_grid, db)
+    split_by_height(data_tables, seen_grid, db)
+    expand_buildings(data_tables, seen_grid, db)
+    logfn(dump_seen_grid, seen_grid, #data_tables)
+    for _, data in ipairs(data_tables) do
+        local extent_grid, is_solid = build_extent_grid(seen_grid, data)
+        if not extent_grid then
+            log('building/stockpile completely overwritten by other elements' ..
+                ' (defined in spreadsheet cells %s)',
+                table.concat(data.cells, ', '))
+        elseif not db[data.type].has_extents and not is_solid then
+            log('building partially overwritten by other buildings, and it ' ..
+                ' cannot be built unless all tiles are free (defined in ' ..
+               'spreadsheet cells %s)', table.concat(data.cells, ', '))
+        else
+            table.insert(buildings,
+                         {type=data.type,
+                          cells=data.cells,
+                          pos=xyz2pos(data.x_min, data.y_min, zlevel),
+                          width=data.x_max-data.x_min+1,
+                          height=data.y_max-data.y_min+1,
+                          extent_grid=extent_grid})
+        end
+    end
+    return invalid_keys
+end
+
+local function is_on_map_x(x)
+    return quickfort_common.is_within_map_bounds_x(x) or
+            quickfort_common.is_on_map_edge_x(x)
+end
+
+local function is_on_map_y(y)
+    return quickfort_common.is_within_map_bounds_y(y) or
+            quickfort_common.is_on_map_edge_y(y)
+end
+
+local is_on_map_z = quickfort_common.is_within_map_bounds_z
+
+-- check bounds against size limits and map edges, adjust pos, width, height,
+-- and extent_grid accordingly. marks invalid buildings that are cropped below
+-- their minimum dimensions
+-- assumes b.width and b.height > 0 if b.pos is not nil
+function crop_to_bounds(buildings, db)
+    local out_of_bounds_tiles = 0
+    for _, b in ipairs(buildings) do
+        if not b.pos then goto continue end
+        -- if pos is off the map, crop and move pos until we're ok (or empty)
+        while b.pos and
+                (not is_on_map_x(b.pos.x) or not is_on_map_z(b.pos.z)) do
+            for extent_y=1,b.height do
+                if b.extent_grid[1][extent_y] then
+                    out_of_bounds_tiles = out_of_bounds_tiles + 1
+                end
+            end
+            -- change extent_grid to a linked list if this gets too slow
+            table.remove(b.extent_grid, 1)
+            b.width = b.width - 1
+            b.pos.x = b.pos.x + 1
+            if b.width < db[b.type].min_width then b.pos = nil end
+        end
+        while b.pos and not is_on_map_y(b.pos.y) do
+            for extent_x=1,b.width do
+                if b.extent_grid[extent_x][1] then
+                    out_of_bounds_tiles = out_of_bounds_tiles + 1
+                end
+                table.remove(b.extent_grid[extent_x], 1)
+            end
+            b.height = b.height - 1
+            b.pos.y = b.pos.y + 1
+            if b.height < db[b.type].min_height then b.pos = nil end
+        end
+        -- if building extends off map to bottom or right, just crop
+        while b.pos and not is_on_map_x(b.pos.x+b.width-1) do
+            for extent_y=1,b.height do
+                if b.extent_grid[b.width][extent_y] then
+                    out_of_bounds_tiles = out_of_bounds_tiles + 1
+                end
+            end
+            b.extent_grid[b.width] = nil
+            b.width = b.width - 1
+            if b.width < db[b.type].min_width then b.pos = nil end
+        end
+        while b.pos and not is_on_map_y(b.pos.y+b.height-1) do
+            for extent_x=1,b.width do
+                if b.extent_grid[extent_x][b.height] then
+                    out_of_bounds_tiles = out_of_bounds_tiles + 1
+                end
+                b.extent_grid[extent_x][b.height] = nil
+            end
+            b.height = b.height - 1
+            if b.height < db[b.type].min_height then b.pos = nil end
+        end
+        if not b.pos then
+            log('building/stockpile not within map bounds, defined from ' ..
+                'spreadsheet cells: %s', table.concat(b.cells, ', '))
+        end
+        ::continue::
+    end
+    return out_of_bounds_tiles
+end
+
+-- check tiles for validity, adjust the extent_grid, and checks the validity of
+-- the adjusted extent_grid. marks building as invalid if the extent_grid is
+-- invalid.
+function check_tiles_and_extents(buildings, db)
+    local occupied_tiles = 0
+    for _, b in ipairs(buildings) do
+        if not b.pos then goto continue end
+        for extent_x, col in ipairs(b.extent_grid) do
+            for extent_y, in_extent in ipairs(col) do
+                if not b.extent_grid[extent_x][extent_y] then goto continue end
+                local pos =
+                        xyz2pos(b.pos.x+extent_x-1, b.pos.y+extent_y-1, b.pos.z)
+                if not db[b.type].is_valid_tile_fn(pos) then
+                    log('tile occupied: (%d, %d, %d)', pos.x, pos.y, pos.z)
+                    b.extent_grid[extent_x][extent_y] = false
+                    occupied_tiles = occupied_tiles + 1
+                end
+                ::continue::
+            end
+        end
+        if not db[b.type].is_valid_extent_fn(b) then
+            log('no room for %s at (%d, %d, %d)',
+                db[b.type].label, b.pos.x, b.pos.y, b.pos.z)
+            b.pos = nil
+        end
+        ::continue::
+    end
+    return occupied_tiles
+end
+
+-- allocate and initialize extents structure from the extents_grid
+-- returns extents, num_tiles
+-- we assume by this point that the extent is valid and non-empty
+function make_extents(b, db)
+    local area = b.width * b.height
+    local extents = df.new('uint8_t', area)
+    local num_tiles = 0
+    for i=1,area do
+        local extent_x = (i-1) % b.width + 1
+        local extent_y = math.floor((i-1) / b.width) + 1
+        local is_in_stockpile = b.extent_grid[extent_x][extent_y]
+        extents[i-1] = is_in_stockpile and 1 or 0
+        if is_in_stockpile then num_tiles = num_tiles + 1 end
+    end
+    return extents, num_tiles
+end

--- a/internal/quickfort/building.lua
+++ b/internal/quickfort/building.lua
@@ -1,4 +1,4 @@
--- building-related logic for the quickfort build and place modules
+-- building-related logic shared between the quickfort build and place modules
 --@ module = true
 
 if not dfhack_flags.module then

--- a/internal/quickfort/building.lua
+++ b/internal/quickfort/building.lua
@@ -120,6 +120,7 @@ local function split_by_width(data_tables, seen_grid, db)
             data_copy.x_min = data.x_max + 1
             swap_id(data_copy, seen_grid, data.id)
             table.insert(trimmings, data_copy)
+            data = data_copy
             width = width - max_width
         end
         if cuts > 0 then
@@ -146,6 +147,7 @@ local function split_by_height(data_tables, seen_grid, db)
             data_copy.y_min = data.y_max + 1
             swap_id(data_copy, seen_grid, data.id)
             table.insert(trimmings, data_copy)
+            data = data_copy
             height = height - max_height
         end
         if cuts > 0 then

--- a/internal/quickfort/place.lua
+++ b/internal/quickfort/place.lua
@@ -16,263 +16,10 @@ end
 
 require('dfhack.buildings') -- loads additional functions into dfhack.buildings
 local quickfort_common = reqscript('internal/quickfort/common')
+local quickfort_building = reqscript('internal/quickfort/building')
 local log = quickfort_common.log
-local logfn = quickfort_common.logfn
 
-local stockpile_types = {
-    a='Animal',
-    f='Food',
-    u='Furniture',
-    n='Coins',
-    y='Corpses',
-    r='Refuse',
-    s='Stone',
-    w='Wood',
-    e='Gem',
-    b='Bar/Block',
-    h='Cloth',
-    l='Leather',
-    z='Ammo',
-    S='Sheets',
-    g='Finished Goods',
-    p='Weapons',
-    d='Armor',
-}
-
--- maps stockpile boundaries, returns number of invalid keys seen
--- populates seen_grid coordinates with the stockpile id so we can build an
--- extent_grid later. spreadsheet cells that define extents (e.g. a(5x5)) create
--- stockpiles separate from adjacent cells, even if they have the same type.
-local function flood_fill(grid, x, y, seen_grid, id, data)
-    if seen_grid[x] and seen_grid[x][y] then return 0 end
-    if not grid[y] or not grid[y][x] then return 0 end
-    local cell, text = grid[y][x].cell, grid[y][x].text
-    local keys, extent = quickfort_common.parse_cell(text)
-    if not stockpile_types[keys] then
-        if not seen_grid[x] then seen_grid[x] = {} end
-        seen_grid[x][y] = true -- seen, but not part of any stockpile
-        print(string.format('invalid key sequence in cell %s: "%s"',
-                            cell, text))
-        return 1
-    end
-    if data.type and (data.type ~= keys or extent.specified) then return 0 end
-    log('mapping spreadsheet cell %s with text "%s"', cell, text)
-    if not data.type then data.type = keys end
-    table.insert(data.cells, cell)
-    for target_x=x,x+extent.width-1 do
-        for target_y=y,y+extent.height-1 do
-            if not seen_grid[target_x] then seen_grid[target_x] = {} end
-            -- this may overwrite another pile, but we'll remove empties later
-            seen_grid[target_x][target_y] = id
-            if target_x < data.x_min then data.x_min = target_x end
-            if target_x > data.x_max then data.x_max = target_x end
-            if target_y < data.y_min then data.y_min = target_y end
-            if target_y > data.y_max then data.y_max = target_y end
-        end
-    end
-    if not extent.specified then
-        return flood_fill(grid, x-1, y, seen_grid, id, data) +
-                flood_fill(grid, x+1, y, seen_grid, id, data) +
-                flood_fill(grid, x, y-1, seen_grid, id, data) +
-                flood_fill(grid, x, y+1, seen_grid, id, data)
-    end
-    return 0
-end
-
--- returns nil if no tiles are actually set. this can happen when piles overlap
-local function build_extent_grid(seen_grid, data, id)
-    local extent_grid, has_tile = {}, false
-    for x=data.x_min,data.x_max do
-        local extent_x = x - data.x_min + 1
-        extent_grid[extent_x] = {}
-        for y=data.y_min,data.y_max do
-            local extent_y = y - data.y_min + 1
-            extent_grid[extent_x][extent_y] = seen_grid[x][y] == id
-            has_tile = has_tile or extent_grid[extent_x][extent_y]
-        end
-    end
-    return has_tile and extent_grid or nil
-end
-
-local function get_digit_count(num)
-    local num_digits = 1
-    while num >= 10 do
-        num = num / 10
-        num_digits = num_digits + 1
-    end
-    return num_digits
-end
-
-local function left_pad(num, width)
-    local num_digit_count = get_digit_count(num)
-    local ret = ''
-    for i=num_digit_count,width do
-        ret = ret .. ' '
-    end
-    return ret .. tostring(num)
-end
-
--- pretty-prints the populated range of the seen_grid
-local function dump_seen_grid(args)
-    local seen_grid, max_id = args[1], args[2]
-    local x_min, x_max, y_min, y_max = 30000, -30000, 30000, -30000
-    for x, row in pairs(seen_grid) do
-        if x < x_min then x_min = x end
-        if x > x_max then x_max = x end
-        for y, _ in pairs(row) do
-            if y < y_min then y_min = y end
-            if y > y_max then y_max = y end
-        end
-    end
-    print('stockpile extent map:')
-    local field_width = get_digit_count(max_id)
-    local blank = string.rep(' ', field_width+1)
-    for y=y_min,y_max do
-        local line = ''
-        for x=x_min,x_max do
-            if seen_grid[x] and tonumber(seen_grid[x][y]) then
-                line = line .. left_pad(seen_grid[x][y], field_width)
-            else
-                line = line .. blank
-            end
-        end
-        print(line)
-    end
-end
-
--- build extent maps from blueprint grid input
-local function init_stockpiles(zlevel, grid, stockpiles)
-    local invalid_keys = 0
-    local piles = {} -- list of stockpile data tables
-    local seen_grid = {} -- [x][y] -> id
-    for y, row in pairs(grid) do
-        for x, cell_and_text in pairs(row) do
-            if seen_grid[x] and seen_grid[x][y] then goto continue end
-            local data = {
-                type=nil, cells={},
-                x_min=30000, x_max=-30000, y_min=30000, y_max=-30000
-            }
-            invalid_keys = invalid_keys +
-                    flood_fill(grid, x, y, seen_grid, #piles+1, data)
-            if data.type then table.insert(piles, data) end
-            ::continue::
-        end
-    end
-    for id, data in ipairs(piles) do
-        local extent_grid = build_extent_grid(seen_grid, data, id)
-        if extent_grid then
-            table.insert(stockpiles,
-                         {type=data.type,
-                          cells=data.cells,
-                          pos=xyz2pos(data.x_min, data.y_min, zlevel),
-                          width=data.x_max-data.x_min+1,
-                          height=data.y_max-data.y_min+1,
-                          extent_grid=extent_grid})
-        else
-            log('all tiles are overwritten by other stockpiles for pile' ..
-                ' defined from spreadsheet cells: %s',
-                table.concat(data.cells, ', '))
-        end
-    end
-    logfn(dump_seen_grid, seen_grid, #piles)
-    return invalid_keys
-end
-
-local function is_on_map_x(x)
-    return quickfort_common.is_within_map_bounds_x(x) or
-            quickfort_common.is_on_map_edge_x(x)
-end
-
-local function is_on_map_y(y)
-    return quickfort_common.is_within_map_bounds_y(y) or
-            quickfort_common.is_on_map_edge_y(y)
-end
-
-local function is_on_map_xz(pos)
-    return is_on_map_x(pos.x) and quickfort_common.is_within_map_bounds_z(pos.z)
-end
-
-local function is_on_map_yz(pos)
-    return is_on_map_y(pos.y) and quickfort_common.is_within_map_bounds_z(pos.z)
-end
-
--- check bounds against stockpile size limits and map edges, adjust pos, width,
--- height, and extent_grid accordingly
-local function crop_to_bounds(stockpiles)
-    local stockpile_too_big_tiles = 0
-    local out_of_bounds_tiles = 0
-    for _, s in ipairs(stockpiles) do
-        if s.width > 31 or s.height > 31 then
-            log('a single stockpile cannot extend beyond a 31x31 tile' ..
-                ' square; cropping stockpile defined from spreadsheet cells %s',
-                table.concat(s.cells, ', '))
-        end
-        -- if pos is off the map, crop and move pos until we're ok (or empty)
-        while s.pos and s.width > 0 and not is_on_map_xz(s.pos) do
-            for extent_y=1,s.height do
-                if s.extent_grid[1][extent_y] then
-                    out_of_bounds_tiles = out_of_bounds_tiles + 1
-                end
-            end
-            -- change extent_grid to a linked list if this gets too slow
-            table.remove(s.extent_grid, 1)
-            s.width = s.width - 1
-            s.pos.x = s.pos.x + 1
-            if s.width == 0 then s.pos = nil end
-        end
-        while s.pos and s.height > 0 and not is_on_map_yz(s.pos) do
-            for extent_x=1,s.width do
-                if s.extent_grid[extent_x][1] then
-                    out_of_bounds_tiles = out_of_bounds_tiles + 1
-                end
-                table.remove(s.extent_grid[extent_x], 1)
-            end
-            s.height = s.height - 1
-            s.pos.y = s.pos.y + 1
-            if s.height == 0 then s.pos = nil end
-        end
-        -- if stockpile is too big or off map to bottom or right, just crop
-        while s.pos and
-                (s.width > 31 or
-                 (s.width > 0 and not is_on_map_x(s.pos.x+s.width-1))) do
-            for extent_y=1,s.height do
-                if s.extent_grid[s.width][extent_y] then
-                    if s.width > 31 then
-                        stockpile_too_big_tiles = stockpile_too_big_tiles + 1
-                    else
-                        out_of_bounds_tiles = out_of_bounds_tiles + 1
-                    end
-                end
-            end
-            s.extent_grid[s.width] = nil
-            s.width = s.width - 1
-            if s.width == 0 then s.pos = nil end
-        end
-        while s.pos and
-                (s.height > 31 or
-                 (s.height > 0 and not is_on_map_y(s.pos.y+s.height-1))) do
-            for extent_x=1,s.width do
-                if s.extent_grid[extent_x][s.height] then
-                    if s.height > 31 then
-                        stockpile_too_big_tiles = stockpile_too_big_tiles + 1
-                    else
-                        out_of_bounds_tiles = out_of_bounds_tiles + 1
-                    end
-                end
-                s.extent_grid[extent_x][s.height] = nil
-            end
-            s.height = s.height - 1
-            if s.height == 0 then s.pos = nil end
-        end
-        if not s.pos then
-            log('stockpile completely off map, defined from spreadsheet' ..
-                ' cells: %s', table.concat(s.cells, ', '))
-        end
-    end
-    return stockpile_too_big_tiles, out_of_bounds_tiles
-end
-
-local function can_place_stockpile(pos)
+local function is_valid_stockpile_tile(pos)
     local flags, occupancy = dfhack.maps.getTileFlags(pos)
     if flags.hidden or occupancy.building ~= 0 then return false end
     local shape = df.tiletype.attrs[dfhack.maps.getTileType(pos)].shape
@@ -288,62 +35,62 @@ local function can_place_stockpile(pos)
             shape == df.tiletype_shape.SHRUB
 end
 
--- check tiles for validity, adjust extent_grid
-local function mask_occupied_tiles(stockpiles)
-    local occupied_tiles = 0
-    for _, s in ipairs(stockpiles) do
-        for extent_x, col in ipairs(s.extent_grid) do
-            for extent_y, in_extent in ipairs(col) do
-                if not s.extent_grid[extent_x][extent_y] then goto continue end
-                local pos =
-                        xyz2pos(s.pos.x+extent_x-1, s.pos.y+extent_y-1, s.pos.z)
-                if not can_place_stockpile(pos) then
-                    log('tile occupied: (%d, %d, %d)', pos.x, pos.y, pos.z)
-                    s.extent_grid[extent_x][extent_y] = false
-                    occupied_tiles = occupied_tiles + 1
-                end
-                ::continue::
-            end
+local function is_valid_stockpile_extent(s)
+    for extent_x, col in ipairs(s.extent_grid) do
+        for extent_y, in_extent in ipairs(col) do
+            if in_extent then return true end
         end
     end
-    return occupied_tiles
+    return false
 end
 
--- allocate and initialize stockpile extents structure from the extents_grid
-local function make_extents(s)
-    local area = s.width * s.height
-    local extents = df.new('uint8_t', area)
-    local num_tiles = 0
-    for i=1,area do
-        local extent_x = (i-1) % s.width + 1
-        local extent_y = math.floor((i-1) / s.width) + 1
-        local is_in_stockpile = s.extent_grid[extent_x][extent_y]
-        extents[i-1] = is_in_stockpile and 1 or 0
-        if is_in_stockpile then num_tiles = num_tiles + 1 end
-    end
-    return extents, num_tiles
+local stockpile_db = {
+    a={label='Animal'},
+    f={label='Food'},
+    u={label='Furniture'},
+    n={label='Coins'},
+    y={label='Corpses'},
+    r={label='Refuse'},
+    s={label='Stone'},
+    w={label='Wood'},
+    e={label='Gem'},
+    b={label='Bar/Block'},
+    h={label='Cloth'},
+    l={label='Leather'},
+    z={label='Ammo'},
+    S={label='Sheets'},
+    g={label='Finished Goods'},
+    p={label='Weapons'},
+    d={label='Armor'},
+}
+for _, v in pairs(stockpile_db) do
+    v.has_extents = true
+    v.min_width = 1
+    v.max_width = 31
+    v.min_height = 1
+    v.max_height = 31
+    v.is_valid_tile_fn = is_valid_stockpile_tile
+    v.is_valid_extent_fn = is_valid_stockpile_extent
 end
 
 local function init_stockpile_settings(bld, type)
-    print('TODO: initialize stockpile settings')
+    print('stockpile settings initialization not yet implemented')
 end
 
 local function create_stockpile(s)
     log('creating %s stockpile at map coordinates (%d, %d, %d), defined' ..
         ' from spreadsheet cells: %s',
-        stockpile_types[s.type], s.pos.x, s.pos.y, s.pos.z,
+        stockpile_db[s.type].label, s.pos.x, s.pos.y, s.pos.z,
         table.concat(s.cells, ', '))
-    local extents, ntiles = make_extents(s)
-    if ntiles == 0 then
-        log('no valid tiles; not creating stockpile')
-        df.delete(extents)
-        return 0
-    end
+    local extents, ntiles = quickfort_building.make_extents(s, stockpile_db)
     local room = {x=s.pos.x, y=s.pos.y, width=s.width, height=s.height}
     local bld, err = dfhack.buildings.constructBuilding{
         type=df.building_type.Stockpile, abstract=true, pos=s.pos,
         width=s.width, height=s.height, fields={room=room}}
     if not bld then
+        if extents then df.delete(extents) end
+        -- this is an error instead of a qerror since our validity checking
+        -- is supposed to prevent this from ever happening
         error(string.format('unable to place stockpile: %s', err))
     end
     -- constructBuilding deallocates extents, so we have to assign it after
@@ -357,23 +104,23 @@ function do_run(zlevel, grid)
         piles_designated={label='Stockpiles designated', value=0, always=true},
         tiles_designated={label='Tiles designated', value=0},
         occupied={label='Tiles skipped (tile occupied)', value=0},
-        too_big={label='Tiles skipped (stockpile too large)', value=0},
         out_of_bounds={label='Tiles skipped (outside map boundary)', value=0},
         invalid_keys={label='Invalid key sequences', value=0},
     }
 
     local stockpiles = {}
-    stats.invalid_keys.value = init_stockpiles(zlevel, grid, stockpiles)
-    stats.too_big.value, stats.out_of_bounds.value = crop_to_bounds(stockpiles)
-    stats.occupied.value = mask_occupied_tiles(stockpiles)
+    stats.invalid_keys.value = quickfort_building.init_buildings(
+        zlevel, grid, stockpiles, stockpile_db)
+    stats.out_of_bounds.value = quickfort_building.crop_to_bounds(
+        stockpiles, stockpile_db)
+    stats.occupied.value = quickfort_building.check_tiles_and_extents(
+        stockpiles, stockpile_db)
 
     for _, s in ipairs(stockpiles) do
         if s.pos then
             local ntiles = create_stockpile(s)
             stats.tiles_designated.value = stats.tiles_designated.value + ntiles
-            if ntiles > 0 then
-                stats.piles_designated.value = stats.piles_designated.value + 1
-            end
+            stats.piles_designated.value = stats.piles_designated.value + 1
         end
     end
     return stats
@@ -391,7 +138,8 @@ function do_undo(zlevel, grid)
     }
 
     local stockpiles = {}
-    stats.invalid_keys.value = init_stockpiles(zlevel, grid, stockpiles)
+    stats.invalid_keys.value = quickfort_building.init_buildings(
+        zlevel, grid, stockpiles, stockpile_db)
 
     for _, s in ipairs(stockpiles) do
         for extent_x, col in ipairs(s.extent_grid) do

--- a/internal/quickfort/place.lua
+++ b/internal/quickfort/place.lua
@@ -1,4 +1,4 @@
--- place-related logic for the quickfort script
+-- place-related data and logic for the quickfort script
 --@ module = true
 --[[
 stockpiles data structure:

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -101,6 +101,7 @@ files are described in the files themselves.
 -- top-level file. this ensures transitive dependencies are reloaded if any
 -- files have changed.
 local quickfort_build = reqscript('internal/quickfort/build')
+local quickfort_building = reqscript('internal/quickfort/building')
 local quickfort_command = reqscript('internal/quickfort/command')
 local quickfort_common = reqscript('internal/quickfort/common')
 local quickfort_dig = reqscript('internal/quickfort/dig')


### PR DESCRIPTION
DFHack/dfhack#499 Implement build logic for the quickfort script

The algorithmic logic is just a refactored and generalized form of the place logic. A side effect of the generalization is the improvement to stockpile placing where too-big stockpiles are split into multiple stockpiles instead of just being cropped.

I condensed decision-making properties for all buildings into a giant table structure. It works, but it is huge and unwieldy. If there is a better way to do this, I'd like to hear it : )

All buildings are tested to work with the internal constructBuilding() function. I was pleasantly surprised that it handles finding appropriate materials automatically and integrates wtih buildingplan.

The current code has some limitations that I plan to address in a future PR:
- weapon and upright spear traps aren't configurable and are built with only a single weapon
- pressure plates are not configurable at all
- buildings that aren't handled by buildingplan and that don't have sufficient materials to build throw an error. In the future, I plan to choose materials from within the quickfort script so I'll be able to handle this situation before calling constructBuilding()

n.b. I could never get an instrument built with constructBuilding(), but I could never get an instrument built using the game UI either, so maybe I just don't understand which instruments this "building" needs.