### PR TITLE
[test] install scripts/test into hack/scripts/test/scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                        PATTERN "scripts/test" EXCLUDE
 )
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test/
-        DESTINATION ${DFHACK_DATA_DESTINATION}/scripts/test/scripts
-)
+if(BUILD_TESTS)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test/
+            DESTINATION ${DFHACK_DATA_DESTINATION}/scripts/test/scripts
+    )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,3 +6,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                        PATTERN "3rdparty" EXCLUDE
                        PATTERN "scripts/test" EXCLUDE
 )
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test/
+        DESTINATION ${DFHACK_DATA_DESTINATION}/scripts/test/scripts
+)

--- a/changelog.txt
+++ b/changelog.txt
@@ -53,6 +53,9 @@ that repo.
 - `setfps`: improved error handling
 - `unretire-anyone`: the historical figure selection list now includes the ``SYN_NAME`` (necromancer, vampire, etc) of figures where applicable
 
+## Internals
+- Install tests in the scripts repo into hack/scripts/test/scripts when the CMake variable BUILD_TESTS is defined
+
 # 0.47.05-r1
 
 ## Misc Improvements

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,9 @@ that repo.
 ## Fixes
 - `quickfort`: allow machines (e.g. screw pumps) to be built on ramps just like DF allows
 
+## Internals
+- Install tests in the scripts repo into hack/scripts/test/scripts when the CMake variable BUILD_TESTS is defined
+
 # 0.47.05-r2
 
 ## New Scripts
@@ -52,9 +55,6 @@ that repo.
 - `quickfort`: made more quiet when the ``--quiet`` parameter is specified
 - `setfps`: improved error handling
 - `unretire-anyone`: the historical figure selection list now includes the ``SYN_NAME`` (necromancer, vampire, etc) of figures where applicable
-
-## Internals
-- Install tests in the scripts repo into hack/scripts/test/scripts when the CMake variable BUILD_TESTS is defined
 
 # 0.47.05-r1
 


### PR DESCRIPTION
Fixes DFHack/dfhack#1690

Before we merge any scripts tests into the repo, there is one problem I think we need to solve.

Currently, automated CI tests are only run for DFHack/dfhack PRs. This means that a bad test can get checked into DFHack/scripts without blocking the PR that it's a part of, and once the scripts module gets updated in DFHack/dfhack, the bad test will block the next (likely unrelated) PR in DFHack/dfhack. This would be very frustrating for contributors to DFHack/dfhack since they would not be able to do anything about the failures blocking their PRs.

Can we implement test runs for the scripts repo? Or are there other ways to prevent bad tests from getting into the codebase?

Merging the scripts repo back into dfhack would solve the problem, of course, but then the current separation of access controls would be lost.