### PR TITLE
[quickfort] fix query blueprint statistics being added to the wrong metric

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ that repo.
 - `quickfort`: fix handling of modifier keys (e.g. {Ctrl} or {Alt} in query blueprints
 - `quickfort`: fix misconfiguration of nest boxes, hives, and slabs that were preventing them from being built from build blueprints
 - `quickfort`: fix valid placement detection for floor hatches, floor grates, and floor bars (they were erroneously being rejected from open spaces and staircase tops)
+- `quickfort`: fix query blueprint statistics being added to the wrong metric when both a query and a zone blueprint are run by the same meta blueprint
 
 ## Misc Improvements
 - `devel/export-dt-ini`: updated for Dwarf Therapist 41.2.0

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -46,9 +46,9 @@ end
 
 function do_run(zlevel, grid, ctx)
     local stats = ctx.stats
-    stats.query_keystrokes = stats.zone_designated or
+    stats.query_keystrokes = stats.query_keystrokes or
             {label='Keystrokes sent', value=0, always=true}
-    stats.query_tiles = stats.zone_tiles or
+    stats.query_tiles = stats.query_tiles or
             {label='Tiles modified', value=0}
 
     load_aliases()


### PR DESCRIPTION
fix query blueprint statistics being added to the wrong metric when both a query and a zone blueprint are run by the same meta blueprint