### PR TITLE
always create priority event block

### DIFF
--- a/internal/quickfort/dig.lua
+++ b/internal/quickfort/dig.lua
@@ -535,14 +535,12 @@ local function get_priority_block_square_event(block_events)
 end
 
 -- modifies any existing priority block_square_event to the specified priority.
--- if the block_square_event doesn't already exist, create it iff we're setting
--- the priority to any number but 4 (the default)
+-- if the block_square_event doesn't already exist, create it.
 local function set_priority(ctx, priority)
     log('setting priority to %d', priority)
     local block_events = dfhack.maps.getTileBlock(ctx.pos).block_events
     local pbse = get_priority_block_square_event(block_events)
     if not pbse then
-        if priority == 4 then return end
         block_events:insert('#',
                             {new=df.block_square_event_designation_priorityst})
         pbse = block_events[#block_events-1]


### PR DESCRIPTION
this prevents the case where a blueprint has some priorities specified
but not others, and the default priorities are scanned first. the event
block would not get created for the default priorities, then when the
ones with priority set are scanned, the event block would get created
and initialized to 0. the default priority tiles would then have a
priority of 0, which is invalid.