### PR TITLE
Update script to handle a "fresh" unit with no adaptation suffered yet.

### DIFF
--- a/adaptation.rb
+++ b/adaptation.rb
@@ -64,15 +64,12 @@ set_adaptation_value = lambda { |u,v|
     next if u.flags2.killed
     u.status.misc_traits.each { |t|
         if t.id == :CaveAdapt
-            # TBD: expose the color_ostream console and color values of
-            # t.value based on adaptation level
             if mode == 'show'
                 if df.respond_to?(:print_color)
-                    print "Unit #{u.id} (#{u.name}) has an adaptation of "
+                    df.print_color(COLOR_WHITE, "Unit #{u.id} (#{u.name}) has an adaptation of ")
                     case t.value
                     when 0..399999
-                        #df.print_color(COLOR_GREEN, "#{t.value}\n")
-                        print "#{t.value}\n"
+                        df.print_color(COLOR_GREEN, "#{t.value}\n")
                     when 400000..599999
                         df.print_color(COLOR_YELLOW, "#{t.value}\n")
                     else
@@ -86,8 +83,22 @@ set_adaptation_value = lambda { |u,v|
                 t.value = v
                 num_set += 1
             end
+            return
         end
     }
+
+    # If we arrive here, no `CaveAdapt` trait has been found, so we'll add it if needed.
+    if mode == 'show'
+        df.print_color(COLOR_WHITE, "Unit #{u.id} (#{u.name}) has an adaptation of ")
+        df.print_color(COLOR_GREEN, "0\n")
+    elsif mode == 'set'
+        new_trait = DFHack::UnitMiscTrait.cpp_new
+        new_trait.id = :CaveAdapt
+        new_trait.value = v
+        num_set += 1
+        u.status.misc_traits.push(new_trait)
+        puts "Unit #{u.id} (#{u.name}) changed from 0 to #{v}"
+    end
 }
 
 case who

--- a/adaptation.rb
+++ b/adaptation.rb
@@ -15,10 +15,10 @@ The ``value`` must be between 0 and 800,000 (inclusive).
 =end
 
 # Color constants, values mapped to color_value enum in include/ColorText.h
+COLOR_RESET = -1
 COLOR_GREEN  = 2
 COLOR_RED    = 4
 COLOR_YELLOW = 14
-COLOR_WHITE  = 15
 
 def usage(s)
     if nil != s
@@ -66,7 +66,7 @@ set_adaptation_value = lambda { |u,v|
         if t.id == :CaveAdapt
             if mode == 'show'
                 if df.respond_to?(:print_color)
-                    df.print_color(COLOR_WHITE, "Unit #{u.id} (#{u.name}) has an adaptation of ")
+                    df.print_color(COLOR_RESET, "Unit #{u.id} (#{u.name}) has an adaptation of ")
                     case t.value
                     when 0..399999
                         df.print_color(COLOR_GREEN, "#{t.value}\n")
@@ -89,7 +89,7 @@ set_adaptation_value = lambda { |u,v|
 
     # If we arrive here, no `CaveAdapt` trait has been found, so we'll add it if needed.
     if mode == 'show'
-        df.print_color(COLOR_WHITE, "Unit #{u.id} (#{u.name}) has an adaptation of ")
+        df.print_color(COLOR_RESET, "Unit #{u.id} (#{u.name}) has an adaptation of ")
         df.print_color(COLOR_GREEN, "0\n")
     elsif mode == 'set'
         new_trait = DFHack::UnitMiscTrait.cpp_new

--- a/adaptation.rb
+++ b/adaptation.rb
@@ -62,6 +62,7 @@ num_set = 0
 set_adaptation_value = lambda { |u,v|
     next if !df.unit_iscitizen(u)
     next if u.flags2.killed
+    trait_found = false
     u.status.misc_traits.each { |t|
         if t.id == :CaveAdapt
             if mode == 'show'
@@ -83,21 +84,23 @@ set_adaptation_value = lambda { |u,v|
                 t.value = v
                 num_set += 1
             end
-            return
+            #return  # Doesn't work on Ruby 1.8
+            trait_found = true
         end
     }
 
-    # If we arrive here, no `CaveAdapt` trait has been found, so we'll add it if needed.
-    if mode == 'show'
-        df.print_color(COLOR_RESET, "Unit #{u.id} (#{u.name}) has an adaptation of ")
-        df.print_color(COLOR_GREEN, "0\n")
-    elsif mode == 'set'
-        new_trait = DFHack::UnitMiscTrait.cpp_new
-        new_trait.id = :CaveAdapt
-        new_trait.value = v
-        num_set += 1
-        u.status.misc_traits.push(new_trait)
-        puts "Unit #{u.id} (#{u.name}) changed from 0 to #{v}"
+    if !trait_found
+        if mode == 'show'
+            df.print_color(COLOR_RESET, "Unit #{u.id} (#{u.name}) has an adaptation of ")
+            df.print_color(COLOR_GREEN, "0\n")
+        elsif mode == 'set'
+            new_trait = DFHack::UnitMiscTrait.cpp_new
+            new_trait.id = :CaveAdapt
+            new_trait.value = v
+            num_set += 1
+            u.status.misc_traits.push(new_trait)
+            puts "Unit #{u.id} (#{u.name}) changed from 0 to #{v}"
+        end
     end
 }
 


### PR DESCRIPTION
I don't know if modifying others' scripts is considered impolite, if so I apologize. Feel free to disregard this PR.

I added some code to handle the case where the trait "CaveAdapt" does not exist: before my addition the script would have simply ignored the case (I think), while now it can add a new cave adaptation trait to the unit.
Also, "print" statements were being ignored, so I changed those too.