### PR TITLE
Assert df.unit type using the specific is_instance check.

### DIFF
--- a/assign-attributes.lua
+++ b/assign-attributes.lua
@@ -139,7 +139,7 @@ end
 ---   :reset: boolean, or nil.
 function assign(attributes, unit, reset)
     assert(not attributes or type(attributes) == "table")
-    assert(not unit or type(unit) == "number" or type(unit) == "userdata")
+    assert(not unit or type(unit) == "number" or df.unit:is_instance(unit))
     assert(not reset or type(reset) == "boolean")
 
     attributes = attributes or {}

--- a/assign-beliefs.lua
+++ b/assign-beliefs.lua
@@ -94,7 +94,7 @@ end
 ---   :reset: boolean, or nil.
 function assign(beliefs, unit, reset)
     assert(not beliefs or type(beliefs) == "table")
-    assert(not unit or type(unit) == "number" or type(unit) == "userdata")
+    assert(not unit or type(unit) == "number" or df.unit:is_instance(unit))
     assert(not reset or type(reset) == "boolean")
 
     beliefs = beliefs or {}

--- a/assign-facets.lua
+++ b/assign-facets.lua
@@ -91,7 +91,7 @@ end
 ---   :reset: boolean, or nil.
 function assign(facets, unit, reset)
     assert(not facets or type(facets) == "table")
-    assert(not unit or type(unit) == "number" or type(unit) == "userdata")
+    assert(not unit or type(unit) == "number" or df.unit:is_instance(unit))
     assert(not reset or type(reset) == "boolean")
 
     facets = facets or {}

--- a/assign-goals.lua
+++ b/assign-goals.lua
@@ -75,7 +75,7 @@ end
 ---   :reset: boolean, or nil.
 function assign(goals, unit, reset)
     assert(not goals or type(goals) == "table")
-    assert(not unit or type(unit) == "number" or type(unit) == "userdata")
+    assert(not unit or type(unit) == "number" or df.unit:is_instance(unit))
     assert(not reset or type(reset) == "boolean")
 
     goals = goals or {}

--- a/assign-preferences.lua
+++ b/assign-preferences.lua
@@ -583,7 +583,7 @@ local preference_functions = {
 ---   :reset: boolean, or nil.
 function assign(preferences, unit, reset)
     assert(not preferences or type(preferences) == "table")
-    assert(not unit or type(unit) == "number" or type(unit) == "userdata")
+    assert(not unit or type(unit) == "number" or df.unit:is_instance(unit))
     assert(not reset or type(reset) == "boolean")
 
     local preferences = preferences or {} --as:string[][]

--- a/assign-skills.lua
+++ b/assign-skills.lua
@@ -91,7 +91,7 @@ end
 ---   :reset: boolean, or nil.
 function assign(skills, unit, reset)
     assert(not skills or type(skills) == "table")
-    assert(not unit or type(unit) == "number" or type(unit) == "userdata")
+    assert(not unit or type(unit) == "number" or df.unit:is_instance(unit))
     assert(not reset or type(reset) == "boolean")
 
     skills = skills or {}


### PR DESCRIPTION
As the title says: given a "unit" passed as an argument to the `assign` function of each of these scripts, use `df.unit:is_instance(unit)` instead of `type(unit) == "userdata"` to assert its type.