### PR TITLE
[quickfort] don't require a cursor for #notes blueprints

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@ that repo.
 - `quickfort`: implement ``{Empty}`` keycode for use in quickfort aliases; useful for defining blank-by-default alias values
 - `quickfort`: more flexible commandline parsing allowing for more natural parameter ordering (e.g. where you used to have to write ``quickfort list dreamfort -l`` you can now write ``quickfort list -l dreamfort``)
 - `quickfort`: print out blueprint names that a ``#meta`` blueprint is applying so it's easier to understand what meta blueprints are doing
+- `quickfort`: an active cursor is no longer required for running #notes blueprints (like the dreamfort walkthrough)
 - `quickfort`: whitespace is now allowed between a marker name and the opening parenthesis in blueprint modelines. for example, ``#dig start (5; 5)`` is now valid (you used to be required to write ``#dig start(5; 5)``)
 
 # 0.47.04-r4

--- a/internal/quickfort/command.lua
+++ b/internal/quickfort/command.lua
@@ -90,15 +90,18 @@ function do_command(args)
         qerror("expected <list_num> or <blueprint_name> parameter")
     end
 
+    local mode = nil
     local list_num = tonumber(blueprint_name)
     if list_num then
-        blueprint_name, section_name =
+        blueprint_name, section_name, mode =
                 quickfort_list.get_blueprint_by_number(list_num)
+    else
+        mode = quickfort_list.get_blueprint_mode(blueprint_name, section_name)
     end
 
     local cursor = guidm.getCursorPos()
     if not cursor then
-        if command == 'orders' then
+        if command == 'orders' or mode == 'notes' then
             cursor = {x=0, y=0, z=0}
         else
             qerror('please position the game cursor at the blueprint start ' ..

--- a/internal/quickfort/dialog.lua
+++ b/internal/quickfort/dialog.lua
@@ -179,9 +179,13 @@ function BlueprintDialog:onInput(keys)
 end
 
 local function dialog_command(command, text)
+    local id = get_id(text)
+    local blueprint_name, section_name, mode =
+            quickfort_list.get_blueprint_by_number(id)
+
     local cursor = guidm.getCursorPos()
     if not cursor then
-        if command == 'orders' then
+        if command == 'orders' or mode == 'notes' then
             cursor = {x=0, y=0, z=0}
         else
             dialogs.showMessage('Error',


### PR DESCRIPTION
this removes a point of friction when viewing blueprint help text, like the dreamfort walkthrough. no map changes can be made, so no cursor should be required.