### PR TITLE
Quickfort list and parse fixes

### DIFF
--- a/internal/quickfort/list.lua
+++ b/internal/quickfort/list.lua
@@ -18,18 +18,18 @@ local function get_modeline(filepath)
         quickfort_parse.tokenize_csv_line(first_line)[1])
 end
 
-local blueprint_cache = blueprint_cache or {}
+local blueprint_cache = {}
 
 local function scan_blueprint(path)
     local filepath = quickfort_common.get_blueprint_filepath(path)
-    local hash = dfhack.internal.md5File(filepath)
-    if not blueprint_cache[path] or blueprint_cache[path].hash ~= hash then
-        blueprint_cache[path] = {modeline=get_modeline(filepath), hash=hash}
+    local mtime = dfhack.filesystem.mtime(filepath)
+    if not blueprint_cache[path] or blueprint_cache[path].mtime ~= mtime then
+        blueprint_cache[path] = {modeline=get_modeline(filepath), mtime=mtime}
     end
     return blueprint_cache[path].modeline
 end
 
-local blueprint_files = blueprint_files or {}
+local blueprint_files = {}
 
 local function scan_blueprints()
     local paths = dfhack.filesystem.listdir_recursive(

--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -9,6 +9,7 @@ local quickfort_common = reqscript('internal/quickfort/common')
 
 -- adapted from example on http://lua-users.org/wiki/LuaCsv
 function tokenize_csv_line(line)
+    line = string.gsub(line, '[\r\n]*$', '')
     local tokens = {}
     local pos = 1
     local sep = ','
@@ -102,8 +103,9 @@ local function make_cell_label(col_num, row_num)
     return get_col_name(col_num) .. tostring(math.floor(row_num))
 end
 
--- returns a grid representation of the current section and the next z-level
--- modifier, if any. See process_file for grid format.
+-- returns a grid representation of the current section, the number of lines
+-- read from the input, and the next z-level modifier, if any. See process_file
+-- for grid format.
 local function process_section(file, start_line_num, start_coord)
     local grid = {}
     local y = start_coord.y
@@ -142,7 +144,7 @@ contents are non-nil.
 function process_file(filepath, start_cursor_coord)
     local file = io.open(filepath)
     if not file then
-        error(string.format('failed to open blueprint file: "%s"', filepath))
+        qerror(string.format('failed to open blueprint file: "%s"', filepath))
     end
     local line = file:read()
     local modeline = parse_modeline(tokenize_csv_line(line)[1])


### PR DESCRIPTION
DFHack/dfhack#499 

- use mtime instead of md5hash for update checking
when I originally wrote the list cache, I saw that there was no way to get the file modification time from lua, but I saw the md5hash function and used that. in reqscript I saw how we get the mtime, so I'm switching to that since it's faster and has effectively the same functionality.

- chomp trailing newlines from input
I've discovered that when tokenizing csv file input, the last cell on a line includes the newline character. chomp it off before parsing.

- some fixes to documentation and a change from error() -> qerror()