### PR TITLE
[quickfort] remove 'extents' hack

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@ that repo.
 - `quickfort`: fix valid placement detection for floor hatches, floor grates, and floor bars (they were erroneously being rejected from open spaces and staircase tops)
 - `quickfort`: fix query blueprint statistics being added to the wrong metric when both a query and a zone blueprint are run by the same meta blueprint
 - `quickfort`: display missing blueprint labels in gui dialog list
+- `quickfort`: fix occupancy settings for extent-based structures so that stockpiles can be placed within other stockpiles (e.g. in a checkerboard or bullseye pattern)
 - `unsuspend`: now leaves buildingplan-managed buildings alone and doesn't unsuspend underwater tasks
 
 ## Misc Improvements

--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -734,7 +734,8 @@ local function create_building(b)
     local use_extents = db_entry.has_extents and
             not (db_entry.no_extents_if_solid and is_extent_solid(b))
     if use_extents then
-        fields.room = {x=b.pos.x, y=b.pos.y, width=b.width, height=b.height}
+        fields.room = {x=b.pos.x, y=b.pos.y, width=b.width, height=b.height,
+                       extents=quickfort_building.make_extents(b)}
     end
     local bld, err = dfhack.buildings.constructBuilding{
         type=db_entry.type, subtype=db_entry.subtype, custom=db_entry.custom,
@@ -744,10 +745,6 @@ local function create_building(b)
         -- this is an error instead of a qerror since our validity checking
         -- is supposed to prevent this from ever happening
         error(string.format('unable to place %s: %s', db_entry.label, err))
-    end
-    if use_extents then
-        quickfort_building.assign_extents(
-            bld, quickfort_building.make_extents(b, building_db))
     end
     if buildingplan.isEnabled() and buildingplan.isPlannableBuilding(
             db_entry.type, db_entry.subtype or -1, db_entry.custom or -1) then

--- a/internal/quickfort/building.lua
+++ b/internal/quickfort/building.lua
@@ -364,7 +364,7 @@ end
 -- allocate and initialize extents structure from the extents_grid
 -- returns extents, num_tiles
 -- we assume by this point that the extent is valid and non-empty
-function make_extents(b, db)
+function make_extents(b)
     local area = b.width * b.height
     local extents = df.reinterpret_cast(df.building_extents_type,
         df.new('uint8_t', area))
@@ -372,17 +372,9 @@ function make_extents(b, db)
     for i=1,area do
         local extent_x = (i-1) % b.width + 1
         local extent_y = math.floor((i-1) / b.width) + 1
-        local is_in_stockpile = b.extent_grid[extent_x][extent_y]
-        extents[i-1] = is_in_stockpile and 1 or 0
-        if is_in_stockpile then num_tiles = num_tiles + 1 end
+        local is_in_extent = b.extent_grid[extent_x][extent_y]
+        extents[i-1] = is_in_extent and 1 or 0
+        if is_in_extent then num_tiles = num_tiles + 1 end
     end
     return extents, num_tiles
-end
-
--- ensures we don't leak memory by overwriting extents
--- constructBuilding deallocates any extents we pass in, so we have to assign it
--- after the building is created
-function assign_extents(bld, extents)
-    if bld.room.extents then df.delete(bld.room.extents) end
-    bld.room.extents = extents
 end

--- a/internal/quickfort/place.lua
+++ b/internal/quickfort/place.lua
@@ -171,19 +171,18 @@ local function create_stockpile(s, stockpile_query_grid)
     log('creating %s stockpile at map coordinates (%d, %d, %d), defined' ..
         ' from spreadsheet cells: %s',
         db_entry.label, s.pos.x, s.pos.y, s.pos.z, table.concat(s.cells, ', '))
-    local extents, ntiles = quickfort_building.make_extents(s, stockpile_db)
-    local fields = {room={x=s.pos.x, y=s.pos.y, width=s.width, height=s.height}}
+    local extents, ntiles = quickfort_building.make_extents(s)
+    local fields = {room={x=s.pos.x, y=s.pos.y, width=s.width, height=s.height,
+                          extents=extents}}
     init_containers(db_entry, ntiles, fields)
     local bld, err = dfhack.buildings.constructBuilding{
         type=df.building_type.Stockpile, abstract=true, pos=s.pos,
         width=s.width, height=s.height, fields=fields}
     if not bld then
-        if extents then df.delete(extents) end
         -- this is an error instead of a qerror since our validity checking
         -- is supposed to prevent this from ever happening
         error(string.format('unable to place stockpile: %s', err))
     end
-    quickfort_building.assign_extents(bld, extents)
     queue_stockpile_settings_init(s, db_entry, stockpile_query_grid)
     return ntiles
 end

--- a/internal/quickfort/zone.lua
+++ b/internal/quickfort/zone.lua
@@ -178,8 +178,10 @@ local function create_zone(zone)
         ' from spreadsheet cells: %s',
         db_entry.label, zone.pos.x, zone.pos.y, zone.pos.z,
         table.concat(zone.cells, ', '))
-    local fields = {room={x=zone.pos.x, y=zone.pos.y,
-                          width=zone.width, height=zone.height},
+    local extents, ntiles =
+            quickfort_building.make_extents(zone)
+    local fields = {room={x=zone.pos.x, y=zone.pos.y, width=zone.width,
+                          height=zone.height, extents=extents},
                     is_room=true}
     local bld, err = dfhack.buildings.constructBuilding{
         type=df.building_type.Civzone, subtype=df.civzone_type.ActivityZone,
@@ -190,8 +192,6 @@ local function create_zone(zone)
         -- is supposed to prevent this from ever happening
         error(string.format('unable to designate zone: %s', err))
     end
-    local extents, ntiles = quickfort_building.make_extents(zone, zone_db)
-    quickfort_building.assign_extents(bld, extents)
     -- set defaults (should move into constructBuilding)
     bld.gather_flags.pick_trees = true
     bld.gather_flags.pick_shrubs = true


### PR DESCRIPTION
now that Buildings::setSize doesn't unconditionally deallocate existing extents.

This fixes the issue where non-rectangular extent-based buildings had occupancy incorrectly set in non-extent tiles.

Builds on (and requires) DFHack/dfhack#1729