### PR TITLE
[quickfort] #query blueprint sanity check refinements

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ that repo.
 ## Misc Improvements
 - `gui/no-dfhack-init`: clarified how to dismiss dialog that displays when no ``dfhack.init`` file is found
 - `quickfort`: an active cursor is no longer required for running #notes blueprints (like the dreamfort walkthrough)
+- `quickfort`: refine ``#query`` blueprint sanity checks: cursor should still be on target tile at end of configuration, and it's ok for the screen ID to change if you are destroying (or canceling destruction of) a building
 
 # 0.47.05-beta1
 


### PR DESCRIPTION
- check that the cursor is still on the tile at the end of configuration. this catches cases like configuring a stockpile to take from another, but the movement keys to get to that other stockpile are incorrect
- allow viewscreen focus string to change if the configuration causes the building to be destroyed (or cancels destruction of a building)