### PR TITLE
Quickfort playtesting fixes

### DIFF
--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -300,7 +300,8 @@ local building_db = {
     Mrsssqq=make_roller_entry(df.screw_pump_direction.FromWest, 30000),
     Mrsssqqq=make_roller_entry(df.screw_pump_direction.FromWest, 20000),
     Mrsssqqqq=make_roller_entry(df.screw_pump_direction.FromWest, 10000),
-    I={label='Instrument', type=df.building_type.Instrument},
+    -- Instruments are not yet supported by DFHack
+    --I={label='Instrument', type=df.building_type.Instrument},
     S={label='Support', type=df.building_type.Support,
        is_valid_tile_fn=is_valid_tile_has_space},
     m={label='Animal Trap', type=df.building_type.AnimalTrap},
@@ -308,11 +309,14 @@ local building_db = {
     j={label='Cage', type=df.building_type.Cage},
     A={label='Archery Target', type=df.building_type.ArcheryTarget},
     R={label='Traction Bench', type=df.building_type.TractionBench},
-    N={label='Nest Box', type=df.building_type.NextBox},
+    N={label='Nest Box', type=df.building_type.NestBox},
     ['{Alt}h']={label='Hive', type=df.building_type.Hive},
-    ['{Alt}a']={label='Offering Place', type=df.building_type.OfferingPlace},
-    ['{Alt}c']={label='Bookcase', type=df.building_type.Bookcase},
-    F={label='Display Furniture', type=df.building_type.DisplayFurniture},
+    -- Offering Places, Bookcases, and Display Furniture are not yet supported
+    -- by dfhack
+    --['{Alt}a']={label='Offering Place', type=df.building_type.OfferingPlace},
+    --['{Alt}c']={label='Bookcase', type=df.building_type.Bookcase},
+    --F={label='Display Furniture', type=df.building_type.DisplayFurniture},
+
     -- basic building types with extents
     -- in the UI, these are required to be connected regions, which we could
     -- easily enforce with a flood fill check. However, requiring connected
@@ -694,6 +698,11 @@ local building_aliases = {
     trackrampnew='trackrampNEW',
     trackrampsew='trackrampSEW',
     trackrampnsew='trackrampNSEW',
+    ['~h']='{Alt}h',
+    ['~a']='{Alt}a',
+    ['~c']='{Alt}c',
+    ['~b']='{Alt}b',
+    ['~s']='{Alt}s',
 }
 
 --

--- a/internal/quickfort/common.lua
+++ b/internal/quickfort/common.lua
@@ -84,7 +84,7 @@ end
 -- specified is true when an extent was explicitly specified
 function parse_cell(text)
     local _, _, keys, width, height =
-            string.find(text, '^%s*(.-)%s*%(?%s*(%d*)%s*x?%s*(%d*)%s*%)?$')
+            string.find(text, '^%s*([^(]+)%s*%(?%s*(%d*)%s*x?%s*(%d*)%s*%)?$')
     width = tonumber(width)
     height = tonumber(height)
     local specified = width and height and true

--- a/internal/quickfort/dig.lua
+++ b/internal/quickfort/dig.lua
@@ -214,7 +214,9 @@ local function do_down_stair(ctx)
                 (not is_wall(ctx.tileattrs) and
                  not is_fortification(ctx.tileattrs) and
                  not is_diggable_floor(ctx.tileattrs) and
-                 not is_removable_shape(ctx.tileattrs)) then
+                 not is_removable_shape(ctx.tileattrs) and
+                 not is_gatherable(ctx.tileattrs) and
+                 not is_sapling(ctx.tileattrs)) then
             return false
         end
     end

--- a/internal/quickfort/dig.lua
+++ b/internal/quickfort/dig.lua
@@ -33,6 +33,10 @@ local function is_wall(tileattrs)
     return tileattrs.shape == df.tiletype_shape.WALL
 end
 
+local function is_tree(tileattrs)
+    return tileattrs.material == df.tiletype_material.TREE
+end
+
 local function is_fortification(tileattrs)
     return tileattrs.shape == df.tiletype_shape.FORTIFICATION
 end
@@ -180,6 +184,7 @@ local function do_channel(ctx)
     if ctx.on_map_edge then return false end
     if not ctx.flags.hidden then -- always designate if the tile is hidden
         if is_construction(ctx.tileattrs) or
+                is_tree(ctx.tileattrs) or
                 (not is_wall(ctx.tileattrs) and
                  not is_fortification(ctx.tileattrs) and
                  not is_diggable_floor(ctx.tileattrs) and
@@ -211,6 +216,7 @@ local function do_down_stair(ctx)
     if ctx.on_map_edge then return false end
     if not ctx.flags.hidden then -- always designate if the tile is hidden
         if is_construction(ctx.tileattrs) or
+                is_tree(ctx.tileattrs) or
                 (not is_wall(ctx.tileattrs) and
                  not is_fortification(ctx.tileattrs) and
                  not is_diggable_floor(ctx.tileattrs) and


### PR DESCRIPTION
DFHack/dfhack#499
more fixes for bugs found during playtesting:
- fixed tile validity checking for down stairs and channeling (it wasn't allowing digging through saplings and bushes, but it was incorrectly allowing channeling through tree trunks)
- fixed the parser mistaking key sequences with 'x's in them for the extended area syntax: keys(WxH).