### PR TITLE
[quickfort] enqueue manager orders for containers set in #place blueprints

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,9 @@ that repo.
 ## Fixes
 - `quickfort`: raw numeric `quickfort-dig-priorities` (e.g. ``3``, which is a valid shorthand for ``d3``) now works when used in .xlsx blueprints
 
+## Misc Improvements
+- `quickfort`: ``quickfort orders`` on a ``#place`` blueprint will enqueue manager orders for barrels, bins, or wheelbarrows that are explicitly set in the blueprint.
+
 # 0.47.04-r5
 
 ## New Scripts

--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -797,7 +797,7 @@ function do_orders(zlevel, grid, ctx)
     stats.invalid_keys.value =
             stats.invalid_keys.value + quickfort_building.init_buildings(
                 zlevel, grid, buildings, building_db, building_aliases)
-    quickfort_orders.enqueue_orders(stats, buildings, building_db, ctx)
+    quickfort_orders.enqueue_building_orders(buildings, building_db, ctx)
 end
 
 local function is_queued_for_destruction(bld)

--- a/internal/quickfort/orders.lua
+++ b/internal/quickfort/orders.lua
@@ -131,7 +131,7 @@ end
 -- ensure we don't reinit this; it contains allocated memory
 reactions = reactions or stockflow.collect_reactions()
 
-function enqueue_orders(stats, buildings, building_db, ctx)
+function enqueue_building_orders(buildings, building_db, ctx)
     local order_specs = ctx.order_specs or {}
     ctx.order_specs = order_specs
     for _, b in ipairs(buildings) do
@@ -150,7 +150,7 @@ function enqueue_orders(stats, buildings, building_db, ctx)
             for _,label in ipairs(db_entry.additional_orders) do
                 local quantity = 1
                 if additional_order == df.item_type.BLOCKS then
-                    quantity = 1 /4
+                    quantity = 1 / 4
                 end
                 inc_order_spec(order_specs, quantity, reactions, label)
             end
@@ -164,5 +164,20 @@ function enqueue_orders(stats, buildings, building_db, ctx)
             end
             process_filter(order_specs, filter, reactions)
         end
+    end
+end
+
+function enqueue_container_orders(ctx, num_bins, num_barrels, num_wheelbarrows)
+    local order_specs = ctx.order_specs or {}
+    ctx.order_specs = order_specs
+    if num_bins and num_bins > 0 then
+        inc_order_spec(order_specs, num_bins, reactions, "wooden bin")
+    end
+    if num_barrels and num_barrels > 0 then
+        inc_order_spec(order_specs, num_barrels, reactions, "rock pot")
+    end
+    if num_wheelbarrows and num_wheelbarrows > 0 then
+        inc_order_spec(
+            order_specs, num_wheelbarrows, reactions, "wooden wheelbarrow")
     end
 end

--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -506,18 +506,17 @@ end
 -- where token is an alias name or a keycode, and both params and repetitions
 -- are optional. if the first character of token is '{' or '}', it is treated as
 -- a literal and not a syntax element.
--- params are in one of the following formats:
+-- Examples:
 --   param_name=param_val
+--   param_name=param_val{othertoken}
 --   param_name="param val with spaces"
+--   param_name="param val {othertoken} with spaces"
+--   param_name="param_val{otherextendedtoken param=val}"
+--   param_name="{alias1}{alias2}"
 --   param_name={token params repetitions}
 -- if the params within the extended token within the params require quotes,
 -- .csv-style doubled double quotes are required:
---   param_name="{somealias var=""with spaces"" 5}"
--- combining literals with extended tokens is not currently supported to keep
--- the implementation simple, though we can add it if there is demand. That is,
--- the following is not supported: param_name=literal{somealias}. The
--- workaround is just to put the literal in a regularly-defined alias and call
--- that alias.
+--   param_name="{firstalias}{secondalias var=""with spaces"" 5}"
 -- if repetitions is not specified, the value 1 is returned
 -- returns token as string, params as map, repetitions as number, start position
 -- of the next element after the etoken in text as number

--- a/internal/quickfort/place.lua
+++ b/internal/quickfort/place.lua
@@ -18,6 +18,7 @@ require('dfhack.buildings') -- loads additional functions into dfhack.buildings
 local utils = require('utils')
 local quickfort_common = reqscript('internal/quickfort/common')
 local quickfort_building = reqscript('internal/quickfort/building')
+local quickfort_orders = reqscript('internal/quickfort/orders')
 local quickfort_query = reqscript('internal/quickfort/query')
 local log = quickfort_common.log
 
@@ -220,8 +221,15 @@ function do_run(zlevel, grid, ctx)
     dfhack.job.checkBuildingsNow()
 end
 
-function do_orders()
-    log('nothing to do for blueprints in mode: place')
+-- enqueues orders only for explicitly requested containers
+function do_orders(zlevel, grid, ctx)
+    local stockpiles = {}
+    quickfort_building.init_buildings(zlevel, grid, stockpiles, stockpile_db)
+    for _, s in ipairs(stockpiles) do
+        local db_entry = stockpile_db[s.type]
+        quickfort_orders.enqueue_container_orders(ctx,
+            db_entry.num_bins, db_entry.num_barrels, db_entry.num_wheelbarrows)
+    end
 end
 
 function do_undo(zlevel, grid, ctx)


### PR DESCRIPTION
a follow on to #254

this implements generating manager orders for containers specified in `#place` blueprints.

For example, in a place blueprint like this:
```
#place
s2(3x3)
```
two wheelbarrows would be enqueued. For this blueprint:
```
#place
f10(1x9)
```
10 rock pots would be enqueued, even though the stockpile only has 9 tiles.

A stockpile that does not specify a specific number is initialized with the default number of containers, but no manager orders are generated. This prevents huge numbers of containers being generated for regular blueprints that don't do anything special with their stockpile definitions.

This PR also fixes some in-code documentation that was just plain incorrect.

More docs in DFHack/dfhack#1768