### PR TITLE
[quickfort] parse new alias characters in extended tokens

### DIFF
--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -437,7 +437,7 @@ local function no_next_line()
 end
 
 local function get_next_param(etoken, start)
-    local _, pos, name = etoken:find('^(%w[%w]+)=.', start)
+    local _, pos, name = etoken:find('%s*([%w-_][%w-_]+)=.', start)
     return name, pos
 end
 

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -79,7 +79,8 @@ function do_run(zlevel, grid, ctx)
                 if handle_modifiers(token, modifiers) then goto continue end
                 local kcodes = quickfort_keycodes.get_keycodes(token, modifiers)
                 if not kcodes then
-                    qerror(string.format('unknown key: "%s"', token))
+                    qerror(string.format(
+                            'unknown alias or keycode: "%s"', token))
                 end
                 gui.simulateInput(dfhack.gui.getCurViewscreen(true), kcodes)
                 modifiers = {}


### PR DESCRIPTION
and clarify the "alias not defined" error message