### PR TITLE
[quickfort] implement {Empty} keycode for use in aliases

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,7 +17,7 @@ that repo.
 - `workorder-recheck`: resets the selected work order to the ``Checking`` state
 
 ## Misc Improvements
-- `quickfort`: implement {Empty} keycode for use in quickfort aliases; useful for defining blank-by-default alias values
+- `quickfort`: implement ``{Empty}`` keycode for use in quickfort aliases; useful for defining blank-by-default alias values
 
 # 0.47.04-r4
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,9 @@ that repo.
 ## New Scripts
 - `workorder-recheck`: resets the selected work order to the ``Checking`` state
 
+## Misc Improvements
+- `quickfort`: implement {Empty} keycode for use in quickfort aliases; useful for defining blank-by-default alias values
+
 # 0.47.04-r4
 
 ## New Scripts

--- a/internal/quickfort/keycodes.lua
+++ b/internal/quickfort/keycodes.lua
@@ -20,6 +20,8 @@ local function init_keycodes()
     if not file then
         qerror(string.format('failed to open file: "%s"', keycodes_file))
     end
+    -- initialize with "Empty" pseudo-keycode that expands to a 0-length list
+    keycodes = {['[SYM:0:Empty]']={}}
     local cur_binding = nil
     for line in file:lines() do
         line = string.gsub(line, '[\r\n]*$', '')

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -38,7 +38,8 @@ local function handle_modifiers(token, modifiers)
         return true
     end
     if token_lower == 'wait' then
-        print('{Wait} not yet implemented')
+        -- accepted for compatibility with Python Quickfort, but waiting has no
+        -- effect in DFHack quickfort.
         return true
     end
     return false


### PR DESCRIPTION
Allows us to define true blank defaults for optional sub-aliases. Before, we needed to just use a key that didn't have any adverse effect.

Documentation in https://github.com/DFHack/dfhack/pull/1749