### PR TITLE
workorder-recheck - set work order to Checking

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,9 @@ that repo.
 
 # Future
 
+## New Scripts
+- `gui/workorder-recheck`: resets the selected work order to the `Checking` state
+
 # 0.47.04-r4
 
 ## New Scripts

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,7 +14,7 @@ that repo.
 # Future
 
 ## New Scripts
-- `gui/workorder-recheck`: resets the selected work order to the ``Checking`` state
+- `workorder-recheck`: resets the selected work order to the ``Checking`` state
 
 # 0.47.04-r4
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,7 +14,7 @@ that repo.
 # Future
 
 ## New Scripts
-- `gui/workorder-recheck`: resets the selected work order to the `Checking` state
+- `gui/workorder-recheck`: resets the selected work order to the ``Checking`` state
 
 # 0.47.04-r4
 

--- a/gui/workorder-recheck.lua
+++ b/gui/workorder-recheck.lua
@@ -1,0 +1,22 @@
+-- Makes selected `Active` work order `Checking`.
+--[====[
+
+gui/workorder-recheck
+====================
+Sets the status to ``Checking`` (from ``Active``) of the selected work order (in the j-m or u-m screens). This makes the manager reevaluate its conditions.
+
+Example keybinding (put it in your ``dfhack*.init``-file):
+ ``keybinding add Alt-A@jobmanagement/Main gui/workorder-recheck``
+]====]
+local scr = dfhack.gui.getCurViewscreen()
+if df.viewscreen_jobmanagementst:is_instance(scr) then
+    local orders = df.global.world.manager_orders
+    local idx = scr.sel_idx
+    if idx < #orders then
+        orders[idx].status.active = false
+    else
+        dfhack.printerr("Invalid order selected")
+    end
+else
+    dfhack.printerr('Must be called on the manager screen (j-m or u-m)')
+end

--- a/gui/workorder-recheck.lua
+++ b/gui/workorder-recheck.lua
@@ -15,8 +15,8 @@ if df.viewscreen_jobmanagementst:is_instance(scr) then
     if idx < #orders then
         orders[idx].status.active = false
     else
-        dfhack.printerr("Invalid order selected")
+        qerror("Invalid order selected")
     end
 else
-    dfhack.printerr('Must be called on the manager screen (j-m or u-m)')
+    qerror('Must be called on the manager screen (j-m or u-m)')
 end

--- a/gui/workorder-recheck.lua
+++ b/gui/workorder-recheck.lua
@@ -1,4 +1,4 @@
--- Makes selected `Active` work order `Checking`.
+-- Resets the selected work order to the `Checking` state
 --[====[
 
 gui/workorder-recheck

--- a/gui/workorder-recheck.lua
+++ b/gui/workorder-recheck.lua
@@ -3,10 +3,8 @@
 
 gui/workorder-recheck
 =====================
-Sets the status to ``Checking`` (from ``Active``) of the selected work order (in the j-m or u-m screens). This makes the manager reevaluate its conditions.
-
-Example keybinding (put it in your ``dfhack*.init``-file):
- ``keybinding add Alt-A@jobmanagement/Main gui/workorder-recheck``
+Sets the status to ``Checking`` (from ``Active``) of the selected work order (in the ``j-m`` or ``u-m`` screens).
+This makes the manager reevaluate its conditions.
 ]====]
 local scr = dfhack.gui.getCurViewscreen()
 if df.viewscreen_jobmanagementst:is_instance(scr) then

--- a/gui/workorder-recheck.lua
+++ b/gui/workorder-recheck.lua
@@ -2,7 +2,7 @@
 --[====[
 
 gui/workorder-recheck
-====================
+=====================
 Sets the status to ``Checking`` (from ``Active``) of the selected work order (in the j-m or u-m screens). This makes the manager reevaluate its conditions.
 
 Example keybinding (put it in your ``dfhack*.init``-file):

--- a/workorder-recheck.lua
+++ b/workorder-recheck.lua
@@ -1,8 +1,8 @@
 -- Resets the selected work order to the `Checking` state
 --[====[
 
-gui/workorder-recheck
-=====================
+workorder-recheck
+=================
 Sets the status to ``Checking`` (from ``Active``) of the selected work order (in the ``j-m`` or ``u-m`` screens).
 This makes the manager reevaluate its conditions.
 ]====]


### PR DESCRIPTION
This mini-script allows deactivating a work order, f.e. to stop the job cancellation spam from an order whose conditions are no longer met.