### PR TITLE
[gui/quickfort] add script for fast access to the quickfort interactive dialog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ that repo.
 # Future
 
 ## New Scripts
+- `gui/quickfort`: fast access to the quickfort interactive dialog
 - `workorder-recheck`: resets the selected work order to the ``Checking`` state
 
 # 0.47.04-r4

--- a/gui/quickfort.lua
+++ b/gui/quickfort.lua
@@ -1,0 +1,14 @@
+-- in-game dialog interface for the quickfort script
+--[====[
+gui/quickfort
+=========
+In-game dialog interface for the `quickfort` script.
+]====]
+
+local args = {...}
+
+if #args == 0 then
+    dfhack.run_command('quickfort', 'gui')
+else
+    dfhack.run_command('quickfort', table.unpack(args))
+end

--- a/gui/quickfort.lua
+++ b/gui/quickfort.lua
@@ -1,7 +1,7 @@
 -- in-game dialog interface for the quickfort script
 --[====[
 gui/quickfort
-=========
+=============
 In-game dialog interface for the `quickfort` script.
 ]====]
 


### PR DESCRIPTION
For people who look for gui scripts in the `gui/` directory. Otherwise quickfort's gui mode might get missed.