### PR TITLE
[quickfort] fix rare crash in buildingplan when switching ui modes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ that repo.
 
 ## Fixes
 - `quickfort`: zones are now created in the active state by default
+- `quickfort`: solve rare crash when changing UI modes
 
 ## Misc Improvements
 - `quickfort`: new blueprint mode: ``#ignore``, useful for scratch space or personal notes

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -45,14 +45,6 @@ local function handle_modifiers(token, modifiers)
     return false
 end
 
--- send keycodes to exit the current UI sidebar mode and enter another one with
--- the given keycode. we verify before calling this function that we are in a
--- mode that can be exited with one press of ESC.
-local function switch_ui_sidebar_mode(mode_keycode)
-    gui.simulateInput(dfhack.gui.getCurViewscreen(true), 'LEAVESCREEN')
-    gui.simulateInput(dfhack.gui.getCurViewscreen(true), mode_keycode)
-end
-
 local valid_ui_sidebar_modes = {
     [df.ui_sidebar_mode.QueryBuilding]='D_BUILDJOB',
     [df.ui_sidebar_mode.LookAround]='D_LOOK',
@@ -60,6 +52,15 @@ local valid_ui_sidebar_modes = {
     [df.ui_sidebar_mode.Stockpiles]='D_STOCKPILES',
     [df.ui_sidebar_mode.Zones]='D_CIVZONE',
 }
+
+-- send keycodes to exit the current UI sidebar mode and enter another one.
+-- we must be able to leave the mode that we're in with one press of ESC. the
+-- target mode must be a member of valid_ui_sidebar_modes.
+local function switch_ui_sidebar_mode(sidebar_mode)
+    gui.simulateInput(dfhack.gui.getCurViewscreen(true), 'LEAVESCREEN')
+    gui.simulateInput(dfhack.gui.getCurViewscreen(true),
+                      valid_ui_sidebar_modes[sidebar_mode])
+end
 
 function do_run(zlevel, grid, ctx)
     local stats = ctx.stats
@@ -77,8 +78,7 @@ function do_run(zlevel, grid, ctx)
 
     local saved_mode = df.global.ui.main.mode
     if saved_mode ~= df.ui_sidebar_mode.QueryBuilding then
-        switch_ui_sidebar_mode(
-            valid_ui_sidebar_modes[df.ui_sidebar_mode.QueryBuilding])
+        switch_ui_sidebar_mode(df.ui_sidebar_mode.QueryBuilding)
     end
 
     for y, row in pairs(grid) do
@@ -128,7 +128,7 @@ function do_run(zlevel, grid, ctx)
     end
 
     if saved_mode ~= df.ui_sidebar_mode.QueryBuilding then
-        switch_ui_sidebar_mode(valid_ui_sidebar_modes[saved_mode])
+        switch_ui_sidebar_mode(saved_mode)
     end
     quickfort_common.move_cursor(ctx.cursor)
 end

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -45,6 +45,14 @@ local function handle_modifiers(token, modifiers)
     return false
 end
 
+-- send keycodes to exit the current UI sidebar mode and enter another one with
+-- the given keycode. we verify before calling this function that we are in a
+-- mode that can be exited with one press of ESC.
+local function switch_ui_sidebar_mode(mode_keycode)
+    gui.simulateInput(dfhack.gui.getCurViewscreen(true), 'LEAVESCREEN')
+    gui.simulateInput(dfhack.gui.getCurViewscreen(true), mode_keycode)
+end
+
 local valid_ui_sidebar_modes = {
     [df.ui_sidebar_mode.QueryBuilding]='D_BUILDJOB',
     [df.ui_sidebar_mode.LookAround]='D_LOOK',
@@ -69,10 +77,8 @@ function do_run(zlevel, grid, ctx)
 
     local saved_mode = df.global.ui.main.mode
     if saved_mode ~= df.ui_sidebar_mode.QueryBuilding then
-        -- shift into query mode from one of the approved modes verified above
-        gui.simulateInput(dfhack.gui.getCurViewscreen(true), 'LEAVESCREEN')
-        gui.simulateInput(dfhack.gui.getCurViewscreen(true),
-                    valid_ui_sidebar_modes[df.ui_sidebar_mode.QueryBuilding])
+        switch_ui_sidebar_mode(
+            valid_ui_sidebar_modes[df.ui_sidebar_mode.QueryBuilding])
     end
 
     for y, row in pairs(grid) do
@@ -122,10 +128,7 @@ function do_run(zlevel, grid, ctx)
     end
 
     if saved_mode ~= df.ui_sidebar_mode.QueryBuilding then
-        -- shift back into the mode we started in
-        gui.simulateInput(dfhack.gui.getCurViewscreen(true), 'LEAVESCREEN')
-        gui.simulateInput(dfhack.gui.getCurViewscreen(true),
-                          valid_ui_sidebar_modes[saved_mode])
+        switch_ui_sidebar_mode(valid_ui_sidebar_modes[saved_mode])
     end
     quickfort_common.move_cursor(ctx.cursor)
 end

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -45,6 +45,14 @@ local function handle_modifiers(token, modifiers)
     return false
 end
 
+local valid_ui_sidebar_modes = {
+    [df.ui_sidebar_mode.QueryBuilding]='D_BUILDJOB',
+    [df.ui_sidebar_mode.LookAround]='D_LOOK',
+    [df.ui_sidebar_mode.BuildingItems]='D_BUILDITEM',
+    [df.ui_sidebar_mode.Stockpiles]='D_STOCKPILES',
+    [df.ui_sidebar_mode.Zones]='D_CIVZONE',
+}
+
 function do_run(zlevel, grid, ctx)
     local stats = ctx.stats
     stats.query_keystrokes = stats.query_keystrokes or
@@ -52,10 +60,20 @@ function do_run(zlevel, grid, ctx)
     stats.query_tiles = stats.query_tiles or
             {label='Tiles modified', value=0}
 
+    if not valid_ui_sidebar_modes[df.global.ui.main.mode] then
+        qerror('To run a blueprint, you must be in one of the following modes:'
+               ..' query (q), look (k), view (t), stockpiles (p), or zones (i)')
+    end
+
     load_aliases()
 
     local saved_mode = df.global.ui.main.mode
-    df.global.ui.main.mode = df.ui_sidebar_mode.QueryBuilding
+    if saved_mode ~= df.ui_sidebar_mode.QueryBuilding then
+        -- shift into query mode from one of the approved modes verified above
+        gui.simulateInput(dfhack.gui.getCurViewscreen(true), 'LEAVESCREEN')
+        gui.simulateInput(dfhack.gui.getCurViewscreen(true),
+                    valid_ui_sidebar_modes[df.ui_sidebar_mode.QueryBuilding])
+    end
 
     for y, row in pairs(grid) do
         for x, cell_and_text in pairs(row) do
@@ -103,7 +121,12 @@ function do_run(zlevel, grid, ctx)
         end
     end
 
-    df.global.ui.main.mode = saved_mode
+    if saved_mode ~= df.ui_sidebar_mode.QueryBuilding then
+        -- shift back into the mode we started in
+        gui.simulateInput(dfhack.gui.getCurViewscreen(true), 'LEAVESCREEN')
+        gui.simulateInput(dfhack.gui.getCurViewscreen(true),
+                          valid_ui_sidebar_modes[saved_mode])
+    end
     quickfort_common.move_cursor(ctx.cursor)
 end
 


### PR DESCRIPTION
Fixes DFHack/dfhack#1762

by manually changing df.global.ui.main.mode we skipped validity checking the ui normally does on state change. this sometimes resulted in bad data in world->selected_building, which caused buildingplan to crash. using the UI to switch modes avoids this problem.