### PR TITLE
remove references to quickfort being a pre-release

### DIFF
--- a/quickfort.lua
+++ b/quickfort.lua
@@ -1,10 +1,9 @@
--- DFHack-native implementation of the classic Quickfort utility (PRE-RELEASE)
+-- DFHack-native implementation of the classic Quickfort utility
 --[====[
 
 quickfort
 =========
-Processes Quickfort-style blueprint files. This is a pre-release -- not all
-features are implemented yet.
+Processes Quickfort-style blueprint files.
 
 Quickfort blueprints record what you want at each map coordinate in a
 spreadsheet, storing the keys in a spreadsheet cell that you would press to make


### PR DESCRIPTION
let the documentation reflect that quickfort is now feature complete.