### PR TITLE
[quickfort] fix raw numeric dig priorities in .xlsx blueprints

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,9 @@ that repo.
 
 # Future
 
+## Fixes
+- `quickfort`: raw numeric `quickfort-dig-priorities` (e.g. ``3``, which is a valid shorthand for ``d3``) now works when used in .xlsx blueprints
+
 # 0.47.04-r5
 
 ## New Scripts

--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -230,7 +230,14 @@ local function reset_csv_ctx(ctx)
 end
 
 local function read_xlsx_line(ctx)
-    return xlsxreader.get_row(ctx.xlsx_sheet)
+    local tokens = xlsxreader.get_row(ctx.xlsx_sheet)
+    if not tokens then return nil end
+    -- raw numbers can get turned into floats. let's turn them back into ints
+    for i,token in ipairs(tokens) do
+        local num_token = tonumber(token)
+        if num_token then tokens[i] = tostring(math.floor(num_token)) end
+    end
+    return tokens
 end
 
 local function cleanup_xslx_ctx(ctx)


### PR DESCRIPTION
the xlsxio parser formats floats in .xlsx spreadsheet cells with a ".0" suffix. this breaks the quickfort dig parser, which expects just an integer. Floats are not used anywhere in quickfort, so we just floor the value and call it a day.