### PR TITLE
Deprecate unimplemented settings and update quickfort documentation

### DIFF
--- a/internal/quickfort/common.lua
+++ b/internal/quickfort/common.lua
@@ -14,10 +14,11 @@ valid_modes = utils.invert({
     'query'
 })
 
+-- keep deprecated settings in the table so we don't break existing configs
 settings = {
-    blueprints_dir = 'blueprints',
-    force_marker_mode = false,
-    force_interactive_build = false,
+    blueprints_dir={value='blueprints'},
+    force_marker_mode={value=false},
+    force_interactive_build={value=false, deprecated=true},
 }
 
 verbose = false
@@ -32,7 +33,8 @@ end
 
 -- blueprint_name is relative to the blueprints dir
 function get_blueprint_filepath(blueprint_name)
-    return string.format("%s/%s", settings['blueprints_dir'], blueprint_name)
+    return string.format("%s/%s",
+                         settings['blueprints_dir'].value, blueprint_name)
 end
 
 local map_limits = {

--- a/internal/quickfort/dig.lua
+++ b/internal/quickfort/dig.lua
@@ -508,7 +508,8 @@ local function do_run_impl(zlevel, grid)
             log('applying spreadsheet cell %s with text "%s" to map' ..
                 ' coordinates (%d, %d, %d)', cell, text, pos.x, pos.y, pos.z)
             local keys, extent = quickfort_common.parse_cell(text)
-            local marker_mode = quickfort_common.settings['force_marker_mode']
+            local marker_mode =
+                    quickfort_common.settings['force_marker_mode'].value
             if keys:startswith('m') then
                 keys = string.sub(keys, 2)
                 marker_mode = true

--- a/internal/quickfort/list.lua
+++ b/internal/quickfort/list.lua
@@ -97,7 +97,7 @@ function do_list(in_args)
             end
             local start_comment = ''
             if v.modeline.start_comment and #v.modeline.start_comment > 0 then
-                start_comment = string.format('; place cursor: %s',
+                start_comment = string.format('; cursor start: %s',
                                               v.modeline.start_comment)
             end
             print(string.format('%d) "%s" (%s%s%s',

--- a/internal/quickfort/list.lua
+++ b/internal/quickfort/list.lua
@@ -33,7 +33,7 @@ local blueprint_files = {}
 
 local function scan_blueprints()
     local paths = dfhack.filesystem.listdir_recursive(
-        quickfort_common.settings['blueprints_dir'], nil, false)
+        quickfort_common.settings['blueprints_dir'].value, nil, false)
     blueprint_files = {}
     local library_files = {}
     for _, v in ipairs(paths) do

--- a/internal/quickfort/set.lua
+++ b/internal/quickfort/set.lua
@@ -7,15 +7,31 @@ end
 
 local quickfort_common = reqscript('internal/quickfort/common')
 
+local valid_booleans = {
+    ['true']=true,
+    ['1']=true,
+    ['on']=true,
+    ['false']=false,
+    ['0']=false,
+    ['off']=false,
+}
+
 local function set_setting(key, value)
     if quickfort_common.settings[key] == nil then
         qerror(string.format('error: invalid setting: "%s"', key))
     end
-    local val = value
-    if type(quickfort_common.settings[key]) == 'boolean' then
-        val = value == 'true'
+    if type(quickfort_common.settings[key].value) == 'boolean' then
+        if valid_booleans[value] == nil then
+            qerror(string.format('error: invalid boolean: "%s"', value))
+        end
+        value = valid_booleans[value]
+    elseif type(quickfort_common.settings[key].value) == 'number' then
+        if tonumber(value) == nil then
+            qerror(string.format('error: invalid integer: "%s"', value))
+        end
+        value = math.floor(tonumber(value))
     end
-    quickfort_common.settings[key] = val
+    quickfort_common.settings[key].value = value
 end
 
 local function read_config(filename)
@@ -28,18 +44,31 @@ local function read_config(filename)
     end
 end
 
-function do_set(args)
-    if #args == 0 then
-        print('active settings:')
-        printall(quickfort_common.settings)
-        return
+local function print_settings()
+    print('active settings:')
+    local width = 1
+    local settings_arr = {}
+    for k,v in pairs(quickfort_common.settings) do
+        if not v.deprecated then
+            if #k > width then width = #k end
+            table.insert(settings_arr, k)
+        end
     end
+    table.sort(settings_arr)
+    for _, k in ipairs(settings_arr) do
+        print(string.format('  %-'..width..'s = %s',
+                            k, quickfort_common.settings[k].value))
+    end
+end
+
+function do_set(args)
+    if #args == 0 then print_settings() return end
     if #args ~= 2 then
         qerror('error: expected "quickfort set [<key> <value>]"')
     end
     set_setting(args[1], args[2])
     print(string.format('successfully set %s to "%s"',
-                        args[1], quickfort_common.settings[args[1]]))
+                        args[1], quickfort_common.settings[args[1]].value))
 end
 
 function do_reset()

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -21,9 +21,8 @@ real" in Dwarf Fortress, and then export your map using the DFHack
 `blueprint plugin`_ for later replay. Blueprint files should go in the
 ``blueprints`` subfolder in the main DF folder.
 
-You can read more about how to create blueprint files in the
-`blueprints/README.txt`_ file, and there are ready-to-use examples of blueprints
-in each of the four modes in the `blueprints/library`_ folder.
+For more details on blueprint file syntax, look at the ready-to-use examples in
+the `blueprints/library`_ folder.
 
 Usage:
 
@@ -82,14 +81,19 @@ configuration stored in the file:
     will be designated in marker mode.
 
 There are also two other configuration files in the ``dfhack-config/quickfort``
-folder: ``aliases.txt`` and ``materials.txt``. ``aliases.txt`` defines keycode
+folder: `aliases.txt`_ and `materials.txt`_. ``aliases.txt`` defines keycode
 shortcuts for query blueprints, and ``materials.txt`` defines forbidden
 materials and material preferences for build blueprints. The formats for these
-files are described in the files themselves.
+files are described in the files themselves, and default configuration that all
+players can build on is stored in `aliases-common.txt`_ and
+`materials-common.txt`_ in the ``hack/data/quickfort/`` directory.
 
 .. _blueprint plugin: https://docs.dfhack.org/en/stable/docs/Plugins.html#blueprint
-.. _blueprints/README.txt: https://github.com/DFHack/dfhack/tree/develop/data/blueprints/README.txt
 .. _blueprints/library: https://github.com/DFHack/dfhack/tree/develop/data/blueprints/library
+.. _aliases.txt: https://github.com/DFHack/dfhack/tree/develop/dfhack-config/quickfort/aliases.txt
+.. _materials.txt: https://github.com/DFHack/dfhack/tree/develop/dfhack-config/quickfort/materials.txt
+.. _aliases-common.txt: https://github.com/DFHack/dfhack/tree/develop/data/quickfort/aliases-common.txt
+.. _materials-common.txt: https://github.com/DFHack/dfhack/tree/develop/data/quickfort/materials-common.txt
 ]====]
 
 -- reqscript all internal files here, even if they're not directly used by this

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -18,8 +18,8 @@ in cell ``A1``).
 You can create these blueprints by hand or by using any spreadsheet application,
 saving them as ``.xlsx`` or ``.csv`` files. You can also build your plan "for
 real" in Dwarf Fortress, and then export your map using the DFHack
-`blueprint plugin`_ for later replay in a different fort. Blueprint files should
-go in the ``blueprints`` subfolder in the main DF folder.
+`blueprint plugin`_ for later replay. Blueprint files should go in the
+``blueprints`` subfolder in the main DF folder.
 
 You can read more about how to create blueprint files in the
 `blueprints/README.txt`_ file, and there are ready-to-use examples of blueprints
@@ -32,58 +32,54 @@ Usage:
     ``quickfort set`` to show current settings. See the Configuration section
     below for available keys and values.
 **quickfort reset**
-    Resets quickfort script state and re-reads all configuration files.
+    Resets quickfort configuration to the defaults in ``quickfort.txt``.
 **quickfort list [-l|--library]**
     Lists blueprints in the ``blueprints`` folder. Blueprints are ``.csv`` files
     or sheets within ``.xlsx`` files that contain a ``#<mode>`` comment in the
     upper-left cell. By default, blueprints in the ``blueprints/library/``
-    subfolder are not included. Specify ``-l`` to include library blueprints.
+    subfolder are not shown. Specify ``-l`` to include library blueprints.
 **quickfort <command> <list_num> [<options>]**
     Applies the blueprint with the number from the list command.
 **quickfort <command> <filename> [-s|--sheet <sheet_num>] [<options>]**
     Applies the blueprint from the named file. If it is an ``.xlsx`` file,
     the ``-s`` (or ``--sheet``) parameter is required to identify the sheet
-    number (the first sheet is ``-s 1``).
+    number. The first sheet is ``-s 1``.
 
 **<command>** can be one of:
 
-:run:     applies the blueprint at your current active cursor position.
-:orders:  uses the manager interface to queue up orders for the specified
+:run:     Applies the blueprint at your current cursor position. It doesn't
+          matter which mode you are in. You just need an active cursor.
+:orders:  Uses the manager interface to queue up orders for the specified
           build-mode blueprint.
-:undo:    applies the inverse of the specified blueprint, depending on its type.
-          Dig tiles are undesignated, buildings are canceled or removed
-          (depending on their construction status), and stockpiles are removed.
-          No effect for query blueprints.
+:undo:    Applies the inverse of the specified blueprint. Dig tiles are
+          undesignated, buildings are canceled or removed (depending on their
+          construction status), and stockpiles are removed. There is no effect
+          for query blueprints.
 
 **<options>** can be zero or more of:
 
 ``-q``, ``--quiet``
     Don't report on what actions were taken (error messages are still shown).
 ``-v``, ``--verbose``
-    Output extra debugging information.
+    Output extra debugging information. This is especially useful if the
+    blueprint isn't being applied like you expect.
 
 Configuration:
 
 The quickfort script reads its startup configuration from the
 ``dfhack-config/quickfort/quickfort.txt`` file, which you can customize. The
-following settings may be dynamically modified by the ``quickfort set`` command
-(note that settings changed with the ``quickfort set`` command will not change
-the configuration stored in the file):
+following settings may be dynamically modified by the ``quickfort set`` command,
+but settings changed with the ``quickfort set`` command will not change the
+configuration stored in the file:
 
 ``blueprints_dir`` (default: 'blueprints')
-    Can be set to an absolute or relative path. If set to a relative path,
-    resolves to a directory under the DF folder.
+    Directory tree to search for blueprints. Can be set to an absolute or
+    relative path. If set to a relative path, resolves to a directory under the
+    DF folder.
 ``force_marker_mode`` (default: 'false')
     Set to "true" or "false". If true, will designate dig blueprints in marker
-    mode. If false, only cells with dig codes prefixed with ``m`` will be
-    designated in marker mode.
-``force_interactive_build`` (default: 'false')
-    Allows you to manually select building materials for each
-    building/construction when running (or creating orders for) build
-    blueprints. Materials in selection dialogs are ordered according to
-    preferences in ``materials.txt`` (see below). If false, will only prompt for
-    materials that have :labels. See `original Quickfort documentation`_ for
-    details.
+    mode. If false, only cells with dig codes explicitly prefixed with ``m``
+    will be designated in marker mode.
 
 There are also two other configuration files in the ``dfhack-config/quickfort``
 folder: ``aliases.txt`` and ``materials.txt``. ``aliases.txt`` defines keycode
@@ -94,7 +90,6 @@ files are described in the files themselves.
 .. _blueprint plugin: https://docs.dfhack.org/en/stable/docs/Plugins.html#blueprint
 .. _blueprints/README.txt: https://github.com/DFHack/dfhack/tree/develop/data/blueprints/README.txt
 .. _blueprints/library: https://github.com/DFHack/dfhack/tree/develop/data/blueprints/library
-.. _original Quickfort documentation: https://github.com/joelpt/quickfort#manual-material-selection
 ]====]
 
 -- reqscript all internal files here, even if they're not directly used by this
@@ -120,7 +115,7 @@ quickfort set [<key> <value>]
     Allows you to modify the active quickfort configuration. Just run
     "quickfort set" to show current settings.
 quickfort reset
-    Resets quickfort script state and re-reads all configuration files.
+    Resets quickfort configuration to defaults.
 quickfort list [-l|--library]
     Lists blueprints in the "blueprints" folder. Specify -l to include library
     blueprints.
@@ -128,26 +123,29 @@ quickfort <command> <list_num> [<options>]
     Applies the blueprint with the number from the list command.
 quickfort <command> <filename> [-s|--sheet <sheet_num>] [<options>]
     Applies the blueprint from the named file. If it is an .xlsx file, the -s
-    parameter is required to identify the sheet (the first sheet is "-s 1").
+    parameter is required to identify the sheet. The first sheet is "-s 1".
 
 <command> can be one of:
 
-run     applies the blueprint at your current active cursor position.
-orders  uses the manager interface to queue up orders for the specified
+run     Applies the blueprint at your current cursor position. It doesn't matter
+        which mode you are in. You just need an active cursor.
+orders  Uses the manager interface to queue up orders for the specified
         build-mode blueprint.
-undo    applies the inverse of the specified blueprint, depending on its type.
-        Dig tiles are undesignated, buildings are canceled or removed
-        (depending on their construction status), and stockpiles are removed.
-        No effect for query blueprints.
+undo    Applies the inverse of the specified blueprint. Dig tiles are
+        undesignated, buildings are canceled or removed (depending on their
+        construction status), and stockpiles are removed. There is no effect for
+        query blueprints.
 
 <options> can be zero or more of:
 
 -q, --quiet
     Don't report on what actions were taken (error messages are still shown).
 -v, --verbose
-    Output extra debugging information.
+    Output extra debugging information. This is especially useful if the
+    blueprint isn't being applied like you expect.
 
-For more info, see: https://docs.dfhack.org/en/stable/docs/_auto/base.html#quickfort
+For more info, see:
+https://docs.dfhack.org/en/stable/docs/_auto/base.html#quickfort
 ]]
 end
 


### PR DESCRIPTION
DFHack/dfhack#499

- deprecate the force_interactive_build setting since I'm not sure how or when I would implement such a feature, and I don't want the setting to cause confusion
- update the help docs
- handle deprecated settings, type check settings when they are set, and pretty-print the settings list
- clarify the wording in the list output for cursor start comments