### PR TITLE
[quickfort] deprecate buildings_use_blocks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ that repo.
 
 ## Misc Improvements
 - `quickfort`: add ``query_unsafe`` setting to disable query blueprint error checking. useful for query blueprints that send unusual key sequences.
+- `quickfort`: remove ``buildings_use_blocks`` setting and replace it with more flexible functionality in `buildingplan`
 
 # 0.47.04-r3
 

--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -247,7 +247,7 @@ local building_db = {
     h={label='Container', type=df.building_type.Box},
     r={label='Weapon Rack', type=df.building_type.Weaponrack},
     s={label='Statue', type=df.building_type.Statue},
-    ['{Alt}s']={label='Slab', type=df.building_type.Slab, skip_vector_id=true},
+    ['{Alt}s']={label='Slab', type=df.building_type.Slab},
     t={label='Table', type=df.building_type.Table},
     g={label='Bridge (Retracting)', type=df.building_type.Bridge,
        direction=df.building_bridgest.T_direction.Retracting},
@@ -320,14 +320,11 @@ local building_db = {
     A={label='Archery Target', type=df.building_type.ArcheryTarget},
     R={label='Traction Bench', type=df.building_type.TractionBench,
        additional_orders={'table', 'mechanisms', 'cloth rope'}},
-    N={label='Nest Box', type=df.building_type.NestBox, skip_vector_id=true},
-    ['{Alt}h']={label='Hive', type=df.building_type.Hive, skip_vector_id=true},
-    ['{Alt}a']={label='Offering Place', type=df.building_type.OfferingPlace,
-        skip_vector_id=true},
-    ['{Alt}c']={label='Bookcase', type=df.building_type.Bookcase,
-        skip_vector_id=true},
-    F={label='Display Furniture', type=df.building_type.DisplayFurniture,
-        skip_vector_id=true},
+    N={label='Nest Box', type=df.building_type.NestBox},
+    ['{Alt}h']={label='Hive', type=df.building_type.Hive},
+    ['{Alt}a']={label='Offering Place', type=df.building_type.OfferingPlace},
+    ['{Alt}c']={label='Bookcase', type=df.building_type.Bookcase},
+    F={label='Display Furniture', type=df.building_type.DisplayFurniture},
 
     -- basic building types with extents
     -- in the UI, these are required to be connected regions, which we could
@@ -737,26 +734,10 @@ local function create_building(b)
     if use_extents then
         fields.room = {x=b.pos.x, y=b.pos.y, width=b.width, height=b.height}
     end
-    local filters = nil
-    if quickfort_common.settings['buildings_use_blocks'].value then
-        -- don't set the vector_id for custom buildings since it will get
-        -- applied to *all* their filters, not just the "generic building
-        -- material" ones.
-        local vector_id = nil
-        -- remove skip_vector_id when we move block preferences to buildingplan
-        if not db_entry.custom and not db_entry.skip_vector_id then
-            vector_id = df.job_item_vector_id.BLOCKS
-        end
-        local filter_mod = {
-            material={item_type=df.item_type.BLOCKS, vector_id=vector_id}
-        }
-        filters = dfhack.buildings.getFiltersByType(
-            filter_mod, db_entry.type, db_entry.subtype, db_entry.custom)
-    end
     local bld, err = dfhack.buildings.constructBuilding{
         type=db_entry.type, subtype=db_entry.subtype, custom=db_entry.custom,
         pos=b.pos, width=b.width, height=b.height, direction=db_entry.direction,
-        filters=filters, fields=fields}
+        fields=fields}
     if not bld then
         -- this is an error instead of a qerror since our validity checking
         -- is supposed to prevent this from ever happening

--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -310,8 +310,8 @@ local building_db = {
     Mrsssqq=make_roller_entry(df.screw_pump_direction.FromWest, 30000),
     Mrsssqqq=make_roller_entry(df.screw_pump_direction.FromWest, 20000),
     Mrsssqqqq=make_roller_entry(df.screw_pump_direction.FromWest, 10000),
-    -- Instruments are not yet supported by DFHack
-    --I={label='Instrument', type=df.building_type.Instrument},
+    I={label='Instrument', type=df.building_type.Instrument,
+       skip_vector_id=true},
     S={label='Support', type=df.building_type.Support,
        is_valid_tile_fn=is_valid_tile_has_space},
     m={label='Animal Trap', type=df.building_type.AnimalTrap},
@@ -322,11 +322,12 @@ local building_db = {
        additional_orders={'table', 'mechanisms', 'cloth rope'}},
     N={label='Nest Box', type=df.building_type.NestBox, skip_vector_id=true},
     ['{Alt}h']={label='Hive', type=df.building_type.Hive, skip_vector_id=true},
-    -- Offering Places, Bookcases, and Display Furniture are not yet supported
-    -- by dfhack
-    --['{Alt}a']={label='Offering Place', type=df.building_type.OfferingPlace},
-    --['{Alt}c']={label='Bookcase', type=df.building_type.Bookcase},
-    --F={label='Display Furniture', type=df.building_type.DisplayFurniture},
+    ['{Alt}a']={label='Offering Place', type=df.building_type.OfferingPlace,
+        skip_vector_id=true},
+    ['{Alt}c']={label='Bookcase', type=df.building_type.Bookcase,
+        skip_vector_id=true},
+    F={label='Display Furniture', type=df.building_type.DisplayFurniture,
+        skip_vector_id=true},
 
     -- basic building types with extents
     -- in the UI, these are required to be connected regions, which we could

--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -310,8 +310,8 @@ local building_db = {
     Mrsssqq=make_roller_entry(df.screw_pump_direction.FromWest, 30000),
     Mrsssqqq=make_roller_entry(df.screw_pump_direction.FromWest, 20000),
     Mrsssqqqq=make_roller_entry(df.screw_pump_direction.FromWest, 10000),
-    I={label='Instrument', type=df.building_type.Instrument,
-       skip_vector_id=true},
+    -- Instruments are not yet supported by DFHack
+    -- I={label='Instrument', type=df.building_type.Instrument},
     S={label='Support', type=df.building_type.Support,
        is_valid_tile_fn=is_valid_tile_has_space},
     m={label='Animal Trap', type=df.building_type.AnimalTrap},

--- a/internal/quickfort/common.lua
+++ b/internal/quickfort/common.lua
@@ -21,7 +21,7 @@ valid_modes = utils.invert({
 -- keep deprecated settings in the table so we don't break existing configs
 settings = {
     blueprints_dir={value='blueprints'},
-    buildings_use_blocks={value=true},
+    buildings_use_blocks={value=false, deprecated=true},
     force_interactive_build={value=false, deprecated=true},
     force_marker_mode={value=false},
     query_unsafe={value=false},

--- a/internal/quickfort/orders.lua
+++ b/internal/quickfort/orders.lua
@@ -65,7 +65,13 @@ local function process_filter(order_specs, filter, reactions)
             label = 'blocks'
         else label = 'blocks' end
     elseif filter.item_type == df.item_type.TOOL then
-        label = 'rock ' .. df.tool_uses[filter.has_tool_use]:lower()
+        label = df.tool_uses[filter.has_tool_use]:lower()
+        if filter.has_tool_use == df.tool_uses.PLACE_OFFERING then
+            label = 'altar'
+        elseif filter.has_tool_use == df.tool_uses.DISPLAY_OBJECT then
+            label = 'display case'
+        end
+        label = 'rock ' .. label
     elseif filter.item_type == df.item_type.ANIMALTRAP then
         label = 'animal trap'
     elseif filter.item_type == df.item_type.ARMORSTAND then

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -85,16 +85,13 @@ configuration stored in the file:
 ``blueprints_dir`` (default: 'blueprints')
     Directory tree to search for blueprints. Can be set to an absolute or
     relative path. If set to a relative path, resolves to a directory under the
-    DF folder.
-``buildings_use_blocks`` (default: 'true')
-    Force all blueprint buildings that could be built with any building material
-    to only use blocks. The prevents logs, boulders, and bars (e.g. potash and
-    coal) from being wasted on constructions. If set to false, buildings will be
-    built with any available building material.
+    DF folder. Note that if you change this directory, you will not see
+    blueprints written by the DFHack `blueprint` plugin (which always writes to
+    the ``blueprints`` dir).
 ``force_marker_mode`` (default: 'false')
-    Set to "true" or "false". If true, will designate dig blueprints in marker
-    mode. If false, only cells with dig codes explicitly prefixed with ``m``
-    will be designated in marker mode.
+    Set to "true" or "false". If true, will designate all dig blueprints in
+    marker mode. If false, only cells with dig codes explicitly prefixed with
+    ``m`` will be designated in marker mode.
 ``query_unsafe`` (default: 'false')
     Skip query blueprint sanity checks that detect common blueprint errors and
     halt or skip keycode playback. Checks include ensuring a configurable


### PR DESCRIPTION
Depends on changes in DFHack/dfhack#1684

This PR can be reviewed after #212 is merged.

migrate buildings_use_blocks to buildingplan; buildingplan can do it much better