### PR TITLE
Add usage to setfps.lua

### DIFF
--- a/setfps.lua
+++ b/setfps.lua
@@ -15,6 +15,10 @@ Usage::
 local cap = ...
 local capnum = tonumber(cap)
 
+if not cap or cap=='-help' then
+	qerror('Usage:\n\tsetfps <number>')
+end
+
 if not capnum or capnum < 1 then
     qerror('Invalid FPS cap value: '..cap)
 end

--- a/setfps.lua
+++ b/setfps.lua
@@ -16,7 +16,7 @@ local cap = ...
 local capnum = tonumber(cap)
 
 if not cap or cap=='-help' then
-	qerror('Usage:\n\tsetfps <number>')
+    qerror('Usage:\n\tsetfps <number>')
 end
 
 if not capnum or capnum < 1 then


### PR DESCRIPTION
Add usage to setfps when called without an argument (or with `-help`). 

Current script produces a traceback error:
```D:\Desktop\DF\df_47_05_win/hack/scripts/setfps.lua:19: attempt to concatenate a nil value (local 'cap')
stack traceback:
        D:\Desktop\DF\df_47_05_win/hack/scripts/setfps.lua:19: in local 'script_code'
        D:\Desktop\DF\df_47_05_win\hack\lua\dfhack.lua:680: in function 'dfhack.run_script_with_env'
        (...tail calls...)```