### PR TITLE
[quickfort] gui dialog fixes

### DIFF
--- a/internal/quickfort/dialog.lua
+++ b/internal/quickfort/dialog.lua
@@ -207,7 +207,7 @@ local function dialog_command(command, text)
 end
 
 function do_dialog()
-    if blueprint_dialog then qerror('Quickfort gui dialog already open') end
+    if blueprint_dialog then blueprint_dialog:dismiss() end
     blueprint_dialog = BlueprintDialog{
         frame_title='Select quickfort blueprint',
         with_filter=true,


### PR DESCRIPTION
- prevent two instances of the dialog from being opened at the same time
This can happen easily if you just run `quickfort gui` twice. One dialog will appear on top of the other and they must be dismissed separately. This is a particular problem when you try to run a query blueprint with a second dialog open, since that dialog will snarf all the keystrokes.

- prevent the details page from being opened or 'orders' from triggering if there is no list item selected
This can happen if the user puts in a search filter that doesn't match anything, then hits the right arrow key or alt-o