### PR TITLE
use buildingplan to manage plannable buildings for quickfort

### DIFF
--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -17,6 +17,7 @@ if not dfhack_flags.module then
 end
 
 local utils = require('utils')
+local buildingplan = require('plugins.buildingplan')
 local quickfort_common = reqscript('internal/quickfort/common')
 local quickfort_building = reqscript('internal/quickfort/building')
 local log = quickfort_common.log
@@ -710,7 +711,7 @@ local building_aliases = {
 --
 
 local function create_building(b)
-    db_entry = building_db[b.type]
+    local db_entry = building_db[b.type]
     log('creating %dx%d %s at map coordinates (%d, %d, %d), defined from ' ..
         'spreadsheet cells: %s',
         b.width, b.height, db_entry.label, b.pos.x, b.pos.y, b.pos.z,
@@ -735,6 +736,10 @@ local function create_building(b)
     -- constructBuilding deallocates extents, so we have to assign it after
     if use_extents then
         bld.room.extents = quickfort_building.make_extents(b, building_db)
+    end
+    if buildingplan.isPlannableBuilding(db_entry.type) then
+        log('registering with buildingplan')
+        buildingplan.addPlannedBuilding(bld)
     end
     if db_entry.post_construction_fn then db_entry.post_construction_fn(bld) end
 end
@@ -761,6 +766,7 @@ function do_run(zlevel, grid)
             stats.designated.value = stats.designated.value + 1
         end
     end
+    buildingplan.doCycle()
     dfhack.job.checkBuildingsNow()
     return stats
 end


### PR DESCRIPTION
DFHack/dfhack#499

use buildingplan to manage the building types that it handles. Eventually, I'd like to extend buildingplan to handle all building types, but this is much better than nothing.