### PR TITLE
timestream: The end of FPS death as we know it

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ that repo.
 # Future
 
 ## New Scripts
+- `timestream`: controls the speed of the calendar and creatures
 - `quickfort`: DFHack-native implementation of quickfort with many new features and integrations. See the command reference at https://docs.dfhack.org/en/stable/docs/_auto/base.html#quickfort and the user manual at https://github.com/DFHack/dfhack/tree/develop/data/blueprints#dfhack-quickfort-user-manual
 
 ## Fixes

--- a/timestream.lua
+++ b/timestream.lua
@@ -1,19 +1,13 @@
 -- speeds up the calendar, units, or both
 
 --[====[
-
 timestream
 ==========
 Controls the speed of the calendar and creatures. Fortress mode only. Experimental.
-
 The script is also capable of dynamically speeding up the game based on your current FPS to mitigate the effects of FPS death. See examples below to see how.
-
 Usage::
-
     timestream [-rate R] [-fps FPS] [-units [FLAG]] [-debug]
-
 Examples:
-
 - ``timestream -rate 2``:
     Calendar runs at x2 normal speed, units run at normal speed
 - ``timestream -fps 100``:
@@ -27,9 +21,7 @@ Examples:
 - ``timestream -fps 100 -units 2``:
     Activates a different mode for speeding up units, using the native DF
     ``debug_turbospeed`` flag (similar to `fastdwarf` 2) instead of adjusting
-    timers of all units. It may result in strange unit motion, so it is not
-    the default.
-
+    timers of all units. This results in rubberbanding unit motion, so it is not recommended over the default method.
 Original timestream.lua: https://gist.github.com/IndigoFenix/cf358b8c994caa0f93d5
 ]====]
 
@@ -65,7 +57,7 @@ local prev_time = df.global.enabler.clock
 local ui_main = df.global.ui.main
 local saved_game_frame = -1
 local frames_until_speeding = 0
-local speedy_frame_delta = desired_fps
+local speedy_frame_delta = desired_fps or DEFAULT_MAX_FPS
 
 local SEASON_LEN = 3360
 local YEAR_LEN = 403200
@@ -83,7 +75,9 @@ end
 simulating_desired_fps = true
 if desired_fps == nil then
     desired_fps = DEFAULT_MAX_FPS
-    simulating_desired_fps = false
+    if simulating_units ~= 1 and simulating_units ~= 2 then
+        simulating_desired_fps = false
+    end
 elseif desired_fps < MINIMAL_FPS then
     desired_fps = MINIMAL_FPS
 end

--- a/timestream.lua
+++ b/timestream.lua
@@ -113,8 +113,8 @@ end
 
 function update()
     prev_tick = df.global.cur_year_tick
-    if last_frame + 1 == df.global.world.frame_counter then
-        if rate ~= 1 or simulating_desired_fps then
+    if rate ~= 1 or simulating_desired_fps then
+        if last_frame + 1 == df.global.world.frame_counter then
             timestream = 0
 
             --[[if rate < 1 then
@@ -236,32 +236,83 @@ function update()
                         if dfhack.units.isActive(unit) then
                             for k2, action in pairs(unit.actions) do
                                 if action.type == df.unit_action_type.Move then
-                                    action.data.move.timer = action.data.move.timer - dec
+                                    local d = action.data.move.timer - dec
+                                    if d < 1 then
+                                        d = 1
+                                    end
+                                    action.data.move.timer = d
+                                    
                                 elseif action.type == df.unit_action_type.Attack then
-                                    action.data.attack.timer1 = action.data.attack.timer1 - dec
-                                    action.data.attack.timer2 = action.data.attack.timer2 - dec
+                                    local d = action.data.attack.timer1 - dec
+                                    if d <= 1 then
+                                        d = 1
+                                        action.data.attack.timer2 = 1   -- I don't know why, but if I don't add this line then there's a bug where people just dogpile each other and don't fight.
+                                    end
+                                    d = action.data.attack.timer2 - dec
+                                    if d < 1 then
+                                        d = 1
+                                    end
+                                    action.data.attack.timer2 = d
                                 elseif action.type == df.unit_action_type.HoldTerrain then
-                                    action.data.holdterrain.timer = action.data.holdterrain.timer - dec
+                                    local d = action.data.holdterrain.timer - dec
+                                    if d < 1 then
+                                        d = 1
+                                    end
+                                    action.data.holdterrain.timer = d
                                 elseif action.type == df.unit_action_type.Climb then
-                                    action.data.climb.timer = action.data.climb.timer - dec
+                                    local d = action.data.climb.timer - dec
+                                    if d < 1 then
+                                        d = 1
+                                    end
+                                    action.data.climb.timer = d
                                 elseif action.type == df.unit_action_type.Job then
-                                    action.data.job.timer = action.data.job.timer - dec
+                                    local d = action.data.job.timer - dec
+                                    if d < 1 then
+                                        d = 1
+                                    end
+                                    action.data.job.timer = d
                                 elseif action.type == df.unit_action_type.Talk then
-                                    action.data.talk.timer = action.data.talk.timer - dec
+                                    local d = action.data.talk.timer - dec
+                                    if d < 1 then
+                                        d = 1
+                                    end
+                                    action.data.talk.timer = d
                                 elseif action.type == df.unit_action_type.Unsteady then
-                                    action.data.unsteady.timer = action.data.unsteady.timer - dec
-                                elseif action.type == df.unit_action_type.Dodge then
-                                    action.data.dodge.timer = action.data.doge.timer - dec
+                                    local d = action.data.unsteady.timer - dec
+                                    if d < 1 then
+                                        d = 1
+                                    end
+                                    action.data.unsteady.timer = d
                                 elseif action.type == df.unit_action_type.StandUp then
-                                    action.data.standup.timer = action.data.standup.timer - dec
+                                    local d = action.data.standup.timer - dec
+                                    if d < 1 then
+                                        d = 1
+                                    end
+                                    action.data.standup.timer = d
                                 elseif action.type == df.unit_action_type.LieDown then
-                                    action.data.liedown.timer = action.data.liedown.timer - dec
+                                    local d = action.data.liedown.timer - dec
+                                    if d < 1 then
+                                        d = 1
+                                    end
+                                    action.data.liedown.timer = d
                                 elseif action.type == df.unit_action_type.Job2 then
-                                    action.data.liedown.timer = action.data.liedown.timer - dec
+                                    local d = action.data.job2.timer - dec
+                                    if d < 1 then
+                                        d = 1
+                                    end
+                                    action.data.job2.timer = d
                                 elseif action.type == df.unit_action_type.PushObject then
-                                    action.data.pushobject.timer = action.data.pushobject.timer - dec
+                                    local d = action.data.pushobject.timer - dec
+                                    if d < 1 then
+                                        d = 1
+                                    end
+                                    action.data.pushobject.timer = d
                                 elseif action.type == df.unit_action_type.SuckBlood then
-                                    action.data.suckblood.timer = action.data.suckblood.timer - dec
+                                    local d = action.data.suckblood.timer - dec
+                                    if d < 1 then
+                                        d = 1
+                                    end
+                                    action.data.suckblood.timer = d
                                 end
                             end
                         end
@@ -269,16 +320,16 @@ function update()
                 end
             end
             ticks_left = ticks_left - math.floor(ticks_left) + rate
+            last_frame = df.global.world.frame_counter
+        else
+            if debug_mode then
+                print("last_frame("..last_frame..") + 1 != df.global.world.frame_counter("..df.global.world.frame_counter.."), resetting fps count")
+            end
+            prev_time = df.global.enabler.clock
+            prev_frames = df.global.world.frame_counter
         end
-        last_frame = df.global.world.frame_counter
-    else
-        if debug_mode then
-            print("last_frame("..last_frame..") + 1 != df.global.world.frame_counter("..df.global.world.frame_counter.."), resetting fps count")
-        end
-        prev_time = df.global.enabler.clock
-        prev_frames = df.global.world.frame_counter
+        dfhack.timeout(1,"frames",function() update() end)
     end
-    dfhack.timeout(1,"frames",function() update() end)
 end
 
 --Initial call

--- a/timestream.lua
+++ b/timestream.lua
@@ -1,0 +1,184 @@
+-- Multiplies the speed of calendar time by the specified value.  The parameter can be any positive number, though going over 10 is likely to cause bugs.  1 is normal speed.
+
+args={...}
+local rate=tonumber(args[1])
+local desired_fps = tonumber(args[2])
+local debug_mode = tonumber(args[3])
+
+local prev_tick = 0
+local ticks_left = 0
+local simulating_desired_fps = false
+local prev_frames = df.global.world.frame_counter
+local prev_time = df.global.enabler.clock
+
+if rate == nil then
+	rate = 1
+elseif rate < 0 then
+	rate = 0
+end
+if desired_fps == nil or desired_fps <= 0 then
+    desired_fps = 100
+end
+if debug_mode == nil or debug_mode ~= 1 then
+    debug_mode = false
+else
+    debug_mode = true
+end
+
+eventNow = false
+seasonNow = false
+timestream = 0
+counter = 0
+if df.global.cur_season_tick < 3360 then
+	month = 1
+elseif df.global.cur_season_tick < 6720 then
+	month = 2
+else
+	month = 3
+end
+
+dfhack.onStateChange.loadTimestream = function(code)
+	if code==SC_MAP_LOADED then
+        simulating_desired_fps = false
+		if rate ~= 1 then
+            if rate > 0 then
+                print('Time running at x'..rate..".")
+            else
+                print('Time running dynamically to simulate '..desired_fps..' FPS.')
+                prev_time = df.global.enabler.clock
+                simulating_desired_fps = true
+                prev_frames = df.global.world.frame_counter
+                rate = 1
+            end
+            if debug_mode then
+                print("Debug mode is on.")
+            end
+            ticks_left = rate - 1
+			
+			eventNow = false
+			seasonNow = false
+			timestream = 0
+			if df.global.cur_season_tick < 3360 then
+				month = 1
+			elseif df.global.cur_season_tick < 6720 then
+				month = 2
+			else
+				month = 3
+			end
+			if loaded ~= true then
+				dfhack.timeout(1,"ticks",function() update() end)
+				loaded = true
+			end
+		else
+			print('Time set to normal speed.')
+			loaded = false
+		end
+	elseif code==SC_MAP_UNLOADED then
+	end
+end
+
+function update()
+	prev_tick = df.global.cur_year_tick
+	if rate ~= 1 or simulating_desired_fps then
+		timestream = 0
+		
+		if rate < 1 then
+			if df.global.cur_year_tick - math.floor(df.global.cur_year_tick/10)*10 == 5 then
+				if counter > 1 then
+					counter = counter - 1
+					timestream = -1
+				else
+					counter = counter + math.floor(ticks_left)
+				end
+			end
+		else
+			--counter = counter + rate-1
+            counter = counter + math.floor(ticks_left)
+			while counter >= 10 do
+				counter = counter - 10
+				timestream = timestream + 1
+			end
+		end
+        ticks_left = ticks_left - math.floor(ticks_left)
+		
+		eventFound = false
+		for i=0,#df.global.timed_events-1,1 do
+			event=df.global.timed_events[i]
+			if event.season == df.global.cur_season and event.season_ticks <= df.global.cur_season_tick then
+				if eventNow == false then
+					--df.global.cur_season_tick=event.season_ticks
+					event.season_ticks = df.global.cur_season_tick
+					eventNow = true
+				end
+				eventFound = true
+			end
+		end
+		if eventFound == false then eventNow = false end
+		
+		if df.global.cur_season_tick >= 3359 and df.global.cur_season_tick < 6719 and month == 1 then
+			seasonNow = true
+			month = 2
+			if df.global.cur_season_tick > 3359 then
+				df.global.cur_season_tick = 3360
+			end
+		elseif df.global.cur_season_tick >= 6719 and df.global.cur_season_tick < 10079 and month == 2 then
+			seasonNow = true
+			month = 3
+			if df.global.cur_season_tick > 6719 then
+				df.global.cur_season_tick = 6720
+			end
+		elseif df.global.cur_season_tick >= 10079 then
+			seasonNow = true
+			month = 1
+			if df.global.cur_season_tick > 10080 then
+				df.global.cur_season_tick = 10079
+			end
+		else
+			seasonNow = false
+		end
+		
+		if df.global.cur_year > 0 then
+			if timestream ~= 0 then
+				if df.global.cur_season_tick < 0 then
+					df.global.cur_season_tick = df.global.cur_season_tick + 10080
+					df.global.cur_season = df.global.cur_season-1
+					eventNow = true
+				end
+				if df.global.cur_season < 0 then
+					df.global.cur_season = df.global.cur_season + 4
+					df.global.cur_year_tick = df.global.cur_year_tick + 403200
+					df.global.cur_year = df.global.cur_year - 1
+					eventNow = true
+				end
+				if (eventNow == false and seasonNow == false) or timestream < 0 then
+					if timestream > 0 then
+						df.global.cur_season_tick=df.global.cur_season_tick + timestream
+						remainder = df.global.cur_year_tick - math.floor(df.global.cur_year_tick/10)*10
+						df.global.cur_year_tick=(df.global.cur_season_tick*10)+((df.global.cur_season)*100800) + remainder
+					elseif timestream < 0 then
+						df.global.cur_season_tick=df.global.cur_season_tick
+						df.global.cur_year_tick=(df.global.cur_season_tick*10)+((df.global.cur_season)*100800)
+					end
+				end
+			end
+		end
+        ticks_left = ticks_left + rate
+        if simulating_desired_fps then
+            if df.global.world.frame_counter - prev_frames >= desired_fps then
+                local current_time = df.global.enabler.clock
+                local current_fps = (desired_fps/(current_time - prev_time))*1000
+                rate = desired_fps/current_fps
+                print("current_time: "..current_time..", prev_frames: "..prev_frames..", current_fps: " ..current_fps.. ", current_time - prev_time: "..(current_time - prev_time).. ", rate: "..rate)
+                prev_time = current_time
+                prev_frames = df.global.world.frame_counter
+            end
+        end
+        dfhack.timeout(1,"ticks",function() update() end)
+	end
+end
+
+--Initial call
+
+if dfhack.isMapLoaded() then 
+	dfhack.onStateChange.loadTimestream(SC_MAP_LOADED)
+end

--- a/timestream.lua
+++ b/timestream.lua
@@ -1,18 +1,18 @@
---[[
+-- speeds up the calendar, units, or both
 
-Multiplies the speed of calendar time by the specified value.  The parameter can be any positive number, though going over 10 is likely to cause bugs.  1 is normal speed.
+--[====[
 
-The below is experimental.
-
-Values below 1 will cause the calendar to run at dynamic speeds such that it progresses at the same speed it would were the game being played at a constant frame rate.
-
+timestream
+==========
+Usage:
+:timestream <scalar> <fps> <simulate units y/n>
 Examples:
 
-timestream 2            <- Calendar only will run at x2 speed.
-timestream -1 100       <- Will cause the calendar to run as though the game was being played at 100 FPS.
-timestream -1 100 1     <- Will cause both calendar and creatures to behave as though the game was being played at 100 FPS.
+:timestream     2:          Calendar runs at x2 normal speed
+:timestream    -1 100:      Calendar runs at dynamic speed to simulate 100 FPS
+:timestream    -1 100 1:    Calendar & units are simulated at 100 FPS
 
---]]
+]====]
 
 args={...}
 local rate=tonumber(args[1])

--- a/timestream.lua
+++ b/timestream.lua
@@ -174,8 +174,10 @@ function update()
                 local current_time = df.global.enabler.clock
                 local current_fps = (desired_fps/(current_time - prev_time))*1000
                 rate = desired_fps/current_fps
-                print("current_time: "..current_time..", prev_frames: "..prev_frames..", current_fps: " ..current_fps.. ", current_time - prev_time: "..(current_time - prev_time).. ", rate: "..rate)
-                prev_time = current_time
+		if debug_mode then
+                    print("current_time: "..current_time..", prev_frames: "..prev_frames..", current_fps: " ..current_fps.. ", current_time - prev_time: "..(current_time - prev_time).. ", rate: "..rate)
+                end
+		prev_time = current_time
                 prev_frames = df.global.world.frame_counter
             end
         end

--- a/timestream.lua
+++ b/timestream.lua
@@ -10,15 +10,15 @@ The script is also capable of dynamically speeding up the game based on your cur
 
 Usage::
 
-    timestream <rate> <desired fps> <simulate units 1/0>
+    timestream [-rate R] [-fps FPS] [-units [FLAG]] [-debug]
 
 Examples:
 
-    timestream     2:           Calendar runs at x2 normal speed, units run at normal speed
-    timestream    -1 100:       Calendar runs at dynamic speed to simulate 100 FPS, units normal
-    timestream    -1 100 1:     Calendar & units are simulated at 100 FPS
-    timestream     1:           Resets everything back to normal, regardless of other arguments
-    timestream     1 50 1:      Same as above
+    timestream -rate 2:         Calendar runs at x2 normal speed, units run at normal speed
+    timestream -fps 100:        Calendar runs at dynamic speed to simulate 100 FPS, units normal
+    timestream -fps 100 -units: Calendar & units are simulated at 100 FPS
+    timestream -rate 1:         Resets everything back to normal, regardless of other arguments
+    timestream -rate 1 -fps 50 -units:  Same as above
 
 Original timestream.lua: https://gist.github.com/IndigoFenix/cf358b8c994caa0f93d5
 ]====]
@@ -30,11 +30,20 @@ local DEFAULT_MAX_FPS       = 100
 
 --- DO NOT CHANGE BELOW UNLESS YOU KNOW WHAT YOU'RE DOING ---
 
-args={...}
-local rate=tonumber(args[1])
-local desired_fps = tonumber(args[2])
-local simulating_units = tonumber(args[3])  -- Setting this to 2 instead of 1 will use debug_turbospeed instead of adjusting the timers of all creatures. I don't quite like it because it makes everyone move like insects.
-local debug_mode = tonumber(args[4])
+local utils = require("utils")
+args = utils.processArgs({...}, utils.invert({
+    'rate',
+    'fps',
+    'units',
+    'debug',
+}))
+local rate = tonumber(args.rate) or -1
+local desired_fps = tonumber(args.fps)
+local simulating_units = tonumber(args.units)  -- Setting this to 2 instead of 1 will use debug_turbospeed instead of adjusting the timers of all creatures. I don't quite like it because it makes everyone move like insects.
+if args.units == '' then
+    simulating_units = 1
+end
+local debug_mode = not not args.debug
 
 local current_fps = desired_fps
 local prev_tick = 0
@@ -69,12 +78,6 @@ elseif desired_fps < MINIMAL_FPS then
     desired_fps = MINIMAL_FPS
 end
 current_fps = desired_fps
-
-if debug_mode == nil or debug_mode ~= 1 then
-    debug_mode = false
-else
-    debug_mode = true
-end
 
 eventNow = false
 seasonNow = false

--- a/timestream.lua
+++ b/timestream.lua
@@ -1,34 +1,59 @@
--- Multiplies the speed of calendar time by the specified value.  The parameter can be any positive number, though going over 10 is likely to cause bugs.  1 is normal speed.
+--[[ 
 
---[[ Values below or equal to zero will cause the calendar to run at dynamic speeds such that it progresses at the same speed it would were the game being played at a constant frame rate. Example:
+Multiplies the speed of calendar time by the specified value.  The parameter can be any positive number, though going over 10 is likely to cause bugs.  1 is normal speed.
+
+The below is experimental.
+
+Values below 1 will cause the calendar to run at dynamic speeds such that it progresses at the same speed it would were the game being played at a constant frame rate. Example:
 
 timestream -1 100     <-  Will cause the calendar to run as though the game was being played at 100 FPS.
+timestream -1 100 1   <-  Will cause both calendar and creatures to behave as though the game was being played at 100 FPS, very crudely.
 
 --]]
 
 args={...}
 local rate=tonumber(args[1])
 local desired_fps = tonumber(args[2])
-local debug_mode = tonumber(args[3])
+local simulating_units = tonumber(args[3])
+local debug_mode = tonumber(args[4])
 
+turbo_on = false -- Used to differentiate between external and internal debug_turbospeed
 local prev_tick = 0
 local ticks_left = 0
 local simulating_desired_fps = false
+local minimal_fps = 10 -- This ensures you won't get crazy values on pausing/saving.
 local prev_frames = df.global.world.frame_counter
-local prev_time = df.global.enabler.clock
+local frame_sum = 0
+local avg_fps = desired_fps
+local last_frame_sped_up = 0
+local splicing_threshold = 0.25 -- This controls how generously the script decides to speed up units. Higher values mean that units will be sped up more often than not.
+
+if turbo_on then
+    df.global.debug_turbospeed = false
+    turbo_on = false
+end
 
 if rate == nil then
 	rate = 1
 elseif rate < 0 then
 	rate = 0
 end
+
 if desired_fps == nil or desired_fps <= 0 then
     desired_fps = 100
 end
+avg_fps = desired_fps
+
 if debug_mode == nil or debug_mode ~= 1 then
     debug_mode = false
 else
     debug_mode = true
+end
+
+if simulating_units == 1 then
+    simulating_units = true
+else
+    simulating_units = false
 end
 
 eventNow = false
@@ -47,7 +72,8 @@ dfhack.onStateChange.loadTimestream = function(code)
 	if code==SC_MAP_LOADED then
         simulating_desired_fps = false
 		if rate ~= 1 then
-            if rate > 0 then
+            --if rate > 0 then            -- Won't behave well with unit simulation 
+            if rate > 1 then
                 print('Time running at x'..rate..".")
             else
                 print('Time running dynamically to simulate '..desired_fps..' FPS.')
@@ -55,9 +81,9 @@ dfhack.onStateChange.loadTimestream = function(code)
                 simulating_desired_fps = true
                 prev_frames = df.global.world.frame_counter
                 rate = 1
-            end
-            if debug_mode then
-                print("Debug mode is on.")
+                if simulating_units then
+                    print("Unit simulation is on.")
+                end
             end
             ticks_left = rate - 1
 			
@@ -79,6 +105,9 @@ dfhack.onStateChange.loadTimestream = function(code)
 			print('Time set to normal speed.')
 			loaded = false
 		end
+            if debug_mode then
+            print("Debug mode is on.")
+        end
 	elseif code==SC_MAP_UNLOADED then
 	end
 end
@@ -88,7 +117,7 @@ function update()
 	if rate ~= 1 or simulating_desired_fps then
 		timestream = 0
 		
-		if rate < 1 then
+		--[[if rate < 1 then
 			if df.global.cur_year_tick - math.floor(df.global.cur_year_tick/10)*10 == 5 then
 				if counter > 1 then
 					counter = counter - 1
@@ -98,13 +127,14 @@ function update()
 				end
 			end
 		else
-			--counter = counter + rate-1
-            counter = counter + math.floor(ticks_left)
-			while counter >= 10 do
-				counter = counter - 10
-				timestream = timestream + 1
-			end
-		end
+        --]]
+        --counter = counter + rate-1
+        counter = counter + math.floor(ticks_left)
+        while counter >= 10 do
+            counter = counter - 10
+            timestream = timestream + 1
+        end
+		--end
         ticks_left = ticks_left - math.floor(ticks_left)
 		
 		eventFound = false
@@ -170,15 +200,34 @@ function update()
 		end
         ticks_left = ticks_left + rate
         if simulating_desired_fps then
-            if df.global.world.frame_counter - prev_frames >= desired_fps then
-                local current_time = df.global.enabler.clock
-                local current_fps = (desired_fps/(current_time - prev_time))*1000
-                rate = desired_fps/current_fps
-		if debug_mode then
-                    print("current_time: "..current_time..", prev_frames: "..prev_frames..", current_fps: " ..current_fps.. ", current_time - prev_time: "..(current_time - prev_time).. ", rate: "..rate)
+            local counted_frames = df.global.world.frame_counter - prev_frames
+            frame_sum = frame_sum + df.global.enabler.calculated_fps
+            if counted_frames >= desired_fps then
+                avg_fps = frame_sum/counted_frames
+                if avg_fps <= desired_fps then
+                    rate = desired_fps/avg_fps  -- We don't want to slow down the game
                 end
-		prev_time = current_time
+                if debug_mode then
+                    print("prev_frame: "..prev_frames..", avg_fps: " ..avg_fps.. ", rate: "..rate)
+                end
                 prev_frames = df.global.world.frame_counter
+                frame_sum = 0
+            end
+            if simulating_units and avg_fps > 0 and avg_fps <= desired_fps then  -- God forbid avg_fps is not positive...
+                local missing_frames = desired_fps - avg_fps
+                local speedy_frame_delta = desired_fps/missing_frames
+                local speedy_frame = counted_frames/speedy_frame_delta
+                if speedy_frame - math.floor(speedy_frame) <= splicing_threshold and last_frame_sped_up ~= df.global.world.frame_counter then
+                    if debug_mode then
+                        print("avg_fps: ".. avg_fps .. ", speedy_frame_delta: "..speedy_frame_delta..", speedy_frame: "..counted_frames.."/"..desired_fps)
+                    end
+                    df.global.debug_turbospeed = true
+                    turbo_on = true
+                    last_frame_sped_up = df.global.world.frame_counter
+                else 
+                    df.global.debug_turbospeed = false
+                    turbo_on = false
+                end
             end
         end
         dfhack.timeout(1,"ticks",function() update() end)

--- a/timestream.lua
+++ b/timestream.lua
@@ -1,13 +1,19 @@
 -- speeds up the calendar, units, or both
 
 --[====[
+
 timestream
 ==========
 Controls the speed of the calendar and creatures. Fortress mode only. Experimental.
+
 The script is also capable of dynamically speeding up the game based on your current FPS to mitigate the effects of FPS death. See examples below to see how.
+
 Usage::
+
     timestream [-rate R] [-fps FPS] [-units [FLAG]] [-debug]
+
 Examples:
+
 - ``timestream -rate 2``:
     Calendar runs at x2 normal speed, units run at normal speed
 - ``timestream -fps 100``:
@@ -21,7 +27,9 @@ Examples:
 - ``timestream -fps 100 -units 2``:
     Activates a different mode for speeding up units, using the native DF
     ``debug_turbospeed`` flag (similar to `fastdwarf` 2) instead of adjusting
-    timers of all units. This results in rubberbanding unit motion, so it is not recommended over the default method.
+    timers of all units. This results in rubberbanding unit motion, so it is not
+    recommended over the default method.
+
 Original timestream.lua: https://gist.github.com/IndigoFenix/cf358b8c994caa0f93d5
 ]====]
 

--- a/timestream.lua
+++ b/timestream.lua
@@ -1,5 +1,11 @@
 -- Multiplies the speed of calendar time by the specified value.  The parameter can be any positive number, though going over 10 is likely to cause bugs.  1 is normal speed.
 
+[===[ Values below or equal to zero will cause the calendar to run at dynamic speeds such that it progresses at the same speed it would were the game being played at a constant frame rate. Example:
+
+timestream -1 100     <-  Will cause the calendar to run as though the game was being played at 100 FPS.
+
+]===]
+
 args={...}
 local rate=tonumber(args[1])
 local desired_fps = tonumber(args[2])

--- a/timestream.lua
+++ b/timestream.lua
@@ -24,6 +24,11 @@ Examples:
     Resets everything back to normal, regardless of other arguments
 - ``timestream -rate 1 -fps 50 -units``:
     Same as above
+- ``timestream -fps 100 -units 2``:
+    Activates a different mode for speeding up units, using the native DF
+    ``debug_turbospeed`` flag (similar to `fastdwarf` 2) instead of adjusting
+    timers of all units. It may result in strange unit motion, so it is not
+    the default.
 
 Original timestream.lua: https://gist.github.com/IndigoFenix/cf358b8c994caa0f93d5
 ]====]
@@ -44,7 +49,7 @@ args = utils.processArgs({...}, utils.invert({
 }))
 local rate = tonumber(args.rate) or -1
 local desired_fps = tonumber(args.fps)
-local simulating_units = tonumber(args.units)  -- Setting this to 2 instead of 1 will use debug_turbospeed instead of adjusting the timers of all creatures. I don't quite like it because it makes everyone move like insects.
+local simulating_units = tonumber(args.units)
 if args.units == '' then
     simulating_units = 1
 end

--- a/timestream.lua
+++ b/timestream.lua
@@ -6,9 +6,12 @@ timestream
 ==========
 This only affects fortress mode.
 
-Usage:
-:timestream <scalar> <fps> <simulate units y/n>
+Usage::
+
+    timestream <scalar> <fps> <simulate units y/n>
+
 Examples:
+
 :timestream     2:          Calendar runs at x2 normal speed
 :timestream    -1 100:      Calendar runs at dynamic speed to simulate 100 FPS
 :timestream    -1 100 1:    Calendar & units are simulated at 100 FPS

--- a/timestream.lua
+++ b/timestream.lua
@@ -1,10 +1,10 @@
 -- Multiplies the speed of calendar time by the specified value.  The parameter can be any positive number, though going over 10 is likely to cause bugs.  1 is normal speed.
 
-[===[ Values below or equal to zero will cause the calendar to run at dynamic speeds such that it progresses at the same speed it would were the game being played at a constant frame rate. Example:
+--[[ Values below or equal to zero will cause the calendar to run at dynamic speeds such that it progresses at the same speed it would were the game being played at a constant frame rate. Example:
 
 timestream -1 100     <-  Will cause the calendar to run as though the game was being played at 100 FPS.
 
-]===]
+--]]
 
 args={...}
 local rate=tonumber(args[1])

--- a/timestream.lua
+++ b/timestream.lua
@@ -1,4 +1,4 @@
---[[ 
+--[[
 
 Multiplies the speed of calendar time by the specified value.  The parameter can be any positive number, though going over 10 is likely to cause bugs.  1 is normal speed.
 
@@ -31,9 +31,9 @@ local last_frame_sped_up = 0
 local splicing_threshold = 0.25 -- This controls how generously the script decides to speed up units. Higher values mean that units will be sped up more often than not. This is only for when using debug_turbospeed.
 
 if rate == nil then
-	rate = 1
+    rate = 1
 elseif rate < 0 then
-	rate = 0
+    rate = 0
 end
 
 if desired_fps == nil or desired_fps <= 0 then
@@ -52,18 +52,18 @@ seasonNow = false
 timestream = 0
 counter = 0
 if df.global.cur_season_tick < 3360 then
-	month = 1
+    month = 1
 elseif df.global.cur_season_tick < 6720 then
-	month = 2
+    month = 2
 else
-	month = 3
+    month = 3
 end
 
 dfhack.onStateChange.loadTimestream = function(code)
-	if code==SC_MAP_LOADED then
+    if code==SC_MAP_LOADED then
         simulating_desired_fps = false
-		if rate ~= 1 then
-            --if rate > 0 then            -- Won't behave well with unit simulation 
+        if rate ~= 1 then
+            --if rate > 0 then            -- Won't behave well with unit simulation
             if rate > 1 then
                 print('Time running at x'..rate..".")
             else
@@ -80,48 +80,48 @@ dfhack.onStateChange.loadTimestream = function(code)
                 end
             end
             ticks_left = rate - 1
-			
-			eventNow = false
-			seasonNow = false
-			timestream = 0
-			if df.global.cur_season_tick < 3360 then
-				month = 1
-			elseif df.global.cur_season_tick < 6720 then
-				month = 2
-			else
-				month = 3
-			end
-			if loaded ~= true then
-				dfhack.timeout(1,"ticks",function() update() end)
-				loaded = true
-			end
-		else
-			print('Time set to normal speed.')
-			loaded = false
+
+            eventNow = false
+            seasonNow = false
+            timestream = 0
+            if df.global.cur_season_tick < 3360 then
+                month = 1
+            elseif df.global.cur_season_tick < 6720 then
+                month = 2
+            else
+                month = 3
+            end
+            if loaded ~= true then
+                dfhack.timeout(1,"ticks",function() update() end)
+                loaded = true
+            end
+        else
+            print('Time set to normal speed.')
+            loaded = false
             df.global.debug_turbospeed = false
-		end
+        end
             if debug_mode then
             print("Debug mode is on.")
         end
-	elseif code==SC_MAP_UNLOADED then
-	end
+    elseif code==SC_MAP_UNLOADED then
+    end
 end
 
 function update()
-	prev_tick = df.global.cur_year_tick
-	if rate ~= 1 or simulating_desired_fps then
-		timestream = 0
-		
-		--[[if rate < 1 then
-			if df.global.cur_year_tick - math.floor(df.global.cur_year_tick/10)*10 == 5 then
-				if counter > 1 then
-					counter = counter - 1
-					timestream = -1
-				else
-					counter = counter + math.floor(ticks_left)
-				end
-			end
-		else
+    prev_tick = df.global.cur_year_tick
+    if rate ~= 1 or simulating_desired_fps then
+        timestream = 0
+
+        --[[if rate < 1 then
+            if df.global.cur_year_tick - math.floor(df.global.cur_year_tick/10)*10 == 5 then
+                if counter > 1 then
+                    counter = counter - 1
+                    timestream = -1
+                else
+                    counter = counter + math.floor(ticks_left)
+                end
+            end
+        else
         --]]
         --counter = counter + rate-1
         counter = counter + math.floor(ticks_left)
@@ -129,69 +129,69 @@ function update()
             counter = counter - 10
             timestream = timestream + 1
         end
-		--end
-		eventFound = false
-		for i=0,#df.global.timed_events-1,1 do
-			event=df.global.timed_events[i]
-			if event.season == df.global.cur_season and event.season_ticks <= df.global.cur_season_tick then
-				if eventNow == false then
-					--df.global.cur_season_tick=event.season_ticks
-					event.season_ticks = df.global.cur_season_tick
-					eventNow = true
-				end
-				eventFound = true
-			end
-		end
-		if eventFound == false then eventNow = false end
-		
-		if df.global.cur_season_tick >= 3359 and df.global.cur_season_tick < 6719 and month == 1 then
-			seasonNow = true
-			month = 2
-			if df.global.cur_season_tick > 3359 then
-				df.global.cur_season_tick = 3360
-			end
-		elseif df.global.cur_season_tick >= 6719 and df.global.cur_season_tick < 10079 and month == 2 then
-			seasonNow = true
-			month = 3
-			if df.global.cur_season_tick > 6719 then
-				df.global.cur_season_tick = 6720
-			end
-		elseif df.global.cur_season_tick >= 10079 then
-			seasonNow = true
-			month = 1
-			if df.global.cur_season_tick > 10080 then
-				df.global.cur_season_tick = 10079
-			end
-		else
-			seasonNow = false
-		end
-		
-		if df.global.cur_year > 0 then
-			if timestream ~= 0 then
-				if df.global.cur_season_tick < 0 then
-					df.global.cur_season_tick = df.global.cur_season_tick + 10080
-					df.global.cur_season = df.global.cur_season-1
-					eventNow = true
-				end
-				if df.global.cur_season < 0 then
-					df.global.cur_season = df.global.cur_season + 4
-					df.global.cur_year_tick = df.global.cur_year_tick + 403200
-					df.global.cur_year = df.global.cur_year - 1
-					eventNow = true
-				end
-				if (eventNow == false and seasonNow == false) or timestream < 0 then
-					if timestream > 0 then
-						df.global.cur_season_tick=df.global.cur_season_tick + timestream
-						remainder = df.global.cur_year_tick - math.floor(df.global.cur_year_tick/10)*10
-						df.global.cur_year_tick=(df.global.cur_season_tick*10)+((df.global.cur_season)*100800) + remainder
-					elseif timestream < 0 then
-						df.global.cur_season_tick=df.global.cur_season_tick
-						df.global.cur_year_tick=(df.global.cur_season_tick*10)+((df.global.cur_season)*100800)
-					end
-				end
-			end
-		end
-        
+        --end
+        eventFound = false
+        for i=0,#df.global.timed_events-1,1 do
+            event=df.global.timed_events[i]
+            if event.season == df.global.cur_season and event.season_ticks <= df.global.cur_season_tick then
+                if eventNow == false then
+                    --df.global.cur_season_tick=event.season_ticks
+                    event.season_ticks = df.global.cur_season_tick
+                    eventNow = true
+                end
+                eventFound = true
+            end
+        end
+        if eventFound == false then eventNow = false end
+
+        if df.global.cur_season_tick >= 3359 and df.global.cur_season_tick < 6719 and month == 1 then
+            seasonNow = true
+            month = 2
+            if df.global.cur_season_tick > 3359 then
+                df.global.cur_season_tick = 3360
+            end
+        elseif df.global.cur_season_tick >= 6719 and df.global.cur_season_tick < 10079 and month == 2 then
+            seasonNow = true
+            month = 3
+            if df.global.cur_season_tick > 6719 then
+                df.global.cur_season_tick = 6720
+            end
+        elseif df.global.cur_season_tick >= 10079 then
+            seasonNow = true
+            month = 1
+            if df.global.cur_season_tick > 10080 then
+                df.global.cur_season_tick = 10079
+            end
+        else
+            seasonNow = false
+        end
+
+        if df.global.cur_year > 0 then
+            if timestream ~= 0 then
+                if df.global.cur_season_tick < 0 then
+                    df.global.cur_season_tick = df.global.cur_season_tick + 10080
+                    df.global.cur_season = df.global.cur_season-1
+                    eventNow = true
+                end
+                if df.global.cur_season < 0 then
+                    df.global.cur_season = df.global.cur_season + 4
+                    df.global.cur_year_tick = df.global.cur_year_tick + 403200
+                    df.global.cur_year = df.global.cur_year - 1
+                    eventNow = true
+                end
+                if (eventNow == false and seasonNow == false) or timestream < 0 then
+                    if timestream > 0 then
+                        df.global.cur_season_tick=df.global.cur_season_tick + timestream
+                        remainder = df.global.cur_year_tick - math.floor(df.global.cur_year_tick/10)*10
+                        df.global.cur_year_tick=(df.global.cur_season_tick*10)+((df.global.cur_season)*100800) + remainder
+                    elseif timestream < 0 then
+                        df.global.cur_season_tick=df.global.cur_season_tick
+                        df.global.cur_year_tick=(df.global.cur_season_tick*10)+((df.global.cur_season)*100800)
+                    end
+                end
+            end
+        end
+
         if simulating_desired_fps then
             local counted_frames = df.global.world.frame_counter - prev_frames
             frame_sum = frame_sum + df.global.enabler.calculated_fps
@@ -217,7 +217,7 @@ function update()
                         end
                         df.global.debug_turbospeed = true
                         last_frame_sped_up = df.global.world.frame_counter
-                    else 
+                    else
                         df.global.debug_turbospeed = false
                     end
                 elseif simulating_units == 1 then
@@ -261,11 +261,11 @@ function update()
         end
         ticks_left = ticks_left - math.floor(ticks_left) + rate
         dfhack.timeout(1,"ticks",function() update() end)
-	end
+    end
 end
 
 --Initial call
 
-if dfhack.isMapLoaded() then 
-	dfhack.onStateChange.loadTimestream(SC_MAP_LOADED)
+if dfhack.isMapLoaded() then
+    dfhack.onStateChange.loadTimestream(SC_MAP_LOADED)
 end

--- a/timestream.lua
+++ b/timestream.lua
@@ -14,11 +14,16 @@ Usage::
 
 Examples:
 
-    timestream -rate 2:         Calendar runs at x2 normal speed, units run at normal speed
-    timestream -fps 100:        Calendar runs at dynamic speed to simulate 100 FPS, units normal
-    timestream -fps 100 -units: Calendar & units are simulated at 100 FPS
-    timestream -rate 1:         Resets everything back to normal, regardless of other arguments
-    timestream -rate 1 -fps 50 -units:  Same as above
+- ``timestream -rate 2``:
+    Calendar runs at x2 normal speed, units run at normal speed
+- ``timestream -fps 100``:
+    Calendar runs at dynamic speed to simulate 100 FPS, units normal
+- ``timestream -fps 100 -units``:
+    Calendar & units are simulated at 100 FPS
+- ``timestream -rate 1``:
+    Resets everything back to normal, regardless of other arguments
+- ``timestream -rate 1 -fps 50 -units``:
+    Same as above
 
 Original timestream.lua: https://gist.github.com/IndigoFenix/cf358b8c994caa0f93d5
 ]====]


### PR DESCRIPTION
Proof of concept for https://github.com/DFHack/dfhack/issues/1638.

This is an expansion of [timestream](https://gist.github.com/IndigoFenix/cf358b8c994caa0f93d5). I fixed the idling bug and made it so that all units on the map and the calendar progress at a constant rate **at any given FPS.** This means that no matter if you have 100 FPS or 20 FPS, your gameplay will remain _mostly_ the same.

What I did was speed up action timers and the calendar based on the ratio between the desired FPS and the current FPS. Unlike `fastdwarf` which sets all actions to be instantaneous, this only speeds them up evenly for everyone.

At first I tried a lazy solution by applying the `DEBUG_MEGAFAST` flag on and off during different frames, but that resulted in the dwarves taking short breaks between their zooming about like insects. Nauseating. Speeding up the timers works like magic.

Another thing that this script doesn't do is deal with physics. Things like water flow, bolts, miasma, etc. are still at their normal speed.

Issues so far:
* ~I used the game's own FPS counter to calculate the average FPS, so naturally when you pause the game you're back at max FPS, so it would take a moment for the speed to pick up again, since the script thinks you're at 100 FPS and require no boost.~
* The current implementation is very inefficient. The script loops over all the creatures every tick and manually increments their timers. A vastly better way of doing this would be to either use some sort of callback to when the timers were set or to adjust the increment value that the game uses for the timers.
* Once you get below 10 FPS, there are diminishing returns and you won't get full 100 FPS experience. Although, during a ~300 invader siege my FPS dropped to about 6-7, but it played out as though it was around 30-50. The problem is that at that stage the GUI lag becomes the problem. I believe this is related to the 2nd issue, since if the script was more efficient this limit could be pushed lower.
* ~Speeds up too much during seasonal autosave.~
* Merchant wagons are not sped up so they take a very long time to reach the trade depot in very low FPS situations, which results in them hanging around sometimes for multiple seasons.
* Relationships between dwarves are formed slower since the tick rate remains the same yet time moves faster.
* ~Pregnancies take longer.~
* Crossbows are less effective in combat because ~reloading &~ projectile speed is slower relative to everything else.
* Everyone gets tired faster during combat because the stamina regeneration remains at the same rate, so exhaustion is much more common.

Let it also be known that I am also not very knowledgeable in the technical aspects of the game, so I may have missed things such as more timers or the underlying implications of speeding up the calendar.
