### PR TITLE
quickfort: only use buildingplan if it's enabled

### DIFF
--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -763,7 +763,7 @@ local function create_building(b)
         quickfort_building.assign_extents(
             bld, quickfort_building.make_extents(b, building_db))
     end
-    if buildingplan.isPlannableBuilding(
+    if buildingplan.isEnabled() and buildingplan.isPlannableBuilding(
             db_entry.type, db_entry.subtype or -1, db_entry.custom or -1) then
         log('registering with buildingplan')
         buildingplan.addPlannedBuilding(bld)
@@ -771,12 +771,21 @@ local function create_building(b)
     if db_entry.post_construction_fn then db_entry.post_construction_fn(bld) end
 end
 
+local warning_shown = false
+
 function do_run(zlevel, grid, ctx)
     local stats = ctx.stats
     stats.build_designated = stats.build_designated or
             {label='Buildings designated', value=0, always=true}
     stats.build_unsuitable = stats.build_unsuitable or
             {label='Unsuitable tiles for building', value=0}
+
+    if not warning_shown and not buildingplan.isEnabled() then
+        dfhack.printerr('the buildingplan plugin is not enabled. buildings '
+                        ..'placed with #build blueprints will disappear if you '
+                        ..'do not have required building materials in stock.')
+        warning_shown = true
+    end
 
     local buildings = {}
     stats.invalid_keys.value =


### PR DESCRIPTION
and print a warning message once about the consequences of not having it
enabled. companion PR to DFHack/dfhack#1656