### PR TITLE
[quickfort] allow more whitespace in blueprint modelines

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,9 @@ that repo.
 ## New Scripts
 - `workorder-recheck`: resets the selected work order to the ``Checking`` state
 
+## Misc Improvements
+- `quickfort`: whitespace is now allowed between a marker name and the opening parenthesis in blueprint modelines. for example, ``#dig start (5; 5)`` is now valid (you used to be required to write ``#dig start(5; 5)``)
+
 # 0.47.04-r4
 
 ## New Scripts

--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -85,7 +85,7 @@ end
 
 local function parse_label(modeline, start_pos, filename, marker_values)
     local _, label_str_end, label_str =
-            string.find(modeline, '^%s+label(%b())', start_pos)
+            string.find(modeline, '^%s+label%s*(%b())', start_pos)
     if not label_str then
         return false, start_pos
     end
@@ -102,11 +102,11 @@ end
 
 local function parse_start(modeline, start_pos, filename, marker_values)
     local _, start_str_end, start_str =
-            string.find(modeline, '^%s+start(%b())', start_pos)
+            string.find(modeline, '^%s+start%s*(%b())', start_pos)
     if not start_str or #start_str == 0 then return false, start_pos end
     local _, _, startx, starty, start_comment =
             string.find(start_str,
-                        '^%(%s*(%d+)%s*[;, ]%s*(%d+)%s*[;, ]?%s*(.*)%)$')
+                        '^%(%s*(%d+)%s-[;, ]%s-(%d+)%s-[;, ]?%s*(.*)%)$')
     if startx and starty then
         marker_values.startx = startx
         marker_values.starty = starty
@@ -121,7 +121,7 @@ end
 
 local function parse_hidden(modeline, start_pos, filename, marker_values)
     local _, hidden_str_end, hidden_str =
-            string.find(modeline, '^%s+hidden(%b())', start_pos)
+            string.find(modeline, '^%s+hidden%s*(%b())', start_pos)
     if not hidden_str or #hidden_str == 0 then return false, start_pos end
     marker_values.hidden = true
     return true, hidden_str_end + 1
@@ -129,7 +129,7 @@ end
 
 local function parse_message(modeline, start_pos, filename, marker_values)
     local _, message_str_end, message_str =
-            string.find(modeline, '^%s+message(%b())', start_pos)
+            string.find(modeline, '^%s+message%s*(%b())', start_pos)
     if not message_str then
         return false, start_pos
     end


### PR DESCRIPTION
whitespace is now allowed between a marker name and the opening parenthesis in blueprint modelines. for example, `#dig start (5; 5)` is now valid (you used to be required to write `#dig start(5; 5)`)