### PR TITLE
Fix issues found while playtesting the quickfort script

### DIFF
--- a/internal/quickfort/aliases.lua
+++ b/internal/quickfort/aliases.lua
@@ -8,11 +8,12 @@ end
 local quickfort_common = reqscript('internal/quickfort/common')
 local log = quickfort_common.log
 
--- special key sequences inherited from python quickfort. these cannot be
--- overridden with aliases
+-- special keycode shortcuts inherited from python quickfort.
 local special_keys = {
     ['&']='Enter',
     ['+']='{Shift}',
+    ['!']='{Ctrl}',
+    ['~']='{Alt}',
     ['@']={'{Shift}','Enter'},
     ['^']='ESC',
     ['%']='{Wait}'

--- a/internal/quickfort/aliases.lua
+++ b/internal/quickfort/aliases.lua
@@ -127,7 +127,7 @@ function expand_aliases(text)
     end
     local expanded_text = table.concat(tokens, '')
     if text ~= expanded_text then
-        log('expanded keys to: "%s"', expanded_text)
+        log('expanded keys to: "%s"', table.concat(tokens, ' '))
     end
     return tokens
 end

--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -389,8 +389,8 @@ local building_db = {
         type=df.building_type.Workshop, subtype=df.workshop_type.Custom,
         custom=0},
     wp={label='Screw Press',
-        type=df.building_type.Workshop, subtype=df.workshop_type.Tool,
-        min_width=1, max_width=1, min_height=1, max_height=1},
+        type=df.building_type.Workshop, subtype=df.workshop_type.Custom,
+        custom=1, min_width=1, max_width=1, min_height=1, max_height=1},
     -- furnaces
     ew={label='Wood Furnace',
         type=df.building_type.Furnace, subtype=df.furnace_type.WoodFurnace},

--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -145,6 +145,10 @@ end
 -- ************ post construction fixup functions ************ --
 --
 
+local function post_construction_init_workshop(bld)
+    bld.profile.max_general_orders = 5
+end
+
 local function post_construction_open_gate(bld)
     bld.gate_flags.closed = false
 end
@@ -581,6 +585,9 @@ for _, v in pairs(building_db) do
             v.min_width, v.max_width, v.min_height, v.max_height = 1, 1, 1, 1
         end
     end
+    if v.type == df.building_type.Workshop then
+        v.post_construction_fn = post_construction_init_workshop
+    end
     if v.type == df.building_type.Bridge then
        v.min_width, v.max_width, v.min_height, v.max_height = 1, 10, 1, 10
        v.is_valid_tile_fn = is_valid_tile_has_space
@@ -740,6 +747,7 @@ function do_run(zlevel, grid)
             stats.designated.value = stats.designated.value + 1
         end
     end
+    dfhack.job.checkBuildingsNow()
     return stats
 end
 

--- a/internal/quickfort/building.lua
+++ b/internal/quickfort/building.lua
@@ -117,7 +117,10 @@ local function chunk_extents(data_tables, seen_grid, db)
         local max_height = db[data.type].max_height
         local width = data.x_max - data.x_min + 1
         local height = data.y_max - data.y_min + 1
-        if width <= max_width and height <= max_height then goto continue end
+        if width <= max_width and height <= max_height then
+            table.insert(chunks, data)
+            goto continue
+        end
         local chunk = nil
         local cuts = 0
         for x=data.x_min,data.x_max do

--- a/internal/quickfort/common.lua
+++ b/internal/quickfort/common.lua
@@ -17,8 +17,11 @@ valid_modes = utils.invert({
 -- keep deprecated settings in the table so we don't break existing configs
 settings = {
     blueprints_dir={value='blueprints'},
-    force_marker_mode={value=false},
     force_interactive_build={value=false, deprecated=true},
+    force_marker_mode={value=false},
+    stockpiles_max_barrels={value=-1},
+    stockpiles_max_bins={value=-1},
+    stockpiles_max_wheelbarrows={value=0},
 }
 
 verbose = false

--- a/internal/quickfort/place.lua
+++ b/internal/quickfort/place.lua
@@ -47,22 +47,22 @@ end
 
 local stockpile_db = {
     a={label='Animal', index=0},
-    f={label='Food', index=1},
+    f={label='Food', index=1, want_barrels=true},
     u={label='Furniture', index=2},
-    n={label='Coins', index=7},
+    n={label='Coins', index=7, want_bins=true},
     y={label='Corpses', index=3},
     r={label='Refuse', index=4},
-    s={label='Stone', index=5},
+    s={label='Stone', index=5, want_wheelbarrows=true},
     w={label='Wood', index=13},
-    e={label='Gem', index=9},
-    b={label='Bar/Block', index=8},
-    h={label='Cloth', index=12},
-    l={label='Leather', index=11},
-    z={label='Ammo', index=6},
-    S={label='Sheets', index=16},
-    g={label='Finished Goods', index=10},
-    p={label='Weapons', index=14},
-    d={label='Armor', index=15},
+    e={label='Gem', index=9, want_bins=true},
+    b={label='Bar/Block', index=8, want_bins=true},
+    h={label='Cloth', index=12, want_bins=true},
+    l={label='Leather', index=11, want_bins=true},
+    z={label='Ammo', index=6, want_bins=true},
+    S={label='Sheets', index=16, want_bins=true},
+    g={label='Finished Goods', index=10, want_bins=true},
+    p={label='Weapons', index=14, want_bins=true},
+    d={label='Armor', index=15, want_bins=true},
 }
 for _, v in pairs(stockpile_db) do
     v.has_extents = true
@@ -101,7 +101,7 @@ local function queue_stockpile_settings_init(s, stockpile_query_grid)
         stockpile_query_grid[query_y] = {}
     end
     stockpile_query_grid[query_y][query_x] =
-            {cell='',text=get_stockpile_query_text(s.type)}
+            {cell='generated',text=get_stockpile_query_text(s.type)}
 end
 
 local function create_stockpile(s, stockpile_query_grid)
@@ -110,10 +110,15 @@ local function create_stockpile(s, stockpile_query_grid)
         stockpile_db[s.type].label, s.pos.x, s.pos.y, s.pos.z,
         table.concat(s.cells, ', '))
     local extents, ntiles = quickfort_building.make_extents(s, stockpile_db)
-    local room = {x=s.pos.x, y=s.pos.y, width=s.width, height=s.height}
+    local fields = {room={x=s.pos.x, y=s.pos.y, width=s.width, height=s.height}}
+    if stockpile_db[s.type].want_barrels then fields.max_barrels = ntiles end
+    if stockpile_db[s.type].want_bins then fields.max_bins = ntiles end
+    if stockpile_db[s.type].want_wheelbarrows then
+        fields.max_wheelbarrows = 1
+    end
     local bld, err = dfhack.buildings.constructBuilding{
         type=df.building_type.Stockpile, abstract=true, pos=s.pos,
-        width=s.width, height=s.height, fields={room=room}}
+        width=s.width, height=s.height, fields=fields}
     if not bld then
         if extents then df.delete(extents) end
         -- this is an error instead of a qerror since our validity checking

--- a/internal/quickfort/place.lua
+++ b/internal/quickfort/place.lua
@@ -152,6 +152,7 @@ function do_run(zlevel, grid)
         end
     end
     init_stockpile_settings(zlevel, stockpile_query_grid)
+    dfhack.job.checkBuildingsNow()
     return stats
 end
 

--- a/internal/quickfort/place.lua
+++ b/internal/quickfort/place.lua
@@ -104,6 +104,37 @@ local function queue_stockpile_settings_init(s, stockpile_query_grid)
             {cell='generated',text=get_stockpile_query_text(s.type)}
 end
 
+local function init_containers(db_entry, ntiles, fields)
+    if db_entry.want_barrels then
+        local max_barrels =
+                quickfort_common.settings['stockpiles_max_barrels'].value
+        if max_barrels < 0 or max_barrels >= ntiles then
+            fields.max_barrels = ntiles
+        else
+            fields.max_barrels = max_barrels
+        end
+    end
+    if db_entry.want_bins then
+        local max_bins = quickfort_common.settings['stockpiles_max_bins'].value
+        if max_bins < 0 or max_bins >= ntiles then
+            fields.max_bins = ntiles
+        else
+            fields.max_bins = max_bins
+        end
+    end
+    if db_entry.want_wheelbarrows then
+        local max_wb =
+                quickfort_common.settings['stockpiles_max_wheelbarrows'].value
+        if max_wb < 0 then
+            fields.max_wheelbarrows = 1
+        elseif max_wb >= ntiles then
+            fields.max_wheelbarrows = ntiles
+        else
+            fields.max_wheelbarrows = max_wb
+        end
+    end
+end
+
 local function create_stockpile(s, stockpile_query_grid)
     log('creating %s stockpile at map coordinates (%d, %d, %d), defined' ..
         ' from spreadsheet cells: %s',
@@ -111,11 +142,7 @@ local function create_stockpile(s, stockpile_query_grid)
         table.concat(s.cells, ', '))
     local extents, ntiles = quickfort_building.make_extents(s, stockpile_db)
     local fields = {room={x=s.pos.x, y=s.pos.y, width=s.width, height=s.height}}
-    if stockpile_db[s.type].want_barrels then fields.max_barrels = ntiles end
-    if stockpile_db[s.type].want_bins then fields.max_bins = ntiles end
-    if stockpile_db[s.type].want_wheelbarrows then
-        fields.max_wheelbarrows = 1
-    end
+    init_containers(stockpile_db[s.type], ntiles, fields)
     local bld, err = dfhack.buildings.constructBuilding{
         type=df.building_type.Stockpile, abstract=true, pos=s.pos,
         width=s.width, height=s.height, fields=fields}

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -28,8 +28,8 @@ local function is_queryable_tile(pos)
     return not flags.hidden and occupancy.building ~= 0
 end
 
-local function move_cursor(screen, overlay, pos)
-    overlay:moveCursorTo(pos)
+local function move_cursor(pos)
+    guidm.setCursorPos(pos)
     dfhack.gui.refreshSidebar()
 end
 
@@ -57,8 +57,6 @@ function do_run(zlevel, grid)
     load_aliases()
     local saved_cursor,saved_mode = guidm.getCursorPos(),df.global.ui.main.mode
     df.global.ui.main.mode = df.ui_sidebar_mode.QueryBuilding
-    local map_screen = dfhack.gui.getCurViewscreen(true)
-    local overlay = guidm.DwarfOverlay{}
 
     for y, row in pairs(grid) do
         for x, cell_and_text in pairs(row) do
@@ -74,7 +72,7 @@ function do_run(zlevel, grid)
             log('applying spreadsheet cell %s with text "%s" to map ' ..
                 'coordinates (%d, %d, %d)', cell, text, pos.x, pos.y, pos.z)
             local tokens = quickfort_aliases.expand_aliases(text)
-            move_cursor(map_screen, overlay, pos)
+            move_cursor(pos)
             local focus_string =
                     dfhack.gui.getFocusString(dfhack.gui.getCurViewscreen(true))
             local modifiers = {} -- tracks ctrl, shift, and alt modifiers
@@ -104,7 +102,7 @@ function do_run(zlevel, grid)
     end
 
     df.global.ui.main.mode = saved_mode
-    move_cursor(map_screen, overlay, saved_cursor)
+    move_cursor(saved_cursor)
     return stats
 end
 

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -79,9 +79,7 @@ configuration stored in the file:
     Set to "true" or "false". If true, will designate dig blueprints in marker
     mode. If false, only cells with dig codes explicitly prefixed with ``m``
     will be designated in marker mode.
-``stockpiles_max_barrels`` (default: -1)
-``stockpiles_max_bins`` (default: -1)
-``stockpiles_max_wheelbarrows`` (default: 0)
+``stockpiles_max_barrels``, ``stockpiles_max_bins``, and ``stockpiles_max_wheelbarrows`` (defaults: -1, -1, 0)
     Set to the maximum number of resources you want assigned to stockpiles of
     the relevant types. Set to -1 for DF defaults (number of stockpile tiles
     for stockpiles that take barrels and bins, 1 wheelbarrow for stone

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -21,8 +21,8 @@ real" in Dwarf Fortress, and then export your map using the DFHack
 `blueprint plugin`_ for later replay. Blueprint files should go in the
 ``blueprints`` subfolder in the main DF folder.
 
-For more details on blueprint file syntax, look at the ready-to-use examples in
-the `blueprints/library`_ folder.
+For more details on blueprint file syntax, see the `Blueprints Guidebook`_ or
+browse through the ready-to-use examples in the `blueprints/library`_ folder.
 
 Usage:
 
@@ -95,6 +95,7 @@ players can build on is stored in `aliases-common.txt`_ and
 `materials-common.txt`_ in the ``hack/data/quickfort/`` directory.
 
 .. _blueprint plugin: https://docs.dfhack.org/en/stable/docs/Plugins.html#blueprint
+.. _Blueprints Guidebook: https://github.com/DFHack/dfhack/tree/develop/data/blueprints
 .. _blueprints/library: https://github.com/DFHack/dfhack/tree/develop/data/blueprints/library
 .. _aliases.txt: https://github.com/DFHack/dfhack/tree/develop/dfhack-config/quickfort/aliases.txt
 .. _materials.txt: https://github.com/DFHack/dfhack/tree/develop/dfhack-config/quickfort/materials.txt

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -79,6 +79,14 @@ configuration stored in the file:
     Set to "true" or "false". If true, will designate dig blueprints in marker
     mode. If false, only cells with dig codes explicitly prefixed with ``m``
     will be designated in marker mode.
+``stockpiles_max_barrels`` (default: -1)
+``stockpiles_max_bins`` (default: -1)
+``stockpiles_max_wheelbarrows`` (default: 0)
+    Set to the maximum number of resources you want assigned to stockpiles of
+    the relevant types. Set to -1 for DF defaults (number of stockpile tiles
+    for stockpiles that take barrels and bins, 1 wheelbarrow for stone
+    stockpiles). The default here for wheelbarrows is 0 since using wheelbarrows
+    normally *decreases* the efficiency of your fort.
 
 There are also two other configuration files in the ``dfhack-config/quickfort``
 folder: `aliases.txt`_ and `materials.txt`_. ``aliases.txt`` defines keycode


### PR DESCRIPTION
DFHack/dfhack#499

A hodgepodge of improvements and fixes for problems found while playtesting. Feedback requested for my decision to default stockpile wheelbarrows to 0. Is this controversial? The wiki suggests that wheelbarrows are a net loss for a fort. The player can still change the default in the quickfort.txt config file. The alternative is to default to 1 and require players who want to set it to 0 to use query mode. The problem with that, though, is the interface for setting wheelbarrows in query mode differs based on whether you have the DFHack tweak max-wheelbarrow enabled. And if you do have the tweak enabled, The issue with this, I've found, is that interacting with DFHack input prompts (like the one for setting the number of wheelbarrows) makes query mode unreliable. I'm documenting this in the user guide, but this is also an issue that I'd like to look into someday and fix.

Dig mode:
- allow additional tile shapes that were incorrectly disallowed for channeling
- mark the tile block as designated when we add a designation so the designation job scanner can create jobs for them
- initiate a job scan after designating tiles for dig

Build/Place mode:
- fix db definition for screw press (was miscategorized as a tool instead of a custom workshop)
- initialize max_general_orders when building a workshop so the blueprint-constructed buildings can take manager orders
- initiate a job scan after placing stockpiles/buildings
- rewrite extent splitting code to process too-large extents in arbitrary "chunks" instead of grids. This allows layouts like solid blocks of staggered workshops of the same type or "C"-shaped lines of 1x1 buildings like beds. The old algorithm would force buildings to align to the grid instead of respecting the layout from the blueprint author.
- initialize max containers for stockpiles
- make max stockpile containers configurable and default wheelbarrows to 0

Query mode:
- don't move the viewport in query mode. it happens too fast to see what's going on anyway and just looks like screen jitter.
- add shortcuts for ctrl ('!') and alt ('\~'). '!' for {Ctrl} is from python quickfort (though it was undocumented). '~' for {Alt} is new, but already in use elsewhere to represent alt
- make alias expansion log easier to read by adding spaces between keycodes