### PR TITLE
add flag to allow arbitrary query blueprints

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,13 @@ that repo.
 
 # Future
 
+## Fixes
+- `quickfort`: fix handling of modifier keys (e.g. {Ctrl} or {Alt} in query blueprints
+
+## Misc Improvements
+- `quickfort`: add ``query_unsafe`` setting to disable query blueprint error
+checking. useful for query blueprints that send unusual key sequences.
+
 # 0.47.04-r3
 
 ## New Scripts

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,8 +17,7 @@ that repo.
 - `quickfort`: fix handling of modifier keys (e.g. {Ctrl} or {Alt} in query blueprints
 
 ## Misc Improvements
-- `quickfort`: add ``query_unsafe`` setting to disable query blueprint error
-checking. useful for query blueprints that send unusual key sequences.
+- `quickfort`: add ``query_unsafe`` setting to disable query blueprint error checking. useful for query blueprints that send unusual key sequences.
 
 # 0.47.04-r3
 

--- a/internal/quickfort/common.lua
+++ b/internal/quickfort/common.lua
@@ -24,6 +24,7 @@ settings = {
     buildings_use_blocks={value=true},
     force_interactive_build={value=false, deprecated=true},
     force_marker_mode={value=false},
+    query_unsafe={value=false},
     stockpiles_max_barrels={value=-1},
     stockpiles_max_bins={value=-1},
     stockpiles_max_wheelbarrows={value=0},

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -24,19 +24,20 @@ end
 
 local function is_queryable_tile(pos)
     local flags, occupancy = dfhack.maps.getTileFlags(pos)
-    return (not flags.hidden and occupancy.building ~= 0)
-        or dfhack.buildings.findCivzonesAt(pos)
+    return not flags.hidden and
+        (occupancy.building ~= 0 or
+         dfhack.buildings.findCivzonesAt(pos))
 end
 
 local function handle_modifiers(token, modifiers)
     local token_lower = token:lower()
-    if token_lower == '{shift}' or
-            token_lower == '{ctrl}' or
-            token_lower == '{alt}' then
+    if token_lower == 'shift' or
+            token_lower == 'ctrl' or
+            token_lower == 'alt' then
         modifiers[token_lower] = true
         return true
     end
-    if token_lower == '{wait}' then
+    if token_lower == 'wait' then
         print('{Wait} not yet implemented')
         return true
     end
@@ -59,7 +60,8 @@ function do_run(zlevel, grid, ctx)
         for x, cell_and_text in pairs(row) do
             local pos = xyz2pos(x, y, zlevel)
             local cell, text = cell_and_text.cell, cell_and_text.text
-            if not is_queryable_tile(pos) then
+            if not quickfort_common.settings['query_unsafe'].value and
+                    not is_queryable_tile(pos) then
                 print(string.format(
                         'no building at coordinates (%d, %d, %d); skipping ' ..
                         'text in spreadsheet cell %s: "%s"',
@@ -86,7 +88,8 @@ function do_run(zlevel, grid, ctx)
             end
             local new_focus_string =
                     dfhack.gui.getFocusString(dfhack.gui.getCurViewscreen(true))
-            if focus_string ~= new_focus_string then
+            if not quickfort_common.settings['query_unsafe'].value and
+                    focus_string ~= new_focus_string then
                 qerror(string.format(
                     'expected to be back on screen "%s" but screen is "%s"; ' ..
                     'there is likely a problem with the blueprint text in ' ..

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -95,6 +95,14 @@ configuration stored in the file:
     Set to "true" or "false". If true, will designate dig blueprints in marker
     mode. If false, only cells with dig codes explicitly prefixed with ``m``
     will be designated in marker mode.
+``query_unsafe`` (default: 'false')
+    Skip query blueprint sanity checks that detect common blueprint errors and
+    halt or skip keycode playback. Checks include ensuring a configurable
+    building exists at the designated cursor position and verifying the active
+    UI screen is the same before and after sending keys for the cursor
+    position. Temporarily enable this if you are running a query blueprint that
+    sends a key sequence that is *not* related to stockpile or building
+    configuration.
 ``stockpiles_max_barrels``, ``stockpiles_max_bins``, and ``stockpiles_max_wheelbarrows`` (defaults: -1, -1, 0)
     Set to the maximum number of resources you want assigned to stockpiles of
     the relevant types. Set to -1 for DF defaults (number of stockpile tiles


### PR DESCRIPTION
since I'm sure there are some out there that I didn't plan for

this is also useful for testing where I use query blueprints to mimic creating buildings from the UI

quickfort.txt config file modified in DFHack/dfhack#1670