### PR TITLE
Quickfort query

### DIFF
--- a/internal/quickfort/aliases.lua
+++ b/internal/quickfort/aliases.lua
@@ -36,14 +36,18 @@ function push_aliases_csv_file(filename)
         return
     end
     local aliases = {}
+    local num_aliases = 0
     for line in file:lines() do
         line = line:gsub('[\r\n]*$', '')
-        _, _, alias, definition = line:find('^([%w]+):%s*(.*)')
+        -- aliases must be at two alphanumerics long to distinguish them from
+        -- regular keystrokes
+        _, _, alias, definition = line:find('^(%w[%w]+):%s*(.*)')
         if alias and #definition > 0 then
             aliases[alias] = definition
+            num_aliases = num_aliases + 1
         end
     end
-    log('successfully read in aliases from "%s"', filename)
+    log('successfully read in %d aliases from "%s"', num_aliases, filename)
     local prev = alias_stack
     setmetatable(aliases, {__index=function(_, key) return prev[key] end})
     alias_stack = aliases

--- a/internal/quickfort/aliases.lua
+++ b/internal/quickfort/aliases.lua
@@ -1,0 +1,125 @@
+-- alias expansion logic for the quickfort script query module
+--@ module = true
+
+if not dfhack_flags.module then
+    qerror('this script cannot be called directly')
+end
+
+local quickfort_common = reqscript('internal/quickfort/common')
+local log = quickfort_common.log
+
+-- special key sequences inherited from python quickfort. these cannot be
+-- overridden with aliases
+local specials = {
+    ['&']='Enter',
+    ['+']='{Shift}',
+    ['@']={'{Shift}','Enter'},
+    ['^']='ESC',
+    ['{ExitMenu}']='ESC',
+    ['%']='{Wait}'
+}
+
+local alias_stack = {}
+
+function reset_aliases()
+    alias_stack = {}
+end
+
+-- pushes a file of aliases on the stack. aliases are resolved with the
+-- definition nearest the top of the stack.
+function push_aliases_csv_file(filename)
+    local file = io.open(filename)
+    if not file then
+        log('aliases file not found: "%s"', filename)
+        return
+    end
+    local aliases = {}
+    for line in file:lines() do
+        line = line:gsub('[\r\n]*$', '')
+        _, _, alias, definition = line:find('^([%w]+):%s*(.*)')
+        if alias and #definition > 0 then
+            log('found alias: "%s" -> "%s"', alias, definition)
+            aliases[alias] = definition
+        end
+    end
+    log('successfully read in aliases from "%s"', filename)
+    local prev = alias_stack
+    setmetatable(aliases, {__index=function(_, key) return prev[key] end})
+    alias_stack = aliases
+end
+
+local function process_text(text, tokens, depth)
+    if depth > 50 then
+        qerror(string.format('alias resolution maximum depth exceeded (%d)',
+                             depth))
+    end
+    local i = 1
+    while i <= #text do
+        local next_char = text:sub(i, i)
+        log('processing next character: "%s"', next_char)
+        local token, expansion, repititions = next_char, {}, 1
+        if next_char ~= '{' then
+            -- token is a sepcial key or a key literal
+            expansion[1] = specials[token] or token
+        else
+            -- find the next closing bracket, skipping one space to allow for
+            -- '{}}' and it's kin
+            local b, e, extended_token = text:find('{(.[^}]*)}', i)
+            if not extended_token then
+                qerror(string.format(
+                        'invalid extended token: "%s"; did you mean "{{}"?',
+                        text:sub(i)))
+            end
+            log('matched extended token: "%s"', extended_token)
+            local _, _, rep_tok, rep_rep = extended_token:find('(.-)%s+(%d+)$')
+            if rep_tok then
+                token = rep_tok
+                repititions = rep_rep
+            end
+            if token == 'Numpad' and repititions then
+                token = string.format('%s %d', token, repititions)
+            end
+            log('found token: "%s" with repitition count: "%s"',
+                token, tostring(repititions))
+            if not repititions then repititions = 1 end
+            if alias_stack[token] then
+                log('expanding alias')
+                process_text(alias_stack[token], expansion, depth+1)
+            else
+                expansion[1] = token
+            end
+            i = i + #extended_token + 1
+        end
+        for j=1,repititions do
+            log('adding tokens: "%s"', table.concat(expansion, ''))
+            for k=1, #expansion do
+                tokens[#tokens+1] = expansion[k]
+            end
+        end
+        i = i + 1
+    end
+end
+
+-- expands aliases in a string and returns the individual key tokens.
+-- if the entirety of text matches an alias, expands the entire text as an alias
+-- otherwise, if the text contains a substring like '{alias}', matches the alias
+-- between the curly brackets and replaces the substring. Aliases themselves
+-- can contain other aliases, but must use the {} format if they do. Literal
+-- key names can also appear in curly brackets to allow the parser to recognize
+-- multi-character keys, such as '{F10}'. Anything in curly brackets can be
+-- followed by a number to indicate repitition. For example, '{Down 5}'
+-- indicates 'Down' 5 times. 'Numpad' is treated specially so that '{Numpad 8}'
+-- doesn't get expanded to 'Numpad' 8 times, but rather 'Numpad 8' once. You can
+-- repeat Numpad keys like this: '{Numpad 8 5}'.
+-- returns an array of character key tokens
+function expand_aliases(text)
+    local tokens = {}
+    log('processing cell text: "%s"', text)
+    if alias_stack[text] then
+        log('expanding alias')
+        process_text(alias_stack[text], tokens, 1)
+    else
+        process_text(text, tokens, 1)
+    end
+    return tokens
+end

--- a/internal/quickfort/keycodes.lua
+++ b/internal/quickfort/keycodes.lua
@@ -1,0 +1,62 @@
+-- keycode conversion logic for the quickfort script query module
+--@ module = true
+
+if not dfhack_flags.module then
+    qerror('this script cannot be called directly')
+end
+
+local quickfort_common = reqscript('internal/quickfort/common')
+local log = quickfort_common.log
+
+local keycodes_file = 'data/init/interface.txt'
+
+local interface_txt_mtime = nil
+local keycodes = {}
+
+local function init_keycodes()
+    local mtime = dfhack.filesystem.mtime(keycodes_file)
+    if interface_txt_mtime == mtime then return end
+    local file = io.open(keycodes_file)
+    if not file then
+        qerror(string.format('failed to open file: "%s"', keycodes_file))
+    end
+    local cur_binding = nil
+    for line in file:lines() do
+        line = string.gsub(line, '[\r\n]*$', '')
+        _, _, binding = string.find(line, '^%[BIND:([0-9_A-Z]+):.*$')
+        if binding then
+            cur_binding = binding
+        elseif cur_binding and #line > 0 then
+            -- it's a keycode definition
+            if not keycodes[line] then keycodes[line] = {} end
+            table.insert(keycodes[line], cur_binding)
+        end
+    end
+    log('successfully read in keycodes from "%s"', keycodes_file)
+    interface_txt_mtime = mtime
+end
+
+-- code is an interface key name from the keycodes_file, like 'a' or 'Down',
+-- with shift, ctrl, or alt modifiers recorded in the modifiers table.
+-- returns a list of all the keycodes that the input could translate to
+function get_keycodes(code, modifiers)
+    init_keycodes()
+    if not code then return nil end
+    local mod = 0
+    if modifiers['{shift}'] then
+        mod = 1
+    end
+    if modifiers['{ctrl}'] then
+        mod = mod + 2
+    end
+    if modifiers['{alt}'] then
+        mod = mod + 4
+    end
+    local key = nil
+    if mod == 0 and #code == 1 and tonumber(code) == nil then
+        key = string.format('[KEY:%s]', code)
+    else
+        key = string.format('[SYM:%d:%s]', mod, code)
+    end
+    return keycodes[key]
+end

--- a/internal/quickfort/keycodes.lua
+++ b/internal/quickfort/keycodes.lua
@@ -53,7 +53,7 @@ function get_keycodes(code, modifiers)
         mod = mod + 4
     end
     local key = nil
-    if mod == 0 and #code == 1 and tonumber(code) == nil then
+    if mod == 0 and #code == 1 then
         key = string.format('[KEY:%s]', code)
     else
         key = string.format('[SYM:%d:%s]', mod, code)

--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -7,6 +7,11 @@ end
 
 local quickfort_common = reqscript('internal/quickfort/common')
 
+local function trim_and_insert(tokens, token)
+    _, _, token = token:find('^%s*(.-)%s*$')
+    table.insert(tokens, token)
+end
+
 -- adapted from example on http://lua-users.org/wiki/LuaCsv
 function tokenize_csv_line(line)
     line = string.gsub(line, '[\r\n]*$', '')
@@ -30,18 +35,18 @@ function tokenize_csv_line(line)
                 -- this is the way to "escape" the quote char in a quote.
                 -- example: "blub""blip""boing" -> blub"blip"boing
             until c ~= '"'
-            table.insert(tokens, txt)
+            trim_and_insert(tokens, txt)
             assert(c == sep or c == '')
             pos = pos + 1
         else
             -- no quotes used, just look for the first separator
             local startp, endp = string.find(line, sep, pos)
             if startp then
-                table.insert(tokens, string.sub(line, pos, startp-1))
+                trim_and_insert(tokens, string.sub(line, pos, startp-1))
                 pos = endp + 1
             else
                 -- no separator found -> use rest of string and terminate
-                table.insert(tokens, string.sub(line, pos))
+                trim_and_insert(tokens, string.sub(line, pos))
                 break
             end
         end

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -30,18 +30,7 @@ end
 
 local function move_cursor(screen, overlay, pos)
     overlay:moveCursorTo(pos)
-    -- wiggle the cursor so the building under the cursor gets properly selected
-    -- is there a better way to do this? I've tried:
-    -- - DwarfOverlay:simulateCursorMovement
-    -- - DwarfOverlay:selectBuilding
-    -- - setting the ui.main.mode to something else then back to QueryBuilding
-    if pos.y > 0 then
-        gui.simulateInput(screen, 'CURSOR_UP')
-        gui.simulateInput(screen, 'CURSOR_DOWN')
-    else
-        gui.simulateInput(screen, 'CURSOR_DOWN')
-        gui.simulateInput(screen, 'CURSOR_UP')
-    end
+    dfhack.gui.refreshSidebar()
 end
 
 local function handle_modifiers(token, modifiers)
@@ -53,7 +42,7 @@ local function handle_modifiers(token, modifiers)
         return true
     end
     if token_lower == '{wait}' then
-        print('{wait} not yet implemented')
+        print('{Wait} not yet implemented')
         return true
     end
     return false

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -5,12 +5,86 @@ if not dfhack_flags.module then
     qerror('this script cannot be called directly')
 end
 
+local gui = require('gui')
+local guidm = require('gui.dwarfmode')
 local quickfort_common = reqscript('internal/quickfort/common')
 local log = quickfort_common.log
+local quickfort_aliases = reqscript('internal/quickfort/aliases')
+local quickfort_keycodes = reqscript('internal/quickfort/keycodes')
+
+local common_aliases_filename = 'hack/data/quickfort/aliases-common.txt'
+local user_aliases_filename = 'dfhack-config/quickfort/aliases.txt'
+
+local function move_cursor(screen, overlay, pos)
+    overlay:moveCursorTo(pos)
+    -- wiggle the cursor so the building under the cursor gets properly selected
+    -- is there a better way to do this? I've tried:
+    -- - DwarfOverlay:simulateCursorMovement
+    -- - DwarfOverlay:selectBuilding
+    -- - setting the ui.main.mode to something else then back to QueryBuilding
+    if pos.y > 0 then
+        gui.simulateInput(screen, 'CURSOR_UP')
+        gui.simulateInput(screen, 'CURSOR_DOWN')
+    else
+        gui.simulateInput(screen, 'CURSOR_DOWN')
+        gui.simulateInput(screen, 'CURSOR_UP')
+    end
+end
 
 function do_run(zlevel, grid)
-    local stats = nil
-    print('"quickfort run" not yet implemented for mode: query')
+    local stats = {
+        keystrokes={label='Keystrokes sent', value=0, always=true},
+        tiles={label='Settings modified', value=0},
+    }
+
+    quickfort_aliases.reset_aliases()
+    quickfort_aliases.push_aliases_csv_file(common_aliases_filename)
+    quickfort_aliases.push_aliases_csv_file(user_aliases_filename)
+
+    local saved_cursor = guidm.getCursorPos()
+    local saved_mode = df.global.ui.main.mode
+    df.global.ui.main.mode = df.ui_sidebar_mode.QueryBuilding
+    local screen = dfhack.gui.getCurViewscreen(true)
+    local overlay = guidm.DwarfOverlay{}
+    for y, row in pairs(grid) do
+        for x, cell_and_text in pairs(row) do
+            local pos = xyz2pos(x, y, zlevel)
+            -- TODO: verify that we're on top of a building?
+            local cell, text = cell_and_text.cell, cell_and_text.text
+            log('applying spreadsheet cell %s with text "%s" to map ' ..
+                'coordinates (%d, %d, %d)', cell, text, pos.x, pos.y, pos.z)
+            local tokens = quickfort_aliases.expand_aliases(text)
+            local expanded_text = table.concat(tokens, '')
+            if text ~= expanded_text then
+                log('expanded aliases to: "%s"', expanded_text)
+            end
+            move_cursor(screen, overlay, pos)
+            local modifiers = {} -- tracks ctrl, shift, and alt modifiers
+            for _,token in ipairs(tokens) do
+                local token_lower = token:lower()
+                if token_lower == '{shift}' or
+                        token_lower == '{ctrl}' or
+                        token_lower == '{alt}' then
+                    modifiers[token_lower] = true
+                end
+                -- TODO: pause briefly on '{wait}'
+                local kcodes = quickfort_keycodes.get_keycodes(token, modifiers)
+                modifiers = {}
+                if not kcodes then
+                    qerror(string.format('unknown key: "%s"', token))
+                else
+                    gui.simulateInput(screen, kcodes)
+                    stats.keystrokes.value = stats.keystrokes.value + 1
+                end
+                ::continue::
+            end
+            -- TODO: verify that we're not stuck in a submenu, otherwise error
+            stats.tiles.value = stats.tiles.value + 1
+        end
+    end
+    df.global.ui.main.mode = saved_mode
+    move_cursor(screen, overlay, saved_cursor)
+    quickfort_aliases.reset_aliases()
     return stats
 end
 

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -100,11 +100,13 @@ files are described in the files themselves.
 -- reqscript all internal files here, even if they're not directly used by this
 -- top-level file. this ensures transitive dependencies are reloaded if any
 -- files have changed.
+local quickfort_aliases = reqscript('internal/quickfort/aliases')
 local quickfort_build = reqscript('internal/quickfort/build')
 local quickfort_building = reqscript('internal/quickfort/building')
 local quickfort_command = reqscript('internal/quickfort/command')
 local quickfort_common = reqscript('internal/quickfort/common')
 local quickfort_dig = reqscript('internal/quickfort/dig')
+local quickfort_keycodes = reqscript('internal/quickfort/keycodes')
 local quickfort_list = reqscript('internal/quickfort/list')
 local quickfort_parse = reqscript('internal/quickfort/parse')
 local quickfort_place = reqscript('internal/quickfort/place')


### PR DESCRIPTION
DFHack/dfhack#499 Implement query mode logic for the quickfort script

I have a couple questions for this PR:

1) I use a "wiggle the cursor" technique to get the UI to recognize the building underneath the cursor after I set the cursor position. This feels hacky, though. Is there a better way to do this? I've tried:
- DwarfOverlay:simulateCursorMovement
- DwarfOverlay:selectBuilding
- setting the ui.main.mode to something else then back to QueryBuilding
but nothing else seems to work.

2) Is there currently a way to sleep in a Lua script? I could wire it up through LuaApi if not.

After this PR, the quickfort script can be a reasonable replacement for python quickfort. There are still some advanced features I have yet to support, like construction material labels and blueprint transformations, but all the basic functionality is there. I'm really surprised how productive I can be in Lua!

I need to write some more documentation, especially around file formats. Should I just keep on adding help text to the main quickfort.lua script, or is there a better place to put it?