### PR TITLE
[quickfort] add feedback message for gui orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,9 @@ that repo.
 
 # Future
 
+## Misc Improvements
+- `quickfort`: now reports how many work orders were added when generating manager orders from blueprints in the gui dialog
+
 # 0.47.04-r5
 
 ## New Scripts

--- a/internal/quickfort/dialog.lua
+++ b/internal/quickfort/dialog.lua
@@ -206,6 +206,13 @@ local function dialog_command(command, text)
         dialogs.showMessage('Attention',
                             wrap(table.concat(ctx.messages, '\n\n'),
                                  min_dialog_width))
+    elseif command == 'orders' then
+        local count = 0
+        for _,_ in pairs(ctx.order_specs or {}) do count = count + 1 end
+        local message = string.format(
+            '%d orders enqueued for %s.', count,
+            quickfort_parse.format_command(nil, blueprint_name, section_name))
+        dialogs.showMessage('Orders enqueued', wrap(message, min_dialog_width))
     end
 end
 

--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -17,12 +17,16 @@ end
 --   orders library/dreamfort.csv -n /apartments2
 --   run "some file.csv"
 function format_command(command, blueprint_name, section_name)
+    local command_str = ''
+    if command then
+        command_str = string.format('%s ', command)
+    end
     local section_name_str = ''
     if section_name then
         section_name_str =
                 string.format(' -n %s', quote_if_has_spaces(section_name))
     end
-    return string.format('%s %s%s', command,
+    return string.format('%s%s%s', command_str,
                          quote_if_has_spaces(blueprint_name), section_name_str)
 end
 


### PR DESCRIPTION
to indicate that the operation was successful and to report how many orders were added. Before, the operation was completely silent with no feedback to the user that something was done.