### PR TITLE
[test] don't install scripts/test files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,4 +4,5 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                        PATTERN "*.rb"
                        PATTERN "*.json"
                        PATTERN "3rdparty" EXCLUDE
+                       PATTERN "scripts/test" EXCLUDE
 )


### PR DESCRIPTION
this will prevent script tests from being installed. this will allow tests to be merged to master without letting them affect CI in DFHack/dfhack. once we get CI figured out for DFHack/scripts, then we can enable installation of the tests in #262 

DFHack/dfhack#1690