### PR TITLE
Add script to help "unstick" military dwarves' uniform equiping.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ that repo.
 
 ## New Scripts
 - `quickfort`: DFHack-native implementation of quickfort with many new features and integrations. See the command reference at https://docs.dfhack.org/en/stable/docs/_auto/base.html#quickfort and the user manual at https://github.com/DFHack/dfhack/tree/develop/data/blueprints#dfhack-quickfort-user-manual
+- `uniform-unstick`: prompts units to reevaluate their uniform, by removing/dropping potentially conflicting worn items
 
 ## Fixes
 - `ban-cooking`: fixed an error in several subcommands

--- a/uniforce.lua
+++ b/uniforce.lua
@@ -1,0 +1,319 @@
+-- Force units to take on their uniform.
+local help = [====[
+
+uniforce
+========
+
+Prompt units to reevaluate their uniform, by removing/dropping potentially conflicting worn items.
+
+Unlike a "replace clothing" designation, it won't remove additional clothing
+if it's coexisting with a uniform item already on that body part.
+It also won't remove clothing (e.g. shoes, trousers) if the unit has yet to claim an 
+armor item for that bodypart. (e.g. if you're still manufacturing them.)
+
+By default it simply prints info about the currently selected unit,
+to actually drop items, you need to provide it the -drop option.
+
+The default algorithm assumes that there's only one armor item assigned per body part,
+which means that it may miss cases where one piece of armor is blocked but the other
+is present. The -multi option can possibly get around this, but at the cost of ignoring
+left/right distinctions when dropping items.
+
+In no cases should it cause a uniform item to be removed/dropped. 
+
+Targets:
+:(no target) Force the selected dwarf to put on their uniform.
+:-all        Force the uniform on all military dwarves
+
+Options:
+:(none)      Will simply show identified issues (dry-run)
+:-drop       Will cause offending items to be placed on ground under unit
+:-multi      Be more agressive in removing items, best for when uniforms have muliple items per body part
+]====]
+
+local utils = require('utils')
+
+local validArgs = utils.invert({
+  'all',
+  'drop',
+  'multi',
+  'help'
+})
+
+---- Debugging function
+
+local dumper = require('dumper')
+
+function debug_print_light(entry)
+  dfhack.println("----------------")
+  dfhack.println(tostring(entry))
+  for k,v in pairs(entry) do
+    dfhack.println('    '..k)
+  end
+  dfhack.println("----------------")
+end
+
+function debug_print(entry)
+  dfhack.println("----------------")
+  dfhack.println(tostring(entry))
+  for k,v in pairs(entry) do
+    dfhack.println('    '..k..':  '..tostring(v))
+  end
+  dfhack.println("----------------")
+end
+
+function find_item_by_ID(id)
+  for k,v in pairs(df.global.world.items.all) do
+    if v.id == id then
+      return v
+    end
+  end
+  return nil
+end
+
+function print_item_list(vector)
+  for i,v in pairs(vector) do
+    local item = find_item_by_ID(v)
+    dfhack.println(i.."  "..v.."   "..tostring(item).."  "..utils.getItemDescription(item))
+  end
+end
+
+function print_item_list_verbose(vector)
+  for i,v in pairs(vector) do
+    local item = find_item_by_ID(v)
+    debug_print_light(item)
+  end
+end
+
+-- Unused utility functions
+
+function val_in_vector( vector, value )
+  for i,v in pairs(vector) do
+    if v == value then
+      return true
+    end
+  end
+  return false
+end
+
+-- Functions
+
+function get_item_pos(item)
+  local x, y, z = dfhack.items.getPosition(item)
+  if x == nil or y == nil or z == nil then
+    return nil
+  end
+
+  -- TODO: Base this on valid world positions.
+  if not dfhack.maps.isValidTilePos(x,y,z) then
+    dfhack.println("NOT VALID TILE")
+    return nil
+  end
+  if not dfhack.maps.isTileVisible(x,y,z) then
+    dfhack.println("NOT VISIBLE TILE")
+    return nil
+  end
+--  if x < -2000 or y < -2000 or z < -2000 or
+--     x >  2000 or y >  2000 or z >  2000 then
+--     return nil 
+--  end
+  return {x=x, y=y, z=z}
+end
+
+function find_squad_position(unit)
+  for i, squad in pairs( df.global.world.squads.all ) do
+    for i, position in pairs( squad.positions ) do
+      if position.occupant == unit.hist_figure_id then
+        return position
+      end
+    end
+  end
+  return nil
+end
+
+-- This should be okay for dwarves, not sure if valid for others.
+PART_TO_POSITION = {}
+PART_TO_POSITION[ 0]="body"
+PART_TO_POSITION[ 1]="pants"
+PART_TO_POSITION[ 3]="head"
+PART_TO_POSITION[ 8]="gloves" -- also shield and weapon
+PART_TO_POSITION[ 9]="gloves" -- also shield and weapon
+PART_TO_POSITION[14]="shoes"
+PART_TO_POSITION[15]="shoes"
+ 
+-- Convert the unit.inventory.body_part_id to a squad_position.uniform body position
+function body_part_to_body_position(part)
+  return PART_TO_POSITION[ part ]
+end
+
+function process(unit, multi, silent)
+  silent = silent or false
+  local unit_name = dfhack.TranslateName( dfhack.units.getVisibleName(unit) )
+
+  if not silent then 
+    dfhack.println("Processing unit "..unit_name)
+  end
+
+  -- First get squad position for an early-out for non-military dwarves
+  local squad_position = find_squad_position(unit)
+  if squad_position == nil then
+    if not silent then
+      dfhack.println("Unit "..unit_name.." does not have a military uniform.")
+    end
+    return nil
+  end
+
+  -- Find all worn items which may be at issue.
+  local worn_items = {} -- map of item ids to item objects
+  local worn_parts = {} -- map of item ids to body part ids
+  for k, inv_item in pairs(unit.inventory) do
+   local item = inv_item.item
+   if inv_item.mode == 2 or inv_item.mode == 1 or inv_item.mode == 4 then -- mode == 2 is worn, mode == 1 is weapon, mode == 4 is flask
+     worn_items[ item.id ] = item
+     worn_parts[ item.id ] = inv_item.body_part_id
+   end
+  end
+
+--  dfhack.println("====== Worn items for "..unit_name)
+--  debug_print(worn_items)
+--  debug_print(worn_parts)
+
+
+  -- Now get info about which items have been assigned as part of the uniform
+  local assigned_items = {} -- assigned item ids mapped to their armor location
+
+  for loc, specs in pairs( squad_position.uniform ) do -- indexed by armor location
+    for i, spec in pairs(specs) do
+      for i, assigned in pairs( spec.assigned ) do
+        -- Include weapon and shield so we don't drop them later
+      	assigned_items[ assigned ] = loc
+      end
+    end
+  end
+
+--  dfhack.println("====== Assigned items for "..unit_name)
+--  debug_print(assigned_items)
+
+  -- Figure out which assigned items are currently not being worn
+
+  local present_ids = {} -- map of item ID to item object
+  local missing_ids = {} -- map of item ID to armor location
+  local missing_locs = {} -- map of armor locations to true/nil
+  for u_id, loc in pairs(assigned_items) do
+    if worn_items[ u_id ] == nil then
+      dfhack.println("Unit "..unit_name.." is missing an assigned "..loc.." item")
+      missing_ids[ u_id ] = loc
+      missing_locs[ loc ] = true
+    else
+      present_ids[ u_id ] = worn_items[ u_id ]
+    end
+  end
+
+--  dfhack.println("====== Missing items for "..unit_name)
+--  debug_print(missing_ids)
+--  debug_print(missing_locs)
+
+  -- Figure out which worn items should be dropped
+
+  -- First, figure out which body parts are covered by the uniform pieces we have.
+  local covered = {} -- map of body part id to true/nil
+  for id, item in pairs( present_ids ) do
+    local loc = assigned_items[ id ]
+    if loc ~= 'shield' and loc ~= "weapon" then -- shields and weapons don't "cover" the bodypart they're assigned to.
+     covered[ worn_parts[ id ] ] = id
+    end
+  end 
+
+  if multi then
+    covered = {} -- Don't consider current covers - drop for anything which is missing
+  end
+
+--  dfhack.println("====== Uniform-covered body parts for  "..unit_name)
+--  debug_print(covered)
+
+  -- Figure out body parts which should be covered but aren'y
+  local uncovered = {}
+  for part, loc in pairs( PART_TO_POSITION ) do
+    if not covered[ part ] then
+      -- Only mark it "uncovered" if we're nominally supposed to have something there.
+      if missing_locs[ loc ] then
+        uncovered[ part ] = true
+      end
+    end
+  end
+
+--  dfhack.println("====== Uniform-uncovered body parts for  "..unit_name)
+--  debug_print(uncovered)
+
+  local to_drop = {} -- item id to item object
+
+  -- Drop everything (except uniform pieces) from body parts which should be covered but aren't
+  for w_id, item in pairs(worn_items) do
+    if assigned_items[ w_id ] == nil then -- don't drop uniform pieces (including shields, weapons for hands)
+      if uncovered[ worn_parts[ w_id ] ] then
+        dfhack.println("Unit "..unit_name.." potentially has object #"..w_id.." '"..utils.getItemDescription(item).."' blocking their uniform "..PART_TO_POSITION[ worn_parts[ w_id ] ])
+        to_drop[ w_id ] = item
+      end
+    end 
+  end
+
+  return to_drop
+end
+
+
+function do_drop( item_list )
+  if item_list == nil then
+    return nil
+  end
+
+  for id, item in pairs(item_list) do
+    local pos = get_item_pos(item)
+    if pos == nil then
+      dfhack.println("Could not find drop location for item #"..id.."  "..utils.getItemDescription(item))
+    else
+      local retval = dfhack.items.moveToGround( item, pos )
+      if retval == false then
+        dfhack.println("Could not drop object #"..id.."  "..utils.getItemDescription(item))
+      else
+        dfhack.println("Dropped item #"..id.." '"..utils.getItemDescription(item).."'")
+      end
+    end
+  end
+end
+
+
+-- Main
+
+local args = utils.processArgs({...}, validArgs)
+
+if args.help then
+    print(help)
+    return
+end
+
+if args.drop and df.global.ui.main.mode == df.ui_sidebar_mode.ViewUnits then
+  dfhack.println("Error: Cannot actually drop items when view-unit sidebar is open.")
+  return
+end
+
+if args.all then
+  for k,unit in ipairs(df.global.world.units.active) do
+    if dfhack.units.isCitizen(unit) then
+      local to_drop = process(unit,args.multi,true)
+      if args.drop then
+        do_drop( to_drop ) 
+      end
+    end
+  end  
+else
+  local unit=dfhack.gui.getSelectedUnit(true)
+  if df.isvalid(unit) then
+    local to_drop = process(unit,args.multi,false)
+    if args.drop then
+      do_drop( to_drop )
+    end
+  else
+    dfhack.println("No unit is selected")
+  end
+end
+

--- a/uniforce.lua
+++ b/uniforce.lua
@@ -46,53 +46,6 @@ local validArgs = utils.invert({
   'help'
 })
 
----- Debugging function
-
-local dumper = require('dumper')
-
-function debug_print_light(entry)
-  dfhack.println("----------------")
-  dfhack.println(tostring(entry))
-  for k,v in pairs(entry) do
-    dfhack.println('    '..k)
-  end
-  dfhack.println("----------------")
-end
-
-function debug_print(entry)
-  dfhack.println("----------------")
-  dfhack.println(tostring(entry))
-  for k,v in pairs(entry) do
-    dfhack.println('    '..k..':  '..tostring(v))
-  end
-  dfhack.println("----------------")
-end
-
-function print_item_list(vector)
-  for i,v in pairs(vector) do
-    local item = find_item_by_ID(v)
-    dfhack.println(i.."  "..v.."   "..tostring(item).."  "..utils.getItemDescription(item))
-  end
-end
-
-function print_item_list_verbose(vector)
-  for i,v in pairs(vector) do
-    local item = find_item_by_ID(v)
-    debug_print_light(item)
-  end
-end
-
--- Unused utility functions
-
-function val_in_vector( vector, value )
-  for i,v in pairs(vector) do
-    if v == value then
-      return true
-    end
-  end
-  return false
-end
-
 -- Functions
 
 function get_item_pos(item)
@@ -179,11 +132,6 @@ function process(unit, args)
    end
   end
 
---  dfhack.println("====== Worn items for "..unit_name)
---  debug_print(worn_items)
---  debug_print(worn_parts)
-
-
   -- Now get info about which items have been assigned as part of the uniform
   local assigned_items = {} -- assigned item ids mapped to their armor location
 
@@ -195,9 +143,6 @@ function process(unit, args)
       end
     end
   end
-
---  dfhack.println("====== Assigned items for "..unit_name)
---  debug_print(assigned_items)
 
   -- Figure out which assigned items are currently not being worn
 
@@ -219,10 +164,6 @@ function process(unit, args)
     end
   end
 
---  dfhack.println("====== Missing items for "..unit_name)
---  debug_print(missing_ids)
---  debug_print(missing_locs)
-
   -- Figure out which worn items should be dropped
 
   -- First, figure out which body parts are covered by the uniform pieces we have.
@@ -238,9 +179,6 @@ function process(unit, args)
     covered = {} -- Don't consider current covers - drop for anything which is missing
   end
 
---  dfhack.println("====== Uniform-covered body parts for  "..unit_name)
---  debug_print(covered)
-
   -- Figure out body parts which should be covered but aren'y
   local uncovered = {}
   for part, loc in pairs( PART_TO_POSITION ) do
@@ -251,9 +189,6 @@ function process(unit, args)
       end
     end
   end
-
---  dfhack.println("====== Uniform-uncovered body parts for  "..unit_name)
---  debug_print(uncovered)
 
   -- Drop everything (except uniform pieces) from body parts which should be covered but aren't
   for w_id, item in pairs(worn_items) do

--- a/uniforce.lua
+++ b/uniforce.lua
@@ -1,4 +1,4 @@
--- Force units to take on their uniform.
+-- Prompt units to adjust their uniform.
 local help = [====[
 
 uniforce
@@ -22,13 +22,13 @@ left/right distinctions when dropping items.
 In no cases should it cause a uniform item to be removed/dropped. 
 
 Targets:
-:(no target) Force the selected dwarf to put on their uniform.
-:-all        Force the uniform on all military dwarves
+:(no target): Force the selected dwarf to put on their uniform.
+:-all:        Force the uniform on all military dwarves
 
 Options:
-:(none)      Will simply show identified issues (dry-run)
-:-drop       Will cause offending items to be placed on ground under unit
-:-multi      Be more agressive in removing items, best for when uniforms have muliple items per body part
+:(none):      Will simply show identified issues (dry-run)
+:-drop:       Will cause offending items to be placed on ground under unit
+:-multi:      Be more agressive in removing items, best for when uniforms have muliple items per body part
 ]====]
 
 local utils = require('utils')

--- a/uniforce.lua
+++ b/uniforce.lua
@@ -104,7 +104,6 @@ function get_item_pos(item)
     return nil
   end
 
-  -- TODO: Base this on valid world positions.
   if not dfhack.maps.isValidTilePos(x,y,z) then
     dfhack.println("NOT VALID TILE")
     return nil
@@ -113,10 +112,6 @@ function get_item_pos(item)
     dfhack.println("NOT VISIBLE TILE")
     return nil
   end
---  if x < -2000 or y < -2000 or z < -2000 or
---     x >  2000 or y >  2000 or z >  2000 then
---     return nil 
---  end
   return {x=x, y=y, z=z}
 end
 
@@ -146,6 +141,7 @@ function body_part_to_body_position(part)
   return PART_TO_POSITION[ part ]
 end
 
+-- Will figure out which items need to be moved to the floor, returns an item_id:item map
 function process(unit, multi, silent)
   silent = silent or false
   local unit_name = dfhack.TranslateName( dfhack.units.getVisibleName(unit) )

--- a/uniforce.lua
+++ b/uniforce.lua
@@ -151,12 +151,11 @@ function process(unit, args)
   local missing_locs = {} -- map of armor locations to true/nil
   for u_id, loc in pairs(assigned_items) do
     if worn_items[ u_id ] == nil then
-      dfhack.println("Unit "..unit_name.." is missing an assigned "..loc.." item")
+      local item = find_item_by_ID( u_id )
+      dfhack.println("Unit "..unit_name.." is missing an assigned "..loc.." item, object #"..u_id.." '"..utils.getItemDescription(item).."'" )
       missing_ids[ u_id ] = loc
       missing_locs[ loc ] = true
       if args.free then
-        local item = find_item_by_ID( u_id )
-        dfhack.println("The "..loc.." item #"..u_id.." '"..utils.getItemDescription(item).."' needed by "..unit_name.." will be freed.")
         to_drop[ u_id ] = item
       end
     else

--- a/uniforce.lua
+++ b/uniforce.lua
@@ -150,7 +150,7 @@ end
 -- Will figure out which items need to be moved to the floor, returns an item_id:item map
 function process(unit, args)
   silent = args.all -- Don't print details if we're iterating through all dwarves
-  local unit_name = dfhack.TranslateName( dfhack.units.getVisibleName(unit) )
+  local unit_name = dfhack.df2console( dfhack.TranslateName( dfhack.units.getVisibleName(unit) ) )
 
   if not silent then 
     dfhack.println("Processing unit "..unit_name)

--- a/uniforce.lua
+++ b/uniforce.lua
@@ -8,7 +8,7 @@ Prompt units to reevaluate their uniform, by removing/dropping potentially confl
 
 Unlike a "replace clothing" designation, it won't remove additional clothing
 if it's coexisting with a uniform item already on that body part.
-It also won't remove clothing (e.g. shoes, trousers) if the unit has yet to claim an 
+It also won't remove clothing (e.g. shoes, trousers) if the unit has yet to claim an
 armor item for that bodypart. (e.g. if you're still manufacturing them.)
 
 By default it simply prints info about the currently selected unit,
@@ -23,7 +23,7 @@ In some cases, an assigned armor item can't be put on because someone else is we
 The -free option will cause the assigned item to be removed from the container/dwarven inventory
 and placed onto the ground, ready for pickup.
 
-In no cases should the command cause a uniform item that is being properly worn to be removed/dropped. 
+In no cases should the command cause a uniform item that is being properly worn to be removed/dropped.
 
 Targets:
 :(no target): Force the selected dwarf to put on their uniform.
@@ -94,7 +94,7 @@ PART_TO_POSITION[ 8]="gloves" -- also shield and weapon
 PART_TO_POSITION[ 9]="gloves" -- also shield and weapon
 PART_TO_POSITION[14]="shoes"
 PART_TO_POSITION[15]="shoes"
- 
+
 -- Convert the unit.inventory.body_part_id to a squad_position.uniform body position
 function body_part_to_body_position(part)
   return PART_TO_POSITION[ part ]
@@ -105,7 +105,7 @@ function process(unit, args)
   silent = args.all -- Don't print details if we're iterating through all dwarves
   local unit_name = dfhack.df2console( dfhack.TranslateName( dfhack.units.getVisibleName(unit) ) )
 
-  if not silent then 
+  if not silent then
     dfhack.println("Processing unit "..unit_name)
   end
 
@@ -139,7 +139,7 @@ function process(unit, args)
     for i, spec in pairs(specs) do
       for i, assigned in pairs( spec.assigned ) do
         -- Include weapon and shield so we don't drop them later
-      	assigned_items[ assigned ] = loc
+        assigned_items[ assigned ] = loc
       end
     end
   end
@@ -172,7 +172,7 @@ function process(unit, args)
     if loc ~= 'shield' and loc ~= "weapon" then -- shields and weapons don't "cover" the bodypart they're assigned to.
      covered[ worn_parts[ id ] ] = id
     end
-  end 
+  end
 
   if multi then
     covered = {} -- Don't consider current covers - drop for anything which is missing
@@ -194,11 +194,11 @@ function process(unit, args)
     if assigned_items[ w_id ] == nil then -- don't drop uniform pieces (including shields, weapons for hands)
       if uncovered[ worn_parts[ w_id ] ] then
         dfhack.println("Unit "..unit_name.." potentially has object #"..w_id.." '"..utils.getItemDescription(item).."' blocking their uniform "..PART_TO_POSITION[ worn_parts[ w_id ] ])
-        if args.drop then 
+        if args.drop then
           to_drop[ w_id ] = item
         end
       end
-    end 
+    end
   end
 
   return to_drop
@@ -244,9 +244,9 @@ if args.all then
   for k,unit in ipairs(df.global.world.units.active) do
     if dfhack.units.isCitizen(unit) then
       local to_drop = process(unit,args)
-      do_drop( to_drop ) 
+      do_drop( to_drop )
     end
-  end  
+  end
 else
   local unit=dfhack.gui.getSelectedUnit(true)
   if df.isvalid(unit) then

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -62,16 +62,7 @@ function get_item_pos(item)
     print("NOT VISIBLE TILE")
     return nil
   end
-  return {x=x, y=y, z=z}
-end
-
-function find_item_by_ID(id)
-  for k,v in pairs(df.global.world.items.all) do
-    if v.id == id then
-      return v
-    end
-  end
-  return nil
+  return xyz2pos(x, y, z)
 end
 
 function find_squad_position(unit)
@@ -151,7 +142,7 @@ function process(unit, args)
   local missing_locs = {} -- map of armor locations to true/nil
   for u_id, loc in pairs(assigned_items) do
     if worn_items[ u_id ] == nil then
-      local item = find_item_by_ID( u_id )
+      local item = df.item.find( u_id )
       print("Unit "..unit_name.." is missing an assigned "..loc.." item, object #"..u_id.." '"..utils.getItemDescription(item).."'" )
       missing_ids[ u_id ] = loc
       missing_locs[ loc ] = true

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -48,6 +48,10 @@ local validArgs = utils.invert({
 
 -- Functions
 
+function item_description(item)
+  return dfhack.df2console( dfhack.items.getDescription(item, 0, true) )
+end
+
 function get_item_pos(item)
   local x, y, z = dfhack.items.getPosition(item)
   if x == nil or y == nil or z == nil then
@@ -112,7 +116,7 @@ function bodyparts_that_can_wear(unit, item)
       end
     end
   else
-    -- print("Ignoring item type for "..utils.getItemDescription(item) )
+    -- print("Ignoring item type for "..item_description(item) )
   end
 
   return bodyparts
@@ -167,7 +171,7 @@ function process(unit, args)
   local missing_ids = {} -- map of item ID to item object
   for u_id, item in pairs(assigned_items) do
     if worn_items[ u_id ] == nil then
-      print("Unit "..unit_name.." is missing an assigned item, object #"..u_id.." '"..utils.getItemDescription(item).."'" )
+      print("Unit "..unit_name.." is missing an assigned item, object #"..u_id.." '"..item_description(item).."'" )
       missing_ids[ u_id ] = item
       if args.free then
         to_drop[ u_id ] = item
@@ -205,7 +209,7 @@ function process(unit, args)
   for w_id, item in pairs(worn_items) do
     if assigned_items[ w_id ] == nil then -- don't drop uniform pieces (including shields, weapons for hands)
       if uncovered[ worn_parts[ w_id ] ] then
-        print("Unit "..unit_name.." potentially has object #"..w_id.." '"..utils.getItemDescription(item).."' blocking a missing uniform item.")
+        print("Unit "..unit_name.." potentially has object #"..w_id.." '"..item_description(item).."' blocking a missing uniform item.")
         if args.drop then
           to_drop[ w_id ] = item
         end
@@ -231,13 +235,13 @@ function do_drop( item_list )
   for id, item in pairs(item_list) do
     local pos = get_item_pos(item)
     if pos == nil then
-      dfhack.printerr("Could not find drop location for item #"..id.."  "..utils.getItemDescription(item))
+      dfhack.printerr("Could not find drop location for item #"..id.."  "..item_description(item))
     else
       local retval = dfhack.items.moveToGround( item, pos )
       if retval == false then
-        dfhack.printerr("Could not drop object #"..id.."  "..utils.getItemDescription(item))
+        dfhack.printerr("Could not drop object #"..id.."  "..item_description(item))
       else
-        print("Dropped item #"..id.." '"..utils.getItemDescription(item).."'")
+        print("Dropped item #"..id.." '"..utils.item_description(item).."'")
       end
     end
   end

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -237,11 +237,11 @@ function do_drop( item_list )
   for id, item in pairs(item_list) do
     local pos = get_item_pos(item)
     if pos == nil then
-      print("Could not find drop location for item #"..id.."  "..utils.getItemDescription(item))
+      dfhack.printerr("Could not find drop location for item #"..id.."  "..utils.getItemDescription(item))
     else
       local retval = dfhack.items.moveToGround( item, pos )
       if retval == false then
-        print("Could not drop object #"..id.."  "..utils.getItemDescription(item))
+        dfhack.printerr("Could not drop object #"..id.."  "..utils.getItemDescription(item))
       else
         print("Dropped item #"..id.." '"..utils.getItemDescription(item).."'")
       end

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -26,10 +26,12 @@ and placed onto the ground, ready for pickup.
 In no cases should the command cause a uniform item that is being properly worn to be removed/dropped.
 
 Targets:
+
 :(no target): Force the selected dwarf to put on their uniform.
 :-all:        Force the uniform on all military dwarves.
 
 Options:
+
 :(none):      Simply show identified issues (dry-run).
 :-drop:       Cause offending worn items to be placed on ground under unit.
 :-free:       Remove to-equip items from containers or other's inventories, and place on ground.

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -102,7 +102,7 @@ end
 
 -- Will figure out which items need to be moved to the floor, returns an item_id:item map
 function process(unit, args)
-  silent = args.all -- Don't print details if we're iterating through all dwarves
+  local silent = args.all -- Don't print details if we're iterating through all dwarves
   local unit_name = dfhack.df2console( dfhack.TranslateName( dfhack.units.getVisibleName(unit) ) )
 
   if not silent then
@@ -178,7 +178,7 @@ function process(unit, args)
     covered = {} -- Don't consider current covers - drop for anything which is missing
   end
 
-  -- Figure out body parts which should be covered but aren'y
+  -- Figure out body parts which should be covered but aren't
   local uncovered = {}
   for part, loc in pairs( PART_TO_POSITION ) do
     if not covered[ part ] then

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -88,31 +88,31 @@ function bodyparts_that_can_wear(unit, item)
   if item._type == df.item_helmst then
     for index, part in pairs(unitparts) do
       if part.flags.HEAD then
-        bodyparts[#bodyparts+1] = index
+        table.insert(bodyparts, index)
       end
     end
   elseif item._type == df.item_armorst then
     for index, part in pairs(unitparts) do
       if part.flags.UPPERBODY then
-        bodyparts[#bodyparts+1] = index
+        table.insert(bodyparts, index)
       end
     end
   elseif item._type == df.item_glovesst then
     for index, part in pairs(unitparts) do
       if part.flags.GRASP then
-        bodyparts[#bodyparts+1] = index
+        table.insert(bodyparts, index)
       end
     end
   elseif item._type == df.item_pantsst then
     for index, part in pairs(unitparts) do
       if part.flags.LOWERBODY then
-        bodyparts[#bodyparts+1] = index
+        table.insert(bodyparts, index)
       end
     end
   elseif item._type == df.item_shoesst then
     for index, part in pairs(unitparts) do
       if part.flags.STANCE then
-        bodyparts[#bodyparts+1] = index
+        table.insert(bodyparts, index)
       end
     end
   else

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -55,11 +55,11 @@ function get_item_pos(item)
   end
 
   if not dfhack.maps.isValidTilePos(x,y,z) then
-    dfhack.println("NOT VALID TILE")
+    print("NOT VALID TILE")
     return nil
   end
   if not dfhack.maps.isTileVisible(x,y,z) then
-    dfhack.println("NOT VISIBLE TILE")
+    print("NOT VISIBLE TILE")
     return nil
   end
   return {x=x, y=y, z=z}
@@ -106,7 +106,7 @@ function process(unit, args)
   local unit_name = dfhack.df2console( dfhack.TranslateName( dfhack.units.getVisibleName(unit) ) )
 
   if not silent then
-    dfhack.println("Processing unit "..unit_name)
+    print("Processing unit "..unit_name)
   end
 
   -- The return value
@@ -116,7 +116,7 @@ function process(unit, args)
   local squad_position = find_squad_position(unit)
   if squad_position == nil then
     if not silent then
-      dfhack.println("Unit "..unit_name.." does not have a military uniform.")
+      print("Unit "..unit_name.." does not have a military uniform.")
     end
     return nil
   end
@@ -152,7 +152,7 @@ function process(unit, args)
   for u_id, loc in pairs(assigned_items) do
     if worn_items[ u_id ] == nil then
       local item = find_item_by_ID( u_id )
-      dfhack.println("Unit "..unit_name.." is missing an assigned "..loc.." item, object #"..u_id.." '"..utils.getItemDescription(item).."'" )
+      print("Unit "..unit_name.." is missing an assigned "..loc.." item, object #"..u_id.." '"..utils.getItemDescription(item).."'" )
       missing_ids[ u_id ] = loc
       missing_locs[ loc ] = true
       if args.free then
@@ -193,7 +193,7 @@ function process(unit, args)
   for w_id, item in pairs(worn_items) do
     if assigned_items[ w_id ] == nil then -- don't drop uniform pieces (including shields, weapons for hands)
       if uncovered[ worn_parts[ w_id ] ] then
-        dfhack.println("Unit "..unit_name.." potentially has object #"..w_id.." '"..utils.getItemDescription(item).."' blocking their uniform "..PART_TO_POSITION[ worn_parts[ w_id ] ])
+        print("Unit "..unit_name.." potentially has object #"..w_id.." '"..utils.getItemDescription(item).."' blocking their uniform "..PART_TO_POSITION[ worn_parts[ w_id ] ])
         if args.drop then
           to_drop[ w_id ] = item
         end
@@ -213,13 +213,13 @@ function do_drop( item_list )
   for id, item in pairs(item_list) do
     local pos = get_item_pos(item)
     if pos == nil then
-      dfhack.println("Could not find drop location for item #"..id.."  "..utils.getItemDescription(item))
+      print("Could not find drop location for item #"..id.."  "..utils.getItemDescription(item))
     else
       local retval = dfhack.items.moveToGround( item, pos )
       if retval == false then
-        dfhack.println("Could not drop object #"..id.."  "..utils.getItemDescription(item))
+        print("Could not drop object #"..id.."  "..utils.getItemDescription(item))
       else
-        dfhack.println("Dropped item #"..id.." '"..utils.getItemDescription(item).."'")
+        print("Dropped item #"..id.." '"..utils.getItemDescription(item).."'")
       end
     end
   end
@@ -236,7 +236,7 @@ if args.help then
 end
 
 if (args.drop or args.free) and df.global.ui.main.mode == df.ui_sidebar_mode.ViewUnits then
-  dfhack.println("Error: Cannot actually drop/free items when view-unit sidebar is open.")
+  qerror("Error: Cannot actually drop/free items when view-unit sidebar is open.")
   return
 end
 

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -248,12 +248,10 @@ if args.all then
     end
   end
 else
-  local unit=dfhack.gui.getSelectedUnit(true)
-  if df.isvalid(unit) then
+  local unit=dfhack.gui.getSelectedUnit()
+  if unit then
     local to_drop = process(unit,args)
     do_drop( to_drop )
-  else
-    dfhack.println("No unit is selected")
   end
 end
 

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -1,8 +1,8 @@
 -- Prompt units to adjust their uniform.
 local help = [====[
 
-uniforce
-========
+uniform-unstick
+===============
 
 Prompt units to reevaluate their uniform, by removing/dropping potentially conflicting worn items.
 

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -117,7 +117,7 @@ function process(unit, args)
   local worn_parts = {} -- map of item ids to body part ids
   for k, inv_item in pairs(unit.inventory) do
    local item = inv_item.item
-   if inv_item.mode == 2 or inv_item.mode == 1 or inv_item.mode == 4 then -- mode == 2 is worn, mode == 1 is weapon, mode == 4 is flask
+   if inv_item.mode == df.unit_inventory_item.T_mode.Worn or inv_item.mode == df.unit_inventory_item.T_mode.Weapon then -- Include weapons for the check of if we have them.
      worn_items[ item.id ] = item
      worn_parts[ item.id ] = inv_item.body_part_id
    end

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -234,6 +234,12 @@ function do_drop( item_list )
     return nil
   end
 
+  local mode_swap = false
+  if df.global.ui.main.mode == df.ui_sidebar_mode.ViewUnits then
+    df.global.ui.main.mode = df.ui_sidebar_mode.Default
+    mode_swap = true
+  end
+
   for id, item in pairs(item_list) do
     local pos = get_item_pos(item)
     if pos == nil then
@@ -247,6 +253,10 @@ function do_drop( item_list )
       end
     end
   end
+
+  if mode_swap then
+    df.global.ui.main.mode = df.ui_sidebar_mode.ViewUnits
+  end
 end
 
 
@@ -257,11 +267,6 @@ local args = utils.processArgs({...}, validArgs)
 if args.help then
     print(help)
     return
-end
-
-if (args.drop or args.free) and df.global.ui.main.mode == df.ui_sidebar_mode.ViewUnits then
-  qerror("Error: Cannot actually drop/free items when view-unit sidebar is open.")
-  return
 end
 
 if args.all then
@@ -278,4 +283,3 @@ else
     do_drop( to_drop )
   end
 end
-

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -46,18 +46,6 @@ local validArgs = utils.invert({
   'help'
 })
 
-
--- Debugging function
-
-function debug_print(entry)
-  dfhack.println("----------------")
-  dfhack.println(tostring(entry))
-  for k,v in pairs(entry) do
-    dfhack.println('    '..k..':  '..tostring(v))
-  end
-  dfhack.println("----------------")
-end
-
 -- Functions
 
 function get_item_pos(item)

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -241,7 +241,7 @@ function do_drop( item_list )
       if retval == false then
         dfhack.printerr("Could not drop object #"..id.."  "..item_description(item))
       else
-        print("Dropped item #"..id.." '"..utils.item_description(item).."'")
+        print("Dropped item #"..id.." '"..item_description(item).."'")
       end
     end
   end


### PR DESCRIPTION
One of the long-standing issues with military dwarves is that they can often get "stuck" when putting on their uniform, such that they never actually equip their uniform items. This script is an attempt to address that, in a minimally "cheaty" way.

One cause is of the issue is that dwarves are not smart enough to remove a non-uniform piece from a body part to put on their uniform piece. This script can cause dwarves to drop onto the floor all items on a body part which is missing a uniform piece. Another cause is when the assigned item is held by someone or something else, so the script can also force the assigned items to be removed from whatever inventory/container they're currently in and be placed on the floor. The script does not attempt to assign an item if one isn't already (i.e. if the green check is missing from the military equip screen), and only prints info by default.

This script can achieve much the same thing as the "replace clothing" designation, but with the twin benefits that a) it will only cause disrobing for body parts which are missing uniform items (and not ones where uniform and clothing peacefully coexist) and b) it only functions where there is an assigned uniform item, and doesn't force your dwarves to go barefoot until the armorer finishes making high boots.

In my limited testing, the script is successful in prompting dwarves to pick up the needed armor, though it can take a while and several applications if the dwarf is missing many items.

The script is provisionally called "uniforce" (uniform + force), but that reflected mostly the initial rough concept, and may not be the best name for the current approach. Suggestions for a more appropriate name are welcome.

This is my first significant attempt at both Lua scripting and working with DFHack, so please let me know if there's anything I should be doing differently.
