### PR TITLE
[quickfort] allow aliases to be defined directly in blueprint files

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ that repo.
 ## Misc Improvements
 - `gui/no-dfhack-init`: clarified how to dismiss dialog that displays when no ``dfhack.init`` file is found
 - `quickfort`: an active cursor is no longer required for running #notes blueprints (like the dreamfort walkthrough)
+- `quickfort`: you can now add alias definitions directly to your blueprint files instead of having to put them in a separate aliases.txt file. makes sharing blueprints with custom alias definitions much easier.
 
 # 0.47.05-beta1
 

--- a/internal/quickfort/aliases.lua
+++ b/internal/quickfort/aliases.lua
@@ -29,7 +29,8 @@ function reset_aliases()
     alias_stack = {}
 end
 
-local function push_aliases(aliases)
+-- overwrites metatable of passed-in aliases map
+function push_aliases(aliases)
     local prev = alias_stack
     setmetatable(aliases, {prev=prev,
                            __index=function(_, key) return prev[key] end})
@@ -52,11 +53,7 @@ function push_aliases_csv_file(filename)
     local num_aliases = 0
     for line in file:lines() do
         line = line:gsub('[\r\n]*$', '')
-        -- aliases must be at least two alphanumerics long (plus - and _) to
-        -- distinguish them from regular keystrokes
-        _, _, alias, definition = line:find('^([%w-_][%w-_]+):%s*(.*)')
-        if alias and #definition > 0 then
-            aliases[alias] = definition
+        if quickfort_parse.parse_alias_combined(line, aliases) then
             num_aliases = num_aliases + 1
         end
     end

--- a/internal/quickfort/command.lua
+++ b/internal/quickfort/command.lua
@@ -14,7 +14,7 @@ local quickfort_parse = reqscript('internal/quickfort/parse')
 
 local mode_modules = {}
 for mode, _ in pairs(quickfort_common.valid_modes) do
-    if mode ~= 'ignore' then
+    if mode ~= 'ignore' and mode ~= 'aliases' then
         mode_modules[mode] = reqscript('internal/quickfort/'..mode)
     end
 end
@@ -114,8 +114,9 @@ function do_command(args)
     dfhack.with_finalize(
         function() quickfort_common.verbose = false end,
         function()
+            local aliases = quickfort_list.get_aliases(blueprint_name)
             local ctx = {command=command, blueprint_name=blueprint_name,
-                         cursor=cursor, stats={}, messages={}, dry_run=dry_run}
+                         cursor=cursor, stats={}, messages={}, aliases=aliases, dry_run=dry_run}
             do_command_internal(ctx, section_name)
             finish_command(ctx, section_name, quiet)
             if command == 'run' then

--- a/internal/quickfort/common.lua
+++ b/internal/quickfort/common.lua
@@ -17,6 +17,7 @@ valid_modes = utils.invert({
     'meta',
     'notes',
     'ignore',
+    'aliases',
 })
 
 -- keep deprecated settings in the table so we don't break existing configs

--- a/internal/quickfort/dialog.lua
+++ b/internal/quickfort/dialog.lua
@@ -203,8 +203,9 @@ local function dialog_command(command, text)
     print(string.format('executing via gui dialog: quickfort %s',
                         quickfort_parse.format_command(
                             command, blueprint_name, section_name)))
+    local aliases = quickfort_list.get_aliases(blueprint_name)
     local ctx = {command=command, blueprint_name=blueprint_name, cursor=cursor,
-                 stats={}, messages={}}
+                 stats={}, messages={}, aliases=aliases}
     quickfort_command.do_command_internal(ctx, section_name)
     quickfort_command.finish_command(ctx, section_name, true)
     if command == 'run' and #ctx.messages > 0 then

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -105,7 +105,8 @@ function do_run(zlevel, grid, ctx)
                 'coordinates (%d, %d, %d)', cell, text, pos.x, pos.y, pos.z)
             local tokens = quickfort_aliases.expand_aliases(text)
             if not dry_run then quickfort_common.move_cursor(pos) end
-            local focus_string = dfhack.gui.getCurFocus(true)
+            local focus_string =
+                    dfhack.gui.getFocusString(dfhack.gui.getCurViewscreen(true))
             local modifiers = {} -- tracks ctrl, shift, and alt modifiers
             for _,token in ipairs(tokens) do
                 if handle_modifiers(token, modifiers) then goto continue end
@@ -121,7 +122,8 @@ function do_run(zlevel, grid, ctx)
                 stats.query_keystrokes.value = stats.query_keystrokes.value + 1
                 ::continue::
             end
-            local new_focus_string = dfhack.gui.getCurFocus(true)
+            local new_focus_string =
+                    dfhack.gui.getFocusString(dfhack.gui.getCurViewscreen(true))
             if not quickfort_common.settings['query_unsafe'].value and
                     focus_string ~= new_focus_string then
                 qerror(string.format(

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -14,12 +14,19 @@ local quickfort_keycodes = reqscript('internal/quickfort/keycodes')
 local common_aliases_filename = 'hack/data/quickfort/aliases-common.txt'
 local user_aliases_filename = 'dfhack-config/quickfort/aliases.txt'
 
-local function load_aliases()
+local function load_aliases(ctx)
     -- ensure we're starting from a clean alias stack, even if the previous
     -- invocation of this function returned early with an error
     quickfort_aliases.reset_aliases()
     quickfort_aliases.push_aliases_csv_file(common_aliases_filename)
     quickfort_aliases.push_aliases_csv_file(user_aliases_filename)
+    local num_file_aliases = 0
+    for _ in pairs(ctx.aliases) do num_file_aliases = num_file_aliases + 1 end
+    if num_file_aliases > 0 then
+        quickfort_aliases.push_aliases(ctx.aliases)
+        log('successfully read in %d aliases from "%s"',
+            num_file_aliases, ctx.blueprint_name)
+    end
 end
 
 local function is_queryable_tile(pos)
@@ -74,7 +81,7 @@ function do_run(zlevel, grid, ctx)
                ..' query (q), look (k), view (t), stockpiles (p), or zones (i)')
     end
 
-    load_aliases()
+    load_aliases(ctx)
 
     local dry_run = ctx.dry_run
     local saved_mode = df.global.ui.main.mode

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -105,8 +105,7 @@ function do_run(zlevel, grid, ctx)
                 'coordinates (%d, %d, %d)', cell, text, pos.x, pos.y, pos.z)
             local tokens = quickfort_aliases.expand_aliases(text)
             if not dry_run then quickfort_common.move_cursor(pos) end
-            local focus_string =
-                    dfhack.gui.getFocusString(dfhack.gui.getCurViewscreen(true))
+            local focus_string = dfhack.gui.getCurFocus(true)
             local modifiers = {} -- tracks ctrl, shift, and alt modifiers
             for _,token in ipairs(tokens) do
                 if handle_modifiers(token, modifiers) then goto continue end
@@ -122,8 +121,7 @@ function do_run(zlevel, grid, ctx)
                 stats.query_keystrokes.value = stats.query_keystrokes.value + 1
                 ::continue::
             end
-            local new_focus_string =
-                    dfhack.gui.getFocusString(dfhack.gui.getCurViewscreen(true))
+            local new_focus_string = dfhack.gui.getCurFocus(true)
             if not quickfort_common.settings['query_unsafe'].value and
                     focus_string ~= new_focus_string then
                 qerror(string.format(


### PR DESCRIPTION
instead of requiring them to be added to a separate aliases.txt file. This reduces friction for sharing blueprints with custom aliases. It also makes testing much easier since you can define needed aliases along with the test blueprint. It makes alias development much easier for the same reason.

Syntax documentation in DFHack/dfhack#1779, but here's an example I've been using for testing. It scripts the setup of a new dreamfort map (meant to be run over the starting wagon):

- sets manager, bookkeeper, doctor, and broker nobles to the first dwarf
- names hotkeys and sets them to be zoomed to the correct z-level (x and y will need adjustment, and z may need adjustment too depending on number of soil layers, but the pre-naming is handy regardless)
- sets only farmers harvest, gather refuse from outside (incl. vermin), and turns off autoloom
- creates an "Inside" burrow
- sets all preset uniforms to replace clothing
- in the "Metal" uniform, replaces generic "upper body" armor with explicit breastplate + mail shirt, replaces "lower body" armor with greaves
- creates "Siege" alert and sets civilians to the "Inside" burrow
- deconstructs the starting wagon

```
#aliases
startnobles: ^n{Down 4}{togglesequence 8}^q
sethotkey: {fkey}zn{name}&
starthotkeys: >{F1}^H>{sethotkey fkey={F2} name=Farming}>{sethotkey fkey={F3} name=Industry}>{sethotkey fkey={F4} name=Services}{> 4}{sethotkey fkey={F5} name=Guildhall}>{sethotkey fkey={F6} name=Beds}{> 6}{sethotkey fkey={F7} name=Quarry}{< 14}^q
startorders: ^ohrov^Wl^^q
startburrows: ^wa&nInside&^^q
metalarmorsetup: {Right 2}{Down 2}&{Down}&{Left}&M{Right}{Down}&{Left}{Down}{Right}{Down}&{Left}{Down 2}L{Right}{Down 2}&{Left}{Down 3}&M{Right}{Down}&{Left 2}
startmilitary: ^mnr{Down}r{metalarmorsetup}{Down}racNSiege&{Right}&fd^q
#query
x{startnobles}{starthotkeys}{startorders}{startburrows}{startmilitary}
```

Once I refine this a bit more, I might release it with dreamfort