### PR TITLE
[quickfort] be flexible about start mode for #query blueprints

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ that repo.
 
 ## Misc Improvements
 - `gui/no-dfhack-init`: clarified how to dismiss dialog that displays when no ``dfhack.init`` file is found
+- `quickfort`: you can now be in any mode with an active cursor when running #query blueprints (before you could only be in a few "approved" modes, like look, query, or place)
 - `quickfort`: an active cursor is no longer required for running #notes blueprints (like the dreamfort walkthrough)
 
 # 0.47.05-beta1

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -45,7 +45,9 @@ local function handle_modifiers(token, modifiers)
     return false
 end
 
-local valid_ui_sidebar_modes = {
+-- the sidebar modes that we know how to get back to if the player starts there
+-- instead of query mode
+local basic_ui_sidebar_modes = {
     [df.ui_sidebar_mode.QueryBuilding]='D_BUILDJOB',
     [df.ui_sidebar_mode.LookAround]='D_LOOK',
     [df.ui_sidebar_mode.BuildingItems]='D_BUILDITEM',
@@ -53,13 +55,19 @@ local valid_ui_sidebar_modes = {
     [df.ui_sidebar_mode.Zones]='D_CIVZONE',
 }
 
--- send keycodes to exit the current UI sidebar mode and enter another one.
--- we must be able to leave the mode that we're in with one press of ESC. the
--- target mode must be a member of valid_ui_sidebar_modes.
+-- Send ESC keycodes until we get to Dwarfmode/Default and enter the specified
+-- sidebar mode. If we don't get to Default after 10 presses of ESC, throw an
+-- error. The target sidebar mode must be a member of basic_ui_sidebar_modes.
 local function switch_ui_sidebar_mode(sidebar_mode)
-    gui.simulateInput(dfhack.gui.getCurViewscreen(true), 'LEAVESCREEN')
-    gui.simulateInput(dfhack.gui.getCurViewscreen(true),
-                      valid_ui_sidebar_modes[sidebar_mode])
+    for i=1,10 do
+        if df.global.ui.main.mode == df.ui_sidebar_mode.Default then
+            gui.simulateInput(dfhack.gui.getCurViewscreen(true),
+                              basic_ui_sidebar_modes[sidebar_mode])
+            return
+        end
+        gui.simulateInput(dfhack.gui.getCurViewscreen(true), 'LEAVESCREEN')
+    end
+    qerror('Unable to get into query mode from current UI viewscreen.')
 end
 
 function do_run(zlevel, grid, ctx)
@@ -68,11 +76,6 @@ function do_run(zlevel, grid, ctx)
             {label='Keystrokes sent', value=0, always=true}
     stats.query_tiles = stats.query_tiles or
             {label='Tiles modified', value=0}
-
-    if not valid_ui_sidebar_modes[df.global.ui.main.mode] then
-        qerror('To run a blueprint, you must be in one of the following modes:'
-               ..' query (q), look (k), view (t), stockpiles (p), or zones (i)')
-    end
 
     load_aliases()
 
@@ -131,7 +134,8 @@ function do_run(zlevel, grid, ctx)
     end
 
     if not dry_run then
-        if saved_mode ~= df.ui_sidebar_mode.QueryBuilding then
+        if saved_mode ~= df.ui_sidebar_mode.QueryBuilding
+                and basic_ui_sidebar_modes[saved_mode] then
             switch_ui_sidebar_mode(saved_mode)
         end
         quickfort_common.move_cursor(ctx.cursor)


### PR DESCRIPTION
Now any mode that has an active cursor is acceptable. Before, we required that players start in one of a short list of approved modes that we know how to get back to after the query blueprint is done, but that leads to a bad user experience when you happen to be in a mode that's not on the list. It's even worse when you run a meta blueprint that includes other non-#query blueprints and then runs the #query blueprint. The other blueprints will succeed, then the #query blueprint will fail, leaving a #meta sequence partially applied.

This new approach lets players start in any mode they want to, as long as it has a cursor. we send `ESC` repeatedly until we're back at the default screen, then we just send `q` once to get into query mode. easy peasy, and works everywhere. if we don't know how to get back to the start mode when we're done, we just stay in query mode. this may be slightly confusing for a player that started in, say, building placement mode, but it's a better user experience than failing the blueprint entirely.

If we get complaints about not getting back into all start modes, we can expand the table that records how to get back into various modes. we can still fail if we don't get to the main screen within 10 presses of `ESC`, but I don't know of any screen in DF where that will happen.