### PR TITLE
Fix typo in docs examples.

### DIFF
--- a/assign-preferences.lua
+++ b/assign-preferences.lua
@@ -154,7 +154,7 @@ Examples:
 
 * "likes alabaster and willow wood"::
 
-    assign-preferences -reset -likematerial [ INORGANIC:OBSIDAN PLANT:WILLOW:WOOD ]
+    assign-preferences -reset -likematerial [ INORGANIC:ALABASTER PLANT:WILLOW:WOOD ]
 
 * "likes sparrows for their ..."::
 


### PR DESCRIPTION
The console command example was setting `OBISIDIAN` (actually, "OBSIDAN", so two errors in one word) while the text result was showing `likes alabaster`. Now it's all set to `ALABASTER`.

Yep, that's all.