### PR TITLE
[quickfort] Speed up first call to quickfort list

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ that repo.
 - `quickfort`: fix misconfiguration of nest boxes, hives, and slabs that were preventing them from being built from build blueprints
 
 ## Misc Improvements
+- `quickfort`: query blueprint aliases can now accept parameters for dynamic expansion. see dfhack-config/quickfort/aliases.txt for details.
 - `quickfort`: add ``query_unsafe`` setting to disable query blueprint error checking. useful for query blueprints that send unusual key sequences.
 
 # 0.47.04-r3

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ that repo.
 
 ## Misc Improvements
 - `quickfort`: query blueprint aliases can now accept parameters for dynamic expansion. see dfhack-config/quickfort/aliases.txt for details.
+- `quickfort`: speed of first call to ``quickfort list`` is significantly improved, especially for large blueprint libraries
 - `quickfort`: add ``query_unsafe`` setting to disable query blueprint error checking. useful for query blueprints that send unusual key sequences.
 
 # 0.47.04-r3

--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -444,8 +444,14 @@ local function get_params(etoken, start)
     -- alphanumerics
     local name, pos = get_next_param(etoken, start)
     while name do
-        local val, next_param_start =
-                get_next_csv_token(etoken, pos, no_next_line, ' ')
+        local val, next_param_start = nil, nil
+        if etoken:sub(pos, pos) == '{' then
+            _, next_param_start, val = etoken:find('(%b{})', pos)
+            next_param_start = next_param_start + 1
+        else
+            val, next_param_start =
+                    get_next_csv_token(etoken, pos, no_next_line, ' ')
+        end
         if not val then
             qerror(string.format(
                     'invalid extended token param: "%s"', etoken:sub(pos)))
@@ -474,9 +480,9 @@ end
 -- params are in one of the following formats:
 --   param_name=param_val
 --   param_name="param val with spaces"
---   param_name={extended_token}
--- or any combination of the above:
---   param_name=literal" portion with spaces {somealias}"{anotheralias var=aa}
+--   param_name={token params repetitions}
+-- or any combination of the above (note the .csv-style doubled double quotes):
+--   param_name="literal with spaces {somealias var=""with spaces"" 5}"
 -- if repetitions is not specified, the value 1 is returned
 -- returns token as string, params as map, repetitions as number, start position
 -- of the next element after the etoken in text

--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -481,11 +481,17 @@ end
 --   param_name=param_val
 --   param_name="param val with spaces"
 --   param_name={token params repetitions}
--- or any combination of the above (note the .csv-style doubled double quotes):
---   param_name="literal with spaces {somealias var=""with spaces"" 5}"
+-- if the params within the extended token within the params require quotes,
+-- .csv-style doubled double quotes are required:
+--   param_name="{somealias var=""with spaces"" 5}"
+-- combining literals with extended tokens is not currently supported to keep
+-- the implementation simple, though we can add it if there is demand. That is,
+-- the following is not supported: param_name=literal{somealias}. The
+-- workaround is just to put the literal in a regularly-defined alias and call
+-- that alias.
 -- if repetitions is not specified, the value 1 is returned
 -- returns token as string, params as map, repetitions as number, start position
--- of the next element after the etoken in text
+-- of the next element after the etoken in text as number
 function parse_extended_token(text, startpos)
     startpos = startpos or 1
     local etoken = get_extended_token(text, startpos)


### PR DESCRIPTION
This PR can be reviewed after #209 is merged.

On the first call to `quickfort list`, quickfort has to scan all the blueprints in the `blueprints/` directory tree to discover and cache the blueprint modelines. If the player's blueprint library is large, this can take a while.

This change significantly improves the performance of the first call to `quickfort list`. For the Starter Pack's blueprint corpus on my system (plus a few copies of dreamfort that I was testing), latency was reduced from 2.5 seconds to 0.5 seconds.