### PR TITLE
[luacov] add coverage report generation script

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,9 @@ that repo.
 
 # Future
 
+## New Scripts
+- `devel/luacov`: generate code test coverage reports for script development. define the ``DFHACK_ENABLE_LUACOV=1`` environment variable to start gathering coverage metrics.
+
 # 0.47.05-r1
 
 ## Misc Improvements

--- a/devel/luacov.lua
+++ b/devel/luacov.lua
@@ -2,9 +2,14 @@
 
 local help_message =
 [====[
+
+devel/luacov
+============
+
 Lua script coverage report generator
 
 Usage:
+
     luacov [options] [pattern...]
 
 This script generates a coverage report from collected statistics. By default it
@@ -56,7 +61,6 @@ local other_args = utils.processArgsGetopt({...}, {
         {'h', 'help', handler=function() show_help = true end},
     })
 if show_help then
-    dfhack.print(string.format('LuaCov %s - ', runner.version))
     print(help_message)
     return
 end

--- a/devel/luacov.lua
+++ b/devel/luacov.lua
@@ -79,16 +79,21 @@ for _,pattern in ipairs(other_args) do
                 (pattern:gsub("\\", "/"):gsub("%.lua$", "")))
 end
 
-print('flushing accumulated stats')
-runner.save_stats()
+runner.pause()
+dfhack.with_finalize(
+    function() runner.resume() end,
+    function()
+        print('flushing accumulated stats')
+        runner.save_stats()
 
-print(string.format('generating report in "%s" for files matching:',
-                    configuration.reportfile))
-if #configuration.include == 0 then
-    print('  all')
-else
-    for _,pattern in ipairs(configuration.include) do
-        print(('  %s'):format(pattern))
-    end
-end
-runner.run_report(configuration)
+        print(string.format('generating report in "%s" for files matching:',
+                            configuration.reportfile))
+        if #configuration.include == 0 then
+            print('  all')
+        else
+            for _,pattern in ipairs(configuration.include) do
+                print(('  %s'):format(pattern))
+            end
+        end
+        runner.run_report(configuration)
+    end)

--- a/devel/luacov.lua
+++ b/devel/luacov.lua
@@ -20,14 +20,14 @@ from the first report plus the recently run lua script. Restarting DFHack will
 clear the statistics. You can also clear statistics after running a report by
 passing the --clear flag to this script.
 
-Note that the coverage report will be empty unless you run DFHack with the
-"DFHACK_ENABLE_LUACOV=1" environment variable defined, which starts the coverage
-monitoring.
+Note that the coverage report will be empty unless you have started DFHack with
+the "DFHACK_ENABLE_LUACOV=1" environment variable defined, which enables the
+coverage monitoring.
 
-Also note that coverage monitoring and lua profiling via the "profiler" module
-cannot both be active at the same time. Their interceptor hooks override each
-other. Usage of the "kill-lua" command will likewise override the luacov
-interceptor hook and prevent coverage statistics from being collected.
+Also note that enabling both coverage monitoring and lua profiling via the
+"profiler" module can produce strange results. Their interceptor hooks override
+each other. Usage of the "kill-lua" command will likewise override the luacov
+interceptor hook and may prevent coverage statistics from being collected.
 
 Options:
 
@@ -61,13 +61,13 @@ if show_help then
     return
 end
 
-if not runner.initialized or debug.gethook() ~= runner.debug_hook then
+if not runner.initialized then
     dfhack.printerr(
         'Warning: Coverage stats are not being collected. Report will be' ..
-        ' empty unless stats were collected in a previous run. Please run' ..
+        ' empty unless stats were collected in a previous run. Please start' ..
         ' dfhack with the DFHACK_ENABLE_LUACOV environment variable defined' ..
         ' to start coverage monitoring. Keep in mind that using the' ..
-        ' "kill-lua" command or using a Lua profiler will interfere with' ..
+        ' "kill-lua" command or using a Lua profiler may interfere with' ..
         ' coverage monitoring.')
 end
 

--- a/devel/luacov.lua
+++ b/devel/luacov.lua
@@ -71,12 +71,19 @@ local configuration = runner.load_config()
 -- parameters, but we need to restore the original values when this script is
 -- subsequently run without parameters.
 default_include = default_include or configuration.include or {}
-configuration.include = #other_args == 0 and default_include or {}
 
 -- override 'include' table if patterns were explicitly specified
+configuration.include = #other_args == 0 and default_include or {}
 for _,pattern in ipairs(other_args) do
     table.insert(configuration.include,
                 (pattern:gsub("\\", "/"):gsub("%.lua$", "")))
+end
+
+-- always exclude test files
+configuration.exclude = configuration.exclude or {}
+local test_pattern = '/test/' -- those are path slashes and not regex delimiters
+if not utils.invert(configuration.exclude)[test_pattern] then
+    table.insert(configuration.exclude, test_pattern)
 end
 
 runner.pause()

--- a/devel/luacov.lua
+++ b/devel/luacov.lua
@@ -1,0 +1,93 @@
+-- Lua script coverage report generator
+
+local help_message =
+[====[
+Lua script coverage report generator
+
+Usage:
+    luacov [options] [pattern...]
+
+This script generates a coverage report from collected statistics. By default it
+reports on every Lua file in all of DFHack. To filter filenames, specify one or
+more Lua patterns matching files to be included. Alternately, you can configure
+reporting parameters in the .luacov file in your DF directory. See online luacov
+documentation for the format of that file.
+
+Statistics are cumulative across reports. That is, if you run a report, run a
+lua script, and then run another report, the report will include all activity
+from the first report plus the recently run lua script. Restarting DFHack will
+clear the statistics. You can also clear statistics from previous reports while
+DFHack is running by deleting the "luacov.stats.out" file in your DF folder.
+
+Note that the coverage report will be empty unless you run DFHack with the
+"DFHACK_ENABLE_LUACOV" environment variable defined, which starts the coverage
+monitoring.
+
+Also note that coverage monitoring and lua profiling via the "profiler" module
+cannot both be active at the same time. Their interceptor hooks override each
+other. Usage of the "kill-lua" command will likewise override the luacov
+interceptor hook and prevent coverage statistics from being collected.
+
+Options:
+
+-h, --help
+    Show this help message and exit.
+
+Examples:
+
+devel/luacov
+     Report on all DFHack lua scripts.
+devel/luacov quickfort
+    Report only on quickfort source files.
+devel/luacov quickfort hack/lua
+    Report only on quickfort and DFHack library lua source files.
+]====]
+
+local utils = require('utils')
+local runner = require("luacov.runner")
+
+local show_help = false
+local other_args = utils.processArgsGetopt({...}, {
+        {'h', 'help', handler=function() show_help = true end},
+    })
+if show_help then
+    dfhack.print(string.format('LuaCov %s - ', runner.version))
+    print(help_message)
+    return
+end
+
+if not runner.initialized then
+    dfhack.printerr(
+        'Warning: Coverage stats are not being collected. Report will be' ..
+        ' empty. Please run dfhack with the DFHACK_ENABLE_LUACOV environment' ..
+        ' variable defined to start coverage monitoring.')
+end
+
+-- gets the active luacov configuration
+local configuration = runner.load_config()
+
+-- save the original include table since this script can mutate it when run with
+-- parameters, but we need to restore the original values when this script is
+-- subsequently run without parameters.
+default_include = default_include or configuration.include or {}
+configuration.include = #other_args == 0 and default_include or {}
+
+-- override 'include' table if patterns were explicitly specified
+for _,pattern in ipairs(other_args) do
+    table.insert(configuration.include,
+                (pattern:gsub("\\", "/"):gsub("%.lua$", "")))
+end
+
+print('flushing accumulated stats')
+runner.save_stats()
+
+print(string.format('generating report in "%s" for files matching:',
+                    configuration.reportfile))
+if #configuration.include == 0 then
+    print('  all')
+else
+    for _,pattern in ipairs(configuration.include) do
+        print(('  %s'):format(pattern))
+    end
+end
+runner.run_report(configuration)

--- a/devel/luacov.lua
+++ b/devel/luacov.lua
@@ -59,8 +59,9 @@ end
 if not runner.initialized then
     dfhack.printerr(
         'Warning: Coverage stats are not being collected. Report will be' ..
-        ' empty. Please run dfhack with the DFHACK_ENABLE_LUACOV environment' ..
-        ' variable defined to start coverage monitoring.')
+        ' empty unless stats were collected in a previous run. Please run' ..
+        ' dfhack with the DFHACK_ENABLE_LUACOV environment variable defined' ..
+        ' to start coverage monitoring.')
 end
 
 -- gets the active luacov configuration

--- a/devel/luacov.lua
+++ b/devel/luacov.lua
@@ -78,8 +78,7 @@ local config = runner.load_config()
 -- config when run with parameters, but we need to restore the original values
 -- when this script is subsequently run without parameters.
 default_include = default_include or config.include or {}
-default_clear = default_clear ~= nil and default_clear or
-        config.deletestats or false
+if default_clear == nil then default_clear = config.deletestats or false end
 
 -- override 'include' table if patterns were explicitly specified
 config.include = #other_args == 0 and default_include or {}
@@ -102,21 +101,20 @@ runner.pause()
 dfhack.with_finalize(
     function() runner.resume() end,
     function()
-        print(string.format('flushing accumulated stats to "%s"',
-                            config.statsfile))
+        print(('flushing coverage stats to "%s"'):format(config.statsfile))
         runner.save_stats()
 
-        print(string.format('generating report in "%s" for files matching:',
-                            config.reportfile))
+        print(('generating report in "%s" for files matching:'):format(
+                config.reportfile))
         if #config.include == 0 then
-            print('  all')
+            print('  .*')
         else
             for _,pattern in ipairs(config.include) do
                 print(('  %s'):format(pattern))
             end
         end
-        print(string.format('and %s accumulated stats in "%s"',
-                            config.deletestats and 'removing' or 'keeping',
-                            config.statsfile))
+        print(('and %s accumulated stats in "%s"'):format(
+                config.deletestats and 'removing' or 'keeping',
+                config.statsfile))
         runner.run_report(config)
     end)

--- a/devel/luacov.lua
+++ b/devel/luacov.lua
@@ -30,6 +30,9 @@ interceptor hook and prevent coverage statistics from being collected.
 
 Options:
 
+-c, --clear
+    Remove "luacov.stats.out" after generating the report, ensuring the next
+    report starts from a clean slate.
 -h, --help
     Show this help message and exit.
 
@@ -46,8 +49,9 @@ devel/luacov quickfort hack/lua
 local utils = require('utils')
 local runner = require("luacov.runner")
 
-local show_help = false
+local clear, show_help = false, false
 local other_args = utils.processArgsGetopt({...}, {
+        {'c', 'clear', handler=function() clear = true end},
         {'h', 'help', handler=function() show_help = true end},
     })
 if show_help then
@@ -103,4 +107,12 @@ dfhack.with_finalize(
             end
         end
         runner.run_report(configuration)
+        if clear then
+            print(string.format('removing accumulated stats in "%s"',
+                                configuration.statsfile))
+            os.remove(configuration.statsfile)
+        else
+            print(string.format('allowing further stats to accumulate in "%s"',
+                                configuration.statsfile))
+        end
     end)

--- a/devel/luacov.lua
+++ b/devel/luacov.lua
@@ -9,18 +9,18 @@ Usage:
 
 This script generates a coverage report from collected statistics. By default it
 reports on every Lua file in all of DFHack. To filter filenames, specify one or
-more Lua patterns matching files to be included. Alternately, you can configure
-reporting parameters in the .luacov file in your DF directory. See online luacov
-documentation for the format of that file.
+more Lua patterns matching files or directories to be included. Alternately, you
+can configure reporting parameters in the .luacov file in your DF directory. See
+online luacov documentation for the format of that file.
 
 Statistics are cumulative across reports. That is, if you run a report, run a
 lua script, and then run another report, the report will include all activity
 from the first report plus the recently run lua script. Restarting DFHack will
-clear the statistics. You can also clear statistics from previous reports while
-DFHack is running by deleting the "luacov.stats.out" file in your DF folder.
+clear the statistics. You can also clear statistics after running a report by
+passing the --clear flag to this script.
 
 Note that the coverage report will be empty unless you run DFHack with the
-"DFHACK_ENABLE_LUACOV" environment variable defined, which starts the coverage
+"DFHACK_ENABLE_LUACOV=1" environment variable defined, which starts the coverage
 monitoring.
 
 Also note that coverage monitoring and lua profiling via the "profiler" module


### PR DESCRIPTION
DFHack/dfhack#1690

highly modified version of https://github.com/keplerproject/luacov/blob/master/src/bin/luacov that integrates with DFHack facilities and provides a better user interface for report generation.

depends on DFHack/dfhack#1787 for luacov and of course won't produce any actual reports until the DFHACK_ENABLE_LUACOV environment variable is handled in DFHack/dfhack#1789 (this PR needs to be merge before 1789, though, since that PR needs the `devel/luacov` doc header from this PR).

luacov produces text-based coverage reports by default. eventually I plan to investigate integrating with [luacov-reporter-lcov](https://github.com/daurnimator/luacov-reporter-lcov) for HTML report generation via [lcov](https://github.com/linux-test-project/lcov) (but this will require that developers separately install lcov).