### PR TITLE
[quickfort] display missing blueprint labels in dialog list output

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ that repo.
 - `quickfort`: fix handling of modifier keys (e.g. {Ctrl} or {Alt} in query blueprints
 - `quickfort`: fix misconfiguration of nest boxes, hives, and slabs that were preventing them from being built from build blueprints
 - `quickfort`: fix valid placement detection for floor hatches, floor grates, and floor bars (they were erroneously being rejected from open spaces and staircase tops)
+- `quickfort`: display missing blueprint labels in gui dialog list
 
 ## Misc Improvements
 - `devel/export-dt-ini`: updated for Dwarf Therapist 41.2.0

--- a/internal/quickfort/dialog.lua
+++ b/internal/quickfort/dialog.lua
@@ -9,6 +9,7 @@ local dialogs = require('gui.dialogs')
 local guidm = require('gui.dwarfmode')
 local quickfort_command = reqscript('internal/quickfort/command')
 local quickfort_list = reqscript('internal/quickfort/list')
+local quickfort_parse = reqscript('internal/quickfort/parse')
 
 -- must be at least enough to display all help text on the main dialog
 local min_dialog_width = 73
@@ -112,8 +113,15 @@ function BlueprintDialog:refresh()
         if v.start_comment then
             start_comment = string.format(' cursor start: %s', v.start_comment)
         end
-        local text = string.format('%d) %s (%s)%s\n    %s',
-                v.id, v.path, v.mode, start_comment, v.comment or '')
+        local sheet_spec = ''
+        if v.section_name then
+            sheet_spec = string.format(
+                    ' -n %s',
+                    quickfort_parse.quote_if_has_spaces(v.section_name))
+        end
+        local text = string.format('%d) %s%s (%s)%s\n    %s',
+                v.id, quickfort_parse.quote_if_has_spaces(v.path), sheet_spec,
+                v.mode, start_comment, v.comment or '')
         local truncated_text =
                 truncate(text, self.frame_body.width, self.row_height)
         table.insert(choices,

--- a/internal/quickfort/list.lua
+++ b/internal/quickfort/list.lua
@@ -182,7 +182,9 @@ function do_list(in_args)
         end
         local sheet_spec = ''
         if v.section_name then
-            sheet_spec = string.format(' -n "%s"', v.section_name)
+            sheet_spec = string.format(
+                    ' -n %s',
+                    quickfort_parse.quote_if_has_spaces(v.section_name))
         end
         local comment = ')'
         if v.comment then comment = string.format(': %s)', v.comment) end
@@ -191,8 +193,9 @@ function do_list(in_args)
             start_comment = string.format('; cursor start: %s', v.start_comment)
         end
         print(string.format(
-                '%d) "%s"%s (%s%s%s',
-                v.id, v.path, sheet_spec, v.mode, comment, start_comment))
+                '%d) %s%s (%s%s%s', v.id,
+                quickfort_parse.quote_if_has_spaces(v.path),
+                sheet_spec, v.mode, comment, start_comment))
         ::continue::
     end
     if num_filtered > 0 then

--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -8,6 +8,11 @@ end
 local xlsxreader = require('plugins.xlsxreader')
 local quickfort_common = reqscript('internal/quickfort/common')
 
+function quote_if_has_spaces(str)
+    if str:find(' ') then return '"' .. str .. '"' end
+    return str
+end
+
 local function trim_token(token)
     _, _, token = token:find('^%s*(.-)%s*$')
     return token


### PR DESCRIPTION
and only quote strings if they contain spaces. We only have 80 columns or so and we need to scrounge space.