### PR TITLE
[quickfort] add flags for setting initial gui state

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,9 @@ that repo.
 
 # Future
 
+## Misc Improvements
+- `quickfort`: new commandline options for setting the initial state of the gui dialog. for example: ``quickfort gui -l dreamfort notes`` will start the dialog filtered for the dreamfort walkthrough blueprints
+
 # 0.47.04-r5
 
 ## New Scripts

--- a/gui/quickfort.lua
+++ b/gui/quickfort.lua
@@ -2,7 +2,20 @@
 --[====[
 gui/quickfort
 =============
-In-game dialog interface for the `quickfort` script.
+In-game dialog interface for the `quickfort` script. Any arguments passed to
+this script are passed directly to `quickfort`. Invoking this script without
+arguments is equivalent to running ``quickfort gui``.
+
+Examples:
+
+-------------------------------------  --------------------------------------
+Command                                Runs
+-------------------------------------  --------------------------------------
+gui/quickfort                          opens quickfort interactive dialog
+gui/quickfort gui                      same as above
+gui/quickfort gui --library dreamfort  opens the dialog with custom settings
+gui/quickfort help                     prints quickfort help (on the console)
+-------------------------------------  --------------------------------------
 ]====]
 
 local args = {...}

--- a/internal/quickfort/dialog.lua
+++ b/internal/quickfort/dialog.lua
@@ -7,6 +7,7 @@ end
 
 local dialogs = require('gui.dialogs')
 local guidm = require('gui.dwarfmode')
+local utils = require('utils')
 local quickfort_command = reqscript('internal/quickfort/command')
 local quickfort_list = reqscript('internal/quickfort/list')
 local quickfort_parse = reqscript('internal/quickfort/parse')
@@ -209,7 +210,15 @@ local function dialog_command(command, text)
     end
 end
 
-function do_dialog()
+function do_dialog(args)
+    -- allow passed-in flags and strings to pre-set our dialog flags and filter
+    local filter_strings = utils.processArgsGetopt(args, {
+            {'l', 'library', handler=function() show_library = true end},
+            {'h', 'hidden', handler=function() show_hidden = true end},
+        })
+    if #filter_strings > 0 then
+        filter_text = table.concat(filter_strings, ' ')
+    end
     if blueprint_dialog then blueprint_dialog:dismiss() end
     blueprint_dialog = BlueprintDialog{
         frame_title='Select quickfort blueprint',

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -31,9 +31,6 @@ Usage:
     below for available keys and values.
 **quickfort reset**
     Resets quickfort configuration to the defaults in ``quickfort.txt``.
-**quickfort gui**
-    Starts the quickfort dialog, where you can run blueprints from an
-    interactive list.
 **quickfort list [-m|-\-mode <mode>] [-l|-\-library] [-h|-\-hidden] [search string]**
     Lists blueprints in the ``blueprints`` folder. Blueprints are ``.csv`` files
     or sheets within ``.xlsx`` files that contain a ``#<mode>`` comment in the
@@ -44,6 +41,10 @@ Usage:
     "-m build") and/or strings to search for in a path, filename, mode, or
     comment. The id numbers in the list may not be contiguous if there are
     hidden or filtered  blueprints that are not being shown.
+**quickfort gui [-l|-\-library] [-h|-\-hidden] [search string]**
+    Starts the quickfort dialog, where you can run blueprints from an
+    interactive list. The optional arguments have the same meanings as they do
+    in the list command, and can be used to preset the gui dialog state.
 **quickfort <command> <list_num> [<options>]**
     Applies the blueprint with the number from the list command.
 **quickfort <command> <filename> [-n|-\-name <name>] [<options>]**
@@ -154,14 +155,15 @@ quickfort set [<key> <value>]
     run "quickfort set" to show current settings.
 quickfort reset
     Resets quickfort configuration to defaults in quickfort.txt.
-quickfort gui
-    Starts the quickfort dialog, where you can run blueprints from an
-    interactive list.
 quickfort list [-m|--mode <mode>] [-l|--library] [-h|--hidden] [search string]
     Lists blueprints in the "blueprints" folder. Specify -l to include library
     blueprints and -h to include hidden blueprints. The list can be filtered by
     a specified mode (e.g. "-m build") and/or strings to search for in a path,
     filename, mode, or comment.
+quickfort gui [-l|--library] [-h|--hidden] [search string]
+    Starts the quickfort dialog, where you can run blueprints from an
+    interactive list. The optional arguments have the same meanings as they do
+    in the list command, and can be used to preset the gui dialog state.
 quickfort <command> <list_num> [<options>]
     Applies the blueprint with the number from the list command.
 quickfort <command> <filename> [-n|--name <name>] [<options>]


### PR DESCRIPTION
for example: `quickfort gui -l dreamfort notes` will start the dialog pre-filtered for the dreamfort walkthrough blueprints.