### PR TITLE
[quickfort] refactor quickfort/building and add unit tests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ that repo.
 - `quickfort`: comments in blueprint cells no longer prevent the rest of the row from being read. a cell with a single '#' marker in it, though, will still stop the parser from reading further in the row
 - `quickfort`: fix off-by-one line number accounting in blueprints with implicit #dig modelines
 - `quickfort`: properly detect and error on sub-alias params with no values instead of just failing to apply the alias later (if you really want an empty value, use ``{Empty}`` instead)
+- `quickfort`: improve handling of non-rectangular and non-solid extent-based structures (like fancy-shaped stockpiles and farm plots)
 
 ## Misc Improvements
 - `devel/annc-monitor`: added ``report enable|disable`` subcommand to filter combat reports

--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -20,7 +20,6 @@ local utils = require('utils')
 local buildingplan = require('plugins.buildingplan')
 local quickfort_common = reqscript('internal/quickfort/common')
 local quickfort_building = reqscript('internal/quickfort/building')
-local quickfort_map = reqscript('internal/quickfort/map')
 local quickfort_orders = reqscript('internal/quickfort/orders')
 
 local log = quickfort_common.log
@@ -31,6 +30,7 @@ local log = quickfort_common.log
 
 local function is_valid_tile_base(pos)
     local flags, occupancy = dfhack.maps.getTileFlags(pos)
+    if not flags then return false end
     return not flags.hidden and occupancy.building == 0
 end
 
@@ -89,9 +89,9 @@ local function is_valid_tile_construction(pos)
 end
 
 local function is_shape_at(pos, allowed_shapes)
-    if not quickfort_map.is_within_map_bounds(pos) and
-            not quickfort_map.is_on_map_edge(pos) then return false end
-    return allowed_shapes[df.tiletype.attrs[dfhack.maps.getTileType(pos)].shape]
+    local tiletype = dfhack.maps.getTileType(pos)
+    if not tiletype then return false end
+    return allowed_shapes[df.tiletype.attrs[tiletype].shape]
 end
 
 -- for doors
@@ -778,7 +778,7 @@ function do_run(zlevel, grid, ctx)
                 zlevel, grid, buildings, building_db, building_aliases)
     stats.out_of_bounds.value =
             stats.out_of_bounds.value + quickfort_building.crop_to_bounds(
-                buildings, building_db)
+                ctx, buildings, building_db)
     stats.build_unsuitable.value =
             stats.build_unsuitable.value +
             quickfort_building.check_tiles_and_extents(

--- a/internal/quickfort/dig.lua
+++ b/internal/quickfort/dig.lua
@@ -170,145 +170,146 @@ local values_undo = {
 }
 
 -- these functions return a function if a designation needs to be made; else nil
-local function do_mine(ctx)
-    if ctx.on_map_edge then return nil end
-    if not ctx.flags.hidden then -- always designate if the tile is hidden
-        if is_construction(ctx.tileattrs) or
-                (not is_wall(ctx.tileattrs) and
-                 not is_fortification(ctx.tileattrs)) then
+local function do_mine(digctx)
+    if digctx.on_map_edge then return nil end
+    if not digctx.flags.hidden then -- always designate if the tile is hidden
+        if is_construction(digctx.tileattrs) or
+                (not is_wall(digctx.tileattrs) and
+                 not is_fortification(digctx.tileattrs)) then
             return nil
         end
     end
-    return function() ctx.flags.dig = values.dig_default end
+    return function() digctx.flags.dig = values.dig_default end
 end
 
-local function do_channel(ctx)
-    if ctx.on_map_edge then return nil end
-    if not ctx.flags.hidden then -- always designate if the tile is hidden
-        if is_construction(ctx.tileattrs) or
-                is_tree(ctx.tileattrs) or
-                (not is_wall(ctx.tileattrs) and
-                 not is_fortification(ctx.tileattrs) and
-                 not is_diggable_floor(ctx.tileattrs) and
-                 not is_down_stair(ctx.tileattrs) and
-                 not is_removable_shape(ctx.tileattrs) and
-                 not is_gatherable(ctx.tileattrs) and
-                 not is_sapling(ctx.tileattrs)) then
+local function do_channel(digctx)
+    if digctx.on_map_edge then return nil end
+    if not digctx.flags.hidden then -- always designate if the tile is hidden
+        if is_construction(digctx.tileattrs) or
+                is_tree(digctx.tileattrs) or
+                (not is_wall(digctx.tileattrs) and
+                 not is_fortification(digctx.tileattrs) and
+                 not is_diggable_floor(digctx.tileattrs) and
+                 not is_down_stair(digctx.tileattrs) and
+                 not is_removable_shape(digctx.tileattrs) and
+                 not is_gatherable(digctx.tileattrs) and
+                 not is_sapling(digctx.tileattrs)) then
             return nil
         end
     end
-    return function() ctx.flags.dig = values.dig_channel end
+    return function() digctx.flags.dig = values.dig_channel end
 end
 
-local function do_up_stair(ctx)
-    if ctx.on_map_edge then return nil end
-    if not ctx.flags.hidden then -- always designate if the tile is hidden
-        if is_construction(ctx.tileattrs) or
-                (not is_wall(ctx.tileattrs) and
-                 not is_fortification(ctx.tileattrs)) then
+local function do_up_stair(digctx)
+    if digctx.on_map_edge then return nil end
+    if not digctx.flags.hidden then -- always designate if the tile is hidden
+        if is_construction(digctx.tileattrs) or
+                (not is_wall(digctx.tileattrs) and
+                 not is_fortification(digctx.tileattrs)) then
             return nil
         end
     end
-    return function() ctx.flags.dig = values.dig_upstair end
+    return function() digctx.flags.dig = values.dig_upstair end
 end
 
-local function do_down_stair(ctx)
-    if ctx.on_map_edge then return nil end
-    if not ctx.flags.hidden then -- always designate if the tile is hidden
-        if is_construction(ctx.tileattrs) or
-                is_tree(ctx.tileattrs) or
-                (not is_wall(ctx.tileattrs) and
-                 not is_fortification(ctx.tileattrs) and
-                 not is_diggable_floor(ctx.tileattrs) and
-                 not is_removable_shape(ctx.tileattrs) and
-                 not is_gatherable(ctx.tileattrs) and
-                 not is_sapling(ctx.tileattrs)) then
+local function do_down_stair(digctx)
+    if digctx.on_map_edge then return nil end
+    if not digctx.flags.hidden then -- always designate if the tile is hidden
+        if is_construction(digctx.tileattrs) or
+                is_tree(digctx.tileattrs) or
+                (not is_wall(digctx.tileattrs) and
+                 not is_fortification(digctx.tileattrs) and
+                 not is_diggable_floor(digctx.tileattrs) and
+                 not is_removable_shape(digctx.tileattrs) and
+                 not is_gatherable(digctx.tileattrs) and
+                 not is_sapling(digctx.tileattrs)) then
             return nil
         end
     end
-    return function() ctx.flags.dig = values.dig_downstair end
+    return function() digctx.flags.dig = values.dig_downstair end
 end
 
-local function do_up_down_stair(ctx)
-    if ctx.on_map_edge then return nil end
-    if not ctx.flags.hidden then -- always designate if the tile is hidden
-        if is_construction(ctx.tileattrs) or
-                (not is_wall(ctx.tileattrs) and
-                 not is_fortification(ctx.tileattrs) and
-                 not is_up_stair(ctx.tileattrs)) then
+local function do_up_down_stair(digctx)
+    if digctx.on_map_edge then return nil end
+    if not digctx.flags.hidden then -- always designate if the tile is hidden
+        if is_construction(digctx.tileattrs) or
+                (not is_wall(digctx.tileattrs) and
+                 not is_fortification(digctx.tileattrs) and
+                 not is_up_stair(digctx.tileattrs)) then
             return nil
         end
     end
-    if is_up_stair(ctx.tileattrs) then
-        return function() ctx.flags.dig = values.dig_downstair end
+    if is_up_stair(digctx.tileattrs) then
+        return function() digctx.flags.dig = values.dig_downstair end
     end
-    return function() ctx.flags.dig = values.dig_updownstair end
+    return function() digctx.flags.dig = values.dig_updownstair end
 end
 
-local function do_ramp(ctx)
-    if ctx.on_map_edge then return nil end
-    if not ctx.flags.hidden then -- always designate if the tile is hidden
-        if is_construction(ctx.tileattrs) or
-                (not is_wall(ctx.tileattrs) and
-                 not is_fortification(ctx.tileattrs)) then
+local function do_ramp(digctx)
+    if digctx.on_map_edge then return nil end
+    if not digctx.flags.hidden then -- always designate if the tile is hidden
+        if is_construction(digctx.tileattrs) or
+                (not is_wall(digctx.tileattrs) and
+                 not is_fortification(digctx.tileattrs)) then
             return nil
         end
     end
-    return function() ctx.flags.dig = values.dig_ramp end
+    return function() digctx.flags.dig = values.dig_ramp end
 end
 
-local function do_remove_ramps(ctx)
-    if ctx.on_map_edge or ctx.flags.hidden then return nil end
-    if is_construction(ctx.tileattrs) or
-            not is_removable_shape(ctx.tileattrs) then
+local function do_remove_ramps(digctx)
+    if digctx.on_map_edge or digctx.flags.hidden then return nil end
+    if is_construction(digctx.tileattrs) or
+            not is_removable_shape(digctx.tileattrs) then
         return mo;
     end
-    return function() ctx.flags.dig = values.dig_default end
+    return function() digctx.flags.dig = values.dig_default end
 end
 
-local function do_gather(ctx)
-    if ctx.flags.hidden then return nil end
-    if not is_gatherable(ctx.tileattrs) then return nil end
-    return function() ctx.flags.dig = values.dig_default end
+local function do_gather(digctx)
+    if digctx.flags.hidden then return nil end
+    if not is_gatherable(digctx.tileattrs) then return nil end
+    return function() digctx.flags.dig = values.dig_default end
 end
 
-local function do_smooth(ctx)
-    if ctx.flags.hidden then return nil end
-    if is_construction(ctx.tileattrs) or
-            not is_hard(ctx.tileattrs) or
-            is_smooth(ctx.tileattrs) or
-            (not is_floor(ctx.tileattrs) and not is_wall(ctx.tileattrs)) then
+local function do_smooth(digctx)
+    if digctx.flags.hidden then return nil end
+    if is_construction(digctx.tileattrs) or
+            not is_hard(digctx.tileattrs) or
+            is_smooth(digctx.tileattrs) or
+            (not is_floor(digctx.tileattrs) and
+             not is_wall(digctx.tileattrs)) then
         return nil
     end
-    return function() ctx.flags.smooth = values.tile_smooth end
+    return function() digctx.flags.smooth = values.tile_smooth end
 end
 
-local function do_engrave(ctx)
-    if ctx.flags.hidden or
-            is_construction(ctx.tileattrs) or
-            not is_smooth(ctx.tileattrs) or
-            get_engraving(ctx.pos) ~= nil then
+local function do_engrave(digctx)
+    if digctx.flags.hidden or
+            is_construction(digctx.tileattrs) or
+            not is_smooth(digctx.tileattrs) or
+            get_engraving(digctx.pos) ~= nil then
         return nil
     end
-    return function() ctx.flags.smooth = values.tile_engrave end
+    return function() digctx.flags.smooth = values.tile_engrave end
 end
 
-local function do_fortification(ctx)
-    if ctx.flags.hidden then return nil end
-    if not is_wall(ctx.tileattrs) or
-            not is_smooth(ctx.tileattrs) then return nil end
-    return function() ctx.flags.smooth = values.tile_smooth end
+local function do_fortification(digctx)
+    if digctx.flags.hidden then return nil end
+    if not is_wall(digctx.tileattrs) or
+            not is_smooth(digctx.tileattrs) then return nil end
+    return function() digctx.flags.smooth = values.tile_smooth end
 end
 
-local function do_track(ctx)
-    if ctx.on_map_edge or
-            ctx.flags.hidden or
-            is_construction(ctx.tileattrs) or
-            not is_floor(ctx.tileattrs) or
-            not is_hard(ctx.tileattrs) then
+local function do_track(digctx)
+    if digctx.on_map_edge or
+            digctx.flags.hidden or
+            is_construction(digctx.tileattrs) or
+            not is_floor(digctx.tileattrs) or
+            not is_hard(digctx.tileattrs) then
         return nil
     end
-    local extent_adjacent = ctx.extent_adjacent
+    local extent_adjacent = digctx.extent_adjacent
     if not extent_adjacent.north and not  extent_adjacent.south and
             not extent_adjacent.east and not extent_adjacent.west then
         print('ambiguous direction for track; please use T(width x height)' ..
@@ -323,7 +324,7 @@ local function do_track(ctx)
     end
     -- don't overwrite all directions, only 'or' in the new bits. we could be
     -- adding to a previously-designated track.
-    local occupancy = ctx.occupancy
+    local occupancy = digctx.occupancy
     return function()
     if extent_adjacent.north then occupancy.carve_track_north = values.track end
     if extent_adjacent.east then occupancy.carve_track_east = values.track end
@@ -332,29 +333,29 @@ local function do_track(ctx)
     end
 end
 
-local function do_toggle_engravings(ctx)
-    if ctx.flags.hidden then return nil end
-    local engraving = get_engraving(ctx.pos)
+local function do_toggle_engravings(digctx)
+    if digctx.flags.hidden then return nil end
+    local engraving = get_engraving(digctx.pos)
     if engraving == nil then return nil end
     return function() engraving.flags.hidden = not engraving.flags.hidden end
 end
 
-local function do_toggle_marker(ctx)
-    if not has_designation(ctx.flags, ctx.occupancy) then return nil end
+local function do_toggle_marker(digctx)
+    if not has_designation(digctx.flags, digctx.occupancy) then return nil end
     return function()
-        ctx.occupancy.dig_marked = not ctx.occupancy.dig_marked end
+        digctx.occupancy.dig_marked = not digctx.occupancy.dig_marked end
 end
 
-local function do_remove_construction(ctx)
-    if ctx.flags.hidden or not is_construction(ctx.tileattrs) then
+local function do_remove_construction(digctx)
+    if digctx.flags.hidden or not is_construction(digctx.tileattrs) then
         return nil
     end
-    return function() ctx.flags.dig = values.dig_default end
+    return function() digctx.flags.dig = values.dig_default end
 end
 
-local function do_remove_designation(ctx)
-    if not has_designation(ctx.flags, ctx.occupancy) then return nil end
-    return function() clear_designation(ctx.flags, ctx.occupancy) end
+local function do_remove_designation(digctx)
+    if not has_designation(digctx.flags, digctx.occupancy) then return nil end
+    return function() clear_designation(digctx.flags, digctx.occupancy) end
 end
 
 local function is_valid_item(item)
@@ -391,58 +392,58 @@ local function do_item_flag(pos, flag_name, flag_value, include_buildings)
     end
 end
 
-local function do_claim(ctx)
-    return do_item_flag(ctx.pos, "forbid", values.item_claimed, true)
+local function do_claim(digctx)
+    return do_item_flag(digctx.pos, "forbid", values.item_claimed, true)
 end
 
-local function do_forbid(ctx)
-    return do_item_flag(ctx.pos, "forbid", values.item_forbidden, true)
+local function do_forbid(digctx)
+    return do_item_flag(digctx.pos, "forbid", values.item_forbidden, true)
 end
 
-local function do_melt(ctx)
+local function do_melt(digctx)
     -- the game appears to autoremove the flag from unmeltable items, so we
     -- don't actually need to do any filtering here
-    return do_item_flag(ctx.pos, "melt", values.item_melted, false)
+    return do_item_flag(digctx.pos, "melt", values.item_melted, false)
 end
 
-local function do_remove_melt(ctx)
-    return do_item_flag(ctx.pos, "melt", values.item_unmelted, false)
+local function do_remove_melt(digctx)
+    return do_item_flag(digctx.pos, "melt", values.item_unmelted, false)
 end
 
-local function do_dump(ctx)
-    return do_item_flag(ctx.pos, "dump", values.item_dumped, false)
+local function do_dump(digctx)
+    return do_item_flag(digctx.pos, "dump", values.item_dumped, false)
 end
 
-local function do_remove_dump(ctx)
-    return do_item_flag(ctx.pos, "dump", values.item_undumped, false)
+local function do_remove_dump(digctx)
+    return do_item_flag(digctx.pos, "dump", values.item_undumped, false)
 end
 
-local function do_hide(ctx)
-    return do_item_flag(ctx.pos, "hidden", values.item_hidden, true)
+local function do_hide(digctx)
+    return do_item_flag(digctx.pos, "hidden", values.item_hidden, true)
 end
 
-local function do_unhide(ctx)
-    return do_item_flag(ctx.pos, "hidden", values.item_unhidden, true)
+local function do_unhide(digctx)
+    return do_item_flag(digctx.pos, "hidden", values.item_unhidden, true)
 end
 
-local function do_traffic_high(ctx)
-    if ctx.flags.hidden then return nil end
-    return function() ctx.flags.traffic = values.traffic_high end
+local function do_traffic_high(digctx)
+    if digctx.flags.hidden then return nil end
+    return function() digctx.flags.traffic = values.traffic_high end
 end
 
-local function do_traffic_normal(ctx)
-    if ctx.flags.hidden then return nil end
-    return function() ctx.flags.traffic = values.traffic_normal end
+local function do_traffic_normal(digctx)
+    if digctx.flags.hidden then return nil end
+    return function() digctx.flags.traffic = values.traffic_normal end
 end
 
-local function do_traffic_low(ctx)
-    if ctx.flags.hidden then return nil end
-    return function() ctx.flags.traffic = values.traffic_low end
+local function do_traffic_low(digctx)
+    if digctx.flags.hidden then return nil end
+    return function() digctx.flags.traffic = values.traffic_low end
 end
 
-local function do_traffic_restricted(ctx)
-    if ctx.flags.hidden then return nil end
-    return function() ctx.flags.traffic = values.traffic_restricted end
+local function do_traffic_restricted(digctx)
+    if digctx.flags.hidden then return nil end
+    return function() digctx.flags.traffic = values.traffic_restricted end
 end
 
 local dig_db = {
@@ -524,46 +525,48 @@ end
 
 -- modifies any existing priority block_square_event to the specified priority.
 -- if the block_square_event doesn't already exist, create it.
-local function set_priority(ctx, priority)
+local function set_priority(digctx, priority)
     log('setting priority to %d', priority)
-    local block_events = dfhack.maps.getTileBlock(ctx.pos).block_events
+    local block_events = dfhack.maps.getTileBlock(digctx.pos).block_events
     local pbse = get_priority_block_square_event(block_events)
     if not pbse then
         block_events:insert('#',
                             {new=df.block_square_event_designation_priorityst})
         pbse = block_events[#block_events-1]
     end
-    pbse.priority[ctx.pos.x % 16][ctx.pos.y % 16] = priority * 1000
+    pbse.priority[digctx.pos.x % 16][digctx.pos.y % 16] = priority * 1000
 end
 
-local function dig_tile(ctx, db_entry)
-    ctx.flags, ctx.occupancy = dfhack.maps.getTileFlags(ctx.pos)
-    ctx.tileattrs = df.tiletype.attrs[dfhack.maps.getTileType(ctx.pos)]
-    local action_fn = db_entry.action(ctx)
+local function dig_tile(digctx, db_entry)
+    digctx.flags, digctx.occupancy = dfhack.maps.getTileFlags(digctx.pos)
+    digctx.tileattrs = df.tiletype.attrs[dfhack.maps.getTileType(digctx.pos)]
+    local action_fn = db_entry.action(digctx)
     if not action_fn then return nil end
     return function()
         action_fn()
         -- set the block's designated flag so the game does a check to see what
         -- jobs need to be created
-        dfhack.maps.getTileBlock(ctx.pos).flags.designated = true
-        if not has_designation(ctx.flags, ctx.occupancy) then
+        dfhack.maps.getTileBlock(digctx.pos).flags.designated = true
+        if not has_designation(digctx.flags, digctx.occupancy) then
             -- reset marker mode and priority to defaults
-            ctx.occupancy.dig_marked = false
-            set_priority(ctx, 4)
+            digctx.occupancy.dig_marked = false
+            set_priority(digctx, 4)
         else
             if not db_entry.skip_marker_mode then
                 local marker_mode = db_entry.marker_mode or
                         quickfort_common.settings['force_marker_mode'].value
-                ctx.occupancy.dig_marked = marker_mode
+                digctx.occupancy.dig_marked = marker_mode
             end
             if db_entry.use_priority then
-                set_priority(ctx, db_entry.priority)
+                set_priority(digctx, db_entry.priority)
             end
         end
     end
 end
 
-local function do_run_impl(zlevel, grid, stats, dry_run)
+local function do_run_impl(zlevel, grid, ctx)
+    local stats = ctx.stats
+    local bounds = ctx.bounds or quickfort_map.MapBoundsChecker{}
     for y, row in pairs(grid) do
         for x, cell_and_text in pairs(row) do
             local cell, text = cell_and_text.cell, cell_and_text.text
@@ -591,20 +594,20 @@ local function do_run_impl(zlevel, grid, stats, dry_run)
                         south=extent_y<extent.height,
                         west=extent_x>1,
                     }
-                    local ctx = {
+                    local digctx = {
                         pos=extent_pos,
                         extent_adjacent=extent_adjacent,
-                        on_map_edge=quickfort_map.is_on_map_edge(extent_pos)
+                        on_map_edge=bounds:is_on_map_edge(extent_pos)
                     }
-                    if not quickfort_map.is_within_map_bounds(ctx.pos) and
-                            not ctx.on_map_edge then
+                    if not bounds:is_within_map_bounds(digctx.pos) and
+                            not digctx.on_map_edge then
                         log('coordinates out of bounds; skipping')
                         stats.out_of_bounds.value =
                                 stats.out_of_bounds.value + 1
                     else
-                        local action_fn = dig_tile(ctx, db_entry)
+                        local action_fn = dig_tile(digctx, db_entry)
                         if action_fn then
-                            if not dry_run then action_fn() end
+                            if not ctx.dry_run then action_fn() end
                             stats.dig_designated.value =
                                     stats.dig_designated.value + 1
                         end
@@ -620,9 +623,8 @@ function do_run(zlevel, grid, ctx)
     values = values_run
     ctx.stats.dig_designated = ctx.stats.dig_designated or
             {label='Tiles designated for digging', value=0, always=true}
-    local dry_run = ctx.dry_run
-    do_run_impl(zlevel, grid, ctx.stats, dry_run)
-    if not dry_run then dfhack.job.checkDesignationsNow() end
+    do_run_impl(zlevel, grid, ctx)
+    if not ctx.dry_run then dfhack.job.checkDesignationsNow() end
 end
 
 function do_orders()
@@ -633,5 +635,5 @@ function do_undo(zlevel, grid, ctx)
     values = values_undo
     ctx.stats.dig_designated = ctx.stats.dig_designated or
             {label='Tiles undesignated for digging', value=0, always=true}
-    do_run_impl(zlevel, grid, ctx.stats, ctx.dry_run)
+    do_run_impl(zlevel, grid, ctx)
 end

--- a/internal/quickfort/place.lua
+++ b/internal/quickfort/place.lua
@@ -236,7 +236,7 @@ function do_run(zlevel, grid, ctx)
                 zlevel, grid, stockpiles, stockpile_db)
     stats.out_of_bounds.value =
             stats.out_of_bounds.value + quickfort_building.crop_to_bounds(
-                stockpiles, stockpile_db)
+                ctx, stockpiles, stockpile_db)
     stats.place_occupied.value =
             stats.place_occupied.value +
             quickfort_building.check_tiles_and_extents(

--- a/internal/quickfort/zone.lua
+++ b/internal/quickfort/zone.lua
@@ -225,7 +225,7 @@ function do_run(zlevel, grid, ctx)
                 zlevel, grid, zones, zone_db)
     stats.out_of_bounds.value =
             stats.out_of_bounds.value + quickfort_building.crop_to_bounds(
-                zones, zone_db)
+                ctx, zones, zone_db)
     stats.zone_occupied.value =
             stats.zone_occupied.value +
             quickfort_building.check_tiles_and_extents(

--- a/test/quickfort/building_unit.lua
+++ b/test/quickfort/building_unit.lua
@@ -455,11 +455,7 @@ function test.clear_building()
     expect.table_eq({width=0, height=0, extent_grid={}, canary='bird'}, bld)
 end
 
--- crop_to_bounds test generator. we generate top-level tests instead of just
--- having multiple checks within a single test because the checks occur in a
--- helper function. if we didn't generate separate tests for the cases, we
--- wouldn't be able to tell which test is failing.
-do
+function test.crop_to_bounds()
     local ctx = {bounds=quickfort_map.MapBoundsChecker{dims={x=3,y=3,z=1}}}
     local db = {a={min_width=1, min_height=1},
                 b={min_width=3, min_height=3}}
@@ -479,24 +475,23 @@ do
         }
     end
 
-    local function make_crop_to_bounds_tests(type, bitmap, tests)
+    local function do_crop_to_bounds_tests(type, bitmap, tests)
         for _,t in ipairs(tests) do
-            test['crop_to_bounds_'..t.name] = function()
-                local buildings = get_buildings(
-                    type, bitmap, t.xmod or 0, t.ymod or 0, t.zmod or 0)
-                expect.eq(t.expected_cropped,
-                          b.crop_to_bounds(ctx, buildings, db))
+            local buildings = get_buildings(
+                type, bitmap, t.xmod or 0, t.ymod or 0, t.zmod or 0)
+            expect.eq(t.expected_cropped,
+                      b.crop_to_bounds(ctx, buildings, db),
+                      t.name)
 
-                local expected_building = copyall(t.expected_building or {})
-                expected_building.type = type
-                expected_building.cells = {'A1'}
-                if not expected_building.pos then
-                    expected_building.width = 0
-                    expected_building.height = 0
-                    expected_building.extent_grid = {}
-                end
-                expect.table_eq({expected_building}, buildings)
+            local expected_building = copyall(t.expected_building or {})
+            expected_building.type = type
+            expected_building.cells = {'A1'}
+            if not expected_building.pos then
+                expected_building.width = 0
+                expected_building.height = 0
+                expected_building.extent_grid = {}
             end
+            expect.table_eq({expected_building}, buildings, t.name)
         end
     end
 
@@ -505,7 +500,7 @@ do
         {'a','' ,'a'},
         {'a','' ,'a'},
     }
-    make_crop_to_bounds_tests('a', bitmap, {
+    do_crop_to_bounds_tests('a', bitmap, {
         {name='a1_no_crop', expected_cropped=0,
          expected_building={width=3, height=3, pos={x=0, y=0, z=0},
                             extent_grid={[1]={[1]=true,[2]=true,[3]=true},
@@ -555,7 +550,7 @@ do
         {'a','' ,'a'},
         {'a','a','a'},
     }
-    make_crop_to_bounds_tests('a', bitmap, {
+    do_crop_to_bounds_tests('a', bitmap, {
         {name='a2_no_crop', expected_cropped=0,
          expected_building={width=3, height=3, pos={x=0, y=0, z=0},
                             extent_grid={[1]={[1]=true,[2]=true,[3]=true},
@@ -605,7 +600,7 @@ do
         {'a','' ,'' },
         {'a','a','a'},
     }
-    make_crop_to_bounds_tests('a', bitmap, {
+    do_crop_to_bounds_tests('a', bitmap, {
         {name='a3_no_crop', expected_cropped=0,
          expected_building={width=3, height=3, pos={x=0, y=0, z=0},
                             extent_grid={[1]={[1]=true,[2]=true,[3]=true},
@@ -657,7 +652,7 @@ do
         {'' ,'' ,'a'},
         {'a','a','a'},
     }
-    make_crop_to_bounds_tests('a', bitmap, {
+    do_crop_to_bounds_tests('a', bitmap, {
         {name='a4_no_crop', expected_cropped=0,
          expected_building={width=3, height=3, pos={x=0, y=0, z=0},
                             extent_grid={[1]={[1]=true,[3]=true},
@@ -709,7 +704,7 @@ do
         {'a','' ,'a'},
         {'' ,'a','' },
     }
-    make_crop_to_bounds_tests('a', bitmap, {
+    do_crop_to_bounds_tests('a', bitmap, {
         {name='a5_no_crop', expected_cropped=0,
          expected_building={width=3, height=3, pos={x=0, y=0, z=0},
                             extent_grid={[1]={[2]=true},
@@ -761,7 +756,7 @@ do
         {'b','b','b'},
         {'b','b','b'},
     }
-    make_crop_to_bounds_tests('b', bitmap, {
+    do_crop_to_bounds_tests('b', bitmap, {
         {name='b_no_crop', expected_cropped=0,
          expected_building={width=3, height=3, pos={x=0, y=0, z=0},
                             extent_grid={[1]={[1]=true,[2]=true,[3]=true},

--- a/test/quickfort/building_unit.lua
+++ b/test/quickfort/building_unit.lua
@@ -1,0 +1,876 @@
+local utils = require('utils')
+local building = reqscript('internal/quickfort/building')
+local quickfort_map = reqscript('internal/quickfort/map')
+local b = building.unit_test_hooks
+
+function test.module()
+    expect.error_match(
+        'this script cannot be called directly',
+        function() dfhack.run_script('internal/quickfort/building') end)
+end
+
+function test.get_digit_count()
+    expect.eq(1, b.get_digit_count(0))
+    expect.eq(1, b.get_digit_count(1))
+    expect.eq(1, b.get_digit_count(9))
+    expect.eq(2, b.get_digit_count(10))
+    expect.eq(2, b.get_digit_count(11))
+    expect.eq(2, b.get_digit_count(99))
+    expect.eq(3, b.get_digit_count(100))
+    expect.eq(3, b.get_digit_count(101))
+end
+
+function test.left_pad()
+    expect.eq(' 1', b.left_pad(1, 1))
+    expect.eq('  1', b.left_pad(1, 2))
+    expect.eq(' 10', b.left_pad(10, 2))
+    expect.eq('    10', b.left_pad(10, 5))
+    expect.eq(' 1000', b.left_pad(1000, 4))
+    expect.eq('  1000', b.left_pad(1000, 5))
+end
+
+function test.dump_seen_grid()
+    local saved_print, lines = building.print, {}
+    building.print = function(line) table.insert(lines, line) end
+    dfhack.with_finalize(
+        function() building.print = saved_print end,
+        function()
+            b.dump_seen_grid{'empty', {}, 0}
+            expect.table_eq({'boundary map (empty):'}, lines)
+
+            lines = {}
+            b.dump_seen_grid{'two ids vert',
+                             {[20]={[10]=1,[11]=1,[12]=1},
+                              [22]={[10]=2,[11]=2,[12]=2}},
+                             2}
+            expect.table_eq(
+                    {'boundary map (two ids vert):',
+                     ' 1   2',' 1   2',' 1   2'},
+                    lines)
+
+            lines = {}
+            b.dump_seen_grid{'two ids horiz',
+                             {[20]={[10]=1,[12]=2},
+                              [21]={[10]=1,[12]=2},
+                              [22]={[10]=1,[12]=2}},
+                             2}
+            expect.table_eq(
+                    {'boundary map (two ids horiz):',
+                     ' 1 1 1','      ',' 2 2 2'},
+                    lines)
+
+            lines = {}
+            b.dump_seen_grid{'ten ids horiz',
+                             {[20]={[10]=1,[12]=10},
+                              [21]={[10]=1,[12]=10},
+                              [22]={[10]=1,[12]=10}},
+                             10}
+            expect.table_eq(
+                    {'boundary map (ten ids horiz):',
+                     '  1  1  1','         ',' 10 10 10'},
+                    lines)
+        end)
+end
+
+function test.flood_fill()
+    -- a D . . .
+    -- e a a . .
+    -- d . a c b(1x1)
+    -- . . . c b
+    -- . . . b b(1x3)
+    local grid = {
+        [20]={[10]={cell='A1',text='a'},
+              [11]={cell='B1',text='D'},
+              [12]=nil,[13]=nil,[14]=nil},
+        [21]={[10]={cell='A2',text='e'},
+              [11]={cell='B2',text='a'},
+              [12]={cell='C2',text='a'},
+              [13]=nil,[14]=nil},
+        [22]={[10]={cell='A3',text='d'},
+              [11]=nil,
+              [12]={cell='C3',text='a'},
+              [13]={cell='D3',text='c'},
+              [14]={cell='E3',text='b(1x1)'}},
+        [23]={[10]=nil,[11]=nil,[12]=nil,
+              [13]={cell='D4',text='c'},
+              [14]={cell='E4',text='b'}},
+        [24]={[10]=nil,[11]=nil,[12]=nil,
+              [13]={cell='D5',text='b'},
+              [14]={cell='E5',text='b(1x3)'}},
+    }
+    local db = utils.invert{'a','b','c','d'}
+    local aliases = {d='a'}
+
+    expect.eq(0, b.flood_fill(grid, 10, 20, {[10]={[20]=1}}, {}, db, aliases))
+    expect.eq(0, b.flood_fill(grid, 1, 1, {}, {}, db, aliases))
+    expect.eq(0, b.flood_fill(grid, 12, 20, {}, {}, db, aliases))
+
+    local seen_grid = {}
+    expect.printerr_match(
+        'invalid key sequence',
+        function()
+            expect.eq(1, b.flood_fill(grid, 10, 21, seen_grid, {}, db, aliases))
+        end)
+    expect.table_eq({[10]={[21]=true}}, seen_grid)
+
+    expect.eq(0, b.flood_fill(grid, 14, 24, {}, {type='z'}, db, aliases))
+    expect.eq(0, b.flood_fill(grid, 14, 24, {}, {type='b'}, db, aliases))
+
+    local data = {id=1, cells={},
+                  x_min=30000, x_max=-30000, y_min=30000, y_max=-30000}
+    seen_grid = {}
+    expect.eq(0, b.flood_fill(grid, 14, 24, seen_grid, data, db, aliases))
+    expect.table_eq({[14]={[24]=1,[25]=1,[26]=1}}, seen_grid)
+    expect.table_eq({id=1, type='b', cells={'E5'},
+                     x_min=14, x_max=14, y_min=24, y_max=26},
+                    data)
+
+    -- from here on down, seen_grid is cumulative across tests
+    data = {id=2, cells={},
+            x_min=30000, x_max=-30000, y_min=30000, y_max=-30000}
+    expect.eq(0, b.flood_fill(grid, 13, 24, seen_grid, data, db, aliases))
+    expect.table_eq({[13]={[24]=2},
+                     [14]={[23]=2,[24]=1,[25]=1,[26]=1}},
+                    seen_grid)
+    expect.table_eq({id=2, type='b', cells={'D5','E4'},
+                     x_min=13, x_max=14, y_min=23, y_max=24},
+                    data)
+
+    data = {id=3, cells={},
+            x_min=30000, x_max=-30000, y_min=30000, y_max=-30000}
+    expect.eq(0, b.flood_fill(grid, 13, 22, seen_grid, data, db, aliases))
+    expect.table_eq({[13]={[22]=3,[23]=3,[24]=2},
+                     [14]={[23]=2,[24]=1,[25]=1,[26]=1}},
+                    seen_grid)
+    expect.table_eq({id=3, type='c', cells={'D3', 'D4'},
+                     x_min=13, x_max=13, y_min=22, y_max=23},
+                    data)
+
+    data = {id=4, cells={},
+            x_min=30000, x_max=-30000, y_min=30000, y_max=-30000}
+    expect.printerr_match(
+        'invalid key sequence',
+        function()
+            expect.eq(1,
+                      b.flood_fill(grid, 12, 22, seen_grid, data, db, aliases))
+        end)
+    expect.table_eq({[10]={[20]=4,[21]=true,[22]=4},
+                     [11]={[20]=4,[21]=4},
+                     [12]={[21]=4,[22]=4},
+                     [13]={[22]=3,[23]=3,[24]=2},
+                     [14]={[23]=2,[24]=1,[25]=1,[26]=1}},
+                    seen_grid)
+    expect.table_eq({id=4, type='a', cells={'C3','B2','A1','B1','C2','A3'},
+                     x_min=10, x_max=12, y_min=20, y_max=22},
+                    data)
+end
+
+function test.swap_id()
+    local seen_grid = {[1]={[10]=4,[11]=true,[13]=4},
+                       [2]={[10]=4,[11]=true,[13]=4}}
+    local expected = {[1]={[10]=4,[11]=true,[13]=4},
+                      [2]={[10]=5,[11]=true,[13]=5}}
+    b.swap_id({id=5, x_min=2, x_max=3, y_min=9, y_max=14}, seen_grid, 4)
+    expect.table_eq(expected, seen_grid)
+end
+
+function test.chunk_extents()
+    -- 1 1 2 2 2 2
+    -- . 2 2 2 2 .
+    local data_tables = {
+        {id=1, type='a', cells={}, x_min=1, x_max=2, y_min=1, y_max=1},
+        {id=2, type='a', cells={}, x_min=2, x_max=6, y_min=1, y_max=2},
+    }
+    local seen_grid = {
+        [1]={[1]=1},
+        [2]={[1]=1,[2]=2},
+        [3]={[1]=2,[2]=2},
+        [4]={[1]=2,[2]=2},
+        [5]={[1]=2,[2]=2},
+        [6]={[1]=2},
+    }
+    local db = {a={label='typea', max_width=2, max_height=1}}
+
+    -- 1 1 4 4 2 2
+    -- . 3 3 5 5 .
+    local expected = {
+        {id=1, type='a', cells={}, x_min=1, x_max=2, y_min=1, y_max=1},
+        {id=3, type='a', cells={}, x_min=2, x_max=3, y_min=2, y_max=2},
+        {id=4, type='a', cells={}, x_min=3, x_max=4, y_min=1, y_max=1},
+        {id=5, type='a', cells={}, x_min=4, x_max=5, y_min=2, y_max=2},
+        {id=2, type='a', cells={}, x_min=5, x_max=6, y_min=1, y_max=1},
+    }
+    local expected_seen_grid = {
+        [1]={[1]=1},
+        [2]={[1]=1,[2]=3},
+        [3]={[1]=4,[2]=3},
+        [4]={[1]=4,[2]=5},
+        [5]={[1]=2,[2]=5},
+        [6]={[1]=2},
+    }
+    expect.table_eq(expected, b.chunk_extents(data_tables, seen_grid, db))
+    expect.table_eq(expected_seen_grid, seen_grid)
+end
+
+function test.expand_buildings()
+    -- ~ 1 ~ ~ ~ ~
+    -- . . 2 ~ 3 ~
+    -- . . . ~ ~ ~
+    local data_tables = {
+        {id=1, type='a', cells={}, x_min=2, x_max=2, y_min=1, y_max=1},
+        {id=2, type='b', cells={}, x_min=3, x_max=3, y_min=2, y_max=2},
+        {id=3, type='c', cells={}, x_min=5, x_max=5, y_min=2, y_max=2},
+    }
+    local seen_grid = {
+        [2]={[1]=1},
+        [3]={[2]=2},
+        [5]={[2]=3},
+    }
+    local db = {
+        a={label='typea', min_width=2, min_height=1},
+        b={label='typeb', min_width=1, min_height=2},
+        c={label='typec', min_width=3, min_height=3},
+    }
+
+    -- 1 1 2 3 3 3
+    -- . . 2 3 3 3
+    -- . . . 3 3 3
+    local expected = {
+        {id=1, type='a', cells={}, x_min=1, x_max=2, y_min=1, y_max=1},
+        {id=2, type='b', cells={}, x_min=3, x_max=3, y_min=1, y_max=2},
+        {id=3, type='c', cells={}, x_min=4, x_max=6, y_min=1, y_max=3},
+    }
+    local expected_seen_grid = {
+        [1]={[1]=1},
+        [2]={[1]=1},
+        [3]={[1]=2,[2]=2},
+        [4]={[1]=3,[2]=3,[3]=3},
+        [5]={[1]=3,[2]=3,[3]=3},
+        [6]={[1]=3,[2]=3,[3]=3},
+    }
+    b.expand_buildings(data_tables, seen_grid, db)
+    expect.table_eq(expected, data_tables)
+    expect.table_eq(expected_seen_grid, seen_grid)
+end
+
+function test.build_extent_grid()
+    -- 1 . 1
+    -- 2 1 .
+    -- 2 2 2
+    -- . 1 .
+    local seen_grid = {
+        [10]={[20]=1,[21]=2,[22]=2},
+        [11]={       [21]=1,[22]=2,[23]=1},
+        [12]={[20]=1,       [22]=2},
+    }
+    expect.table_eq({nil, false},
+                    {b.build_extent_grid(seen_grid,
+                            {id=3, x_min=10, x_max=12, y_min=20, y_max=22})})
+    expect.table_eq({nil, false},
+                    {b.build_extent_grid(seen_grid,
+                            {id=1, x_min=11, x_max=11, y_min=20, y_max=20})})
+    expect.table_eq({nil, false},
+                    {b.build_extent_grid(seen_grid,
+                            {id=1, x_min=10, x_max=10, y_min=21, y_max=21})})
+
+    expect.table_eq({{[1]={[1]=true},[2]={[2]=true,[4]=true},[3]={[1]=true}},
+                     false},
+                    {b.build_extent_grid(seen_grid,
+                            {id=1, x_min=10, x_max=12, y_min=20, y_max=23})})
+
+    expect.table_eq({{[1]={[1]=true},[2]={},[3]={[1]=true}},
+                     false},
+                    {b.build_extent_grid(seen_grid,
+                            {id=1, x_min=10, x_max=12, y_min=20, y_max=20})})
+
+    expect.table_eq({{[1]={[1]=true,[3]=true}}, false},
+                    {b.build_extent_grid(seen_grid,
+                            {id=1, x_min=11, x_max=11, y_min=21, y_max=23})})
+
+    expect.table_eq({{[1]={[1]=true}}, true},
+                    {b.build_extent_grid(seen_grid,
+                            {id=1, x_min=10, x_max=10, y_min=20, y_max=20})})
+end
+
+function test.init_buildings()
+    local zlevel = 5
+
+    -- one building completely covering another in the flood fill stage
+    local grid = {
+        [20]={[10]={cell='A1',text='a(2x1)'},
+              [11]={cell='B1',text='a'}}
+    }
+    local db = {a={label='a',min_width=1,max_width=2,min_height=1,max_height=2}}
+    local buildings = {}
+    local expected = {
+        type='a',
+        cells={'A1'},
+        pos={x=10, y=20, z=5},
+        width=2, height=1,
+        extent_grid={[1]={[1]=true},[2]={[1]=true}}
+    }
+    expect.eq(0, b.init_buildings(zlevel, grid, buildings, db))
+    expect.table_eq({expected}, buildings)
+
+    -- one building preventing another from expanding
+    grid = {
+        [20]={[10]={cell='A1',text='a'},
+              [11]={cell='B1',text='b'}}
+    }
+    db = {a={label='a',min_width=1,max_width=1,min_height=1,max_height=1},
+          b={label='b',min_width=3,max_width=3,min_height=3,max_height=3}}
+    buildings = {}
+    expected = {
+        type='a',
+        cells={'A1'},
+        pos={x=10, y=20, z=5},
+        width=1, height=1,
+        extent_grid={[1]={[1]=true}}
+    }
+    expect.printerr_match(
+        'taken by adjacent structures',
+        function()
+            expect.eq(0, b.init_buildings(zlevel, grid, buildings, db))
+        end)
+
+    expect.table_eq({expected}, buildings)
+end
+
+function test.count_extent_tiles()
+    expect.eq(0, b.count_extent_tiles({}, 0, 0))
+    expect.eq(0, b.count_extent_tiles({[1]={}}, 1, 1))
+    expect.eq(0, b.count_extent_tiles({[1]={},[2]={},[3]={}}, 3, 1))
+
+    expect.eq(7, b.count_extent_tiles({[1]={[1]=true,[2]=true,[3]=true},
+                                       [2]={[1]=true},
+                                       [3]={[1]=true,[2]=true,[3]=true}}, 3, 3))
+
+    expect.eq(7, b.count_extent_tiles({[1]={[1]=true,[2]=true,[3]=true},
+                                       [2]={[3]=true},
+                                       [3]={[1]=true,[2]=true,[3]=true}}, 3, 3))
+end
+
+function test.trim_empty_cols()
+    local bld = {width=1, height=1, pos={x=0,y=0,z=0},
+                 extent_grid={[1]={[1]=true}}}
+    b.trim_empty_cols(bld)
+    expect.table_eq({width=1, height=1, pos={x=0,y=0,z=0},
+                     extent_grid={[1]={[1]=true}}},
+                    bld, 'no trim, single tile')
+
+    bld = {width=3, height=3, pos={x=0,y=0,z=0},
+           extent_grid={[1]={[1]=true,[3]=true},
+                        [2]={},
+                        [3]={[1]=true,[3]=true}}}
+    b.trim_empty_cols(bld)
+    expect.table_eq({width=3, height=3, pos={x=0,y=0,z=0},
+                     extent_grid={[1]={[1]=true,[3]=true},
+                                  [2]={},
+                                  [3]={[1]=true,[3]=true}}},
+                    bld, 'no trim, hollow center cross')
+
+    bld = {width=3, height=3, pos={x=0,y=0,z=0},
+           extent_grid={[1]={},
+                        [2]={[2]=true},
+                        [3]={}}}
+    b.trim_empty_cols(bld)
+    expect.table_eq({width=1, height=3, pos={x=1,y=0,z=0},
+                     extent_grid={[1]={[2]=true}}},
+                    bld, 'trim 1 left, 1 right')
+
+    bld = {width=5, height=5, pos={x=0,y=0,z=0},
+           extent_grid={[1]={},
+                        [2]={},
+                        [3]={[3]=true},
+                        [4]={},
+                        [5]={}}}
+    b.trim_empty_cols(bld)
+    expect.table_eq({width=1, height=5, pos={x=2,y=0,z=0},
+                     extent_grid={[1]={[3]=true}}},
+                    bld, 'trim 2 left, 2 right')
+end
+
+function test.trim_empty_rows()
+    local bld = {width=1, height=1, pos={x=0,y=0,z=0},
+                 extent_grid={[1]={[1]=true}}}
+    b.trim_empty_rows(bld)
+    expect.table_eq({width=1, height=1, pos={x=0,y=0,z=0},
+                     extent_grid={[1]={[1]=true}}},
+                    bld, 'no trim, single tile')
+
+    bld = {width=3, height=3, pos={x=0,y=0,z=0},
+           extent_grid={[1]={[1]=true,[3]=true},
+                        [2]={},
+                        [3]={[1]=true,[3]=true}}}
+    b.trim_empty_rows(bld)
+    expect.table_eq({width=3, height=3, pos={x=0,y=0,z=0},
+                     extent_grid={[1]={[1]=true,[3]=true},
+                                  [2]={},
+                                  [3]={[1]=true,[3]=true}}},
+                    bld, 'no trim, hollow center cross')
+
+    bld = {width=3, height=3, pos={x=0,y=0,z=0},
+           extent_grid={[1]={},
+                        [2]={[2]=true},
+                        [3]={}}}
+    b.trim_empty_rows(bld)
+    expect.table_eq({width=3, height=1, pos={x=0,y=1,z=0},
+                     extent_grid={[1]={},
+                                  [2]={[1]=true},
+                                  [3]={}}},
+                    bld, 'trim 1 top, 1 bottom')
+
+    bld = {width=5, height=5, pos={x=0,y=0,z=0},
+           extent_grid={[1]={},
+                        [2]={},
+                        [3]={[3]=true},
+                        [4]={},
+                        [5]={}}}
+    b.trim_empty_rows(bld)
+    expect.table_eq({width=5, height=1, pos={x=0,y=2,z=0},
+                     extent_grid={[1]={},
+                                  [2]={},
+                                  [3]={[1]=true},
+                                  [4]={},
+                                  [5]={}}},
+                    bld, 'trim 2 top, 2 bottom')
+end
+
+function test.has_area()
+    expect.true_(b.has_area{width=1, height=1})
+    expect.true_(b.has_area{width=10, height=1})
+    expect.true_(b.has_area{width=1, height=10})
+    expect.true_(b.has_area{width=10, height=10})
+    expect.false_(b.has_area{width=0, height=1})
+    expect.false_(b.has_area{width=1, height=0})
+    expect.false_(b.has_area{width=0, height=0})
+    expect.false_(b.has_area{width=1, height=-1})
+    expect.false_(b.has_area{width=-1, height=1})
+end
+
+function test.clear_building()
+    local bld = {width=5, height=1, pos={x=0,y=2,z=0}, extent_grid={[1]={}},
+                 canary='bird'}
+    b.clear_building(bld)
+    expect.table_eq({width=0, height=0, extent_grid={}, canary='bird'}, bld)
+end
+
+-- crop_to_bounds test generator. we generate top-level tests instead of just
+-- having multiple checks within a single test because the checks occur in a
+-- helper function. if we didn't generate separate tests for the cases, we
+-- wouldn't be able to tell which test is failing.
+do
+    local ctx = {bounds=quickfort_map.MapBoundsChecker{dims={x=3,y=3,z=1}}}
+    local db = {a={min_width=1, min_height=1},
+                b={min_width=3, min_height=3}}
+
+    -- assumes input bitmap represents a 3x3 building
+    local function get_buildings(type, bitmap, x, y, z)
+        local extent_grid = {}
+        for y=1,3 do for x = 1,3 do
+            if bitmap[y][x] ~= '' then
+                if not extent_grid[x] then extent_grid[x] = {} end
+                extent_grid[x][y] = true
+            end
+        end end
+        return {
+            {type=type, cells={'A1'}, width=3, height=3, pos={x=x, y=y, z=z},
+                extent_grid=extent_grid}
+        }
+    end
+
+    local function make_crop_to_bounds_tests(type, bitmap, tests)
+        for _,t in ipairs(tests) do
+            test['crop_to_bounds_'..t.name] = function()
+                local buildings = get_buildings(
+                    type, bitmap, t.xmod or 0, t.ymod or 0, t.zmod or 0)
+                expect.eq(t.expected_cropped,
+                          b.crop_to_bounds(ctx, buildings, db))
+
+                local expected_building = copyall(t.expected_building or {})
+                expected_building.type = type
+                expected_building.cells = {'A1'}
+                if not expected_building.pos then
+                    expected_building.width = 0
+                    expected_building.height = 0
+                    expected_building.extent_grid = {}
+                end
+                expect.table_eq({expected_building}, buildings)
+            end
+        end
+    end
+
+    local bitmap = {
+        {'a','a','a'},
+        {'a','' ,'a'},
+        {'a','' ,'a'},
+    }
+    make_crop_to_bounds_tests('a', bitmap, {
+        {name='a1_no_crop', expected_cropped=0,
+         expected_building={width=3, height=3, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true,[3]=true},
+                                         [2]={[1]=true},
+                                         [3]={[1]=true,[2]=true,[3]=true}}}},
+        {name='a1_shift_above', zmod=-1, expected_cropped=7},
+        {name='a1_shift_up', ymod=-1, expected_cropped=3,
+         expected_building={width=3, height=2, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true},
+                                         [2]={},
+                                         [3]={[1]=true,[2]=true}}}},
+        {name='a1_shift_down', ymod=1, expected_cropped=2,
+         expected_building={width=3, height=2, pos={x=0, y=1, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true},
+                                         [2]={[1]=true},
+                                         [3]={[1]=true,[2]=true}}}},
+        {name='a1_shift_left', xmod=-1, expected_cropped=3,
+         expected_building={width=2, height=3, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[1]=true},
+                                         [2]={[1]=true,[2]=true,[3]=true}}}},
+        {name='a1_shift_right', xmod=1, expected_cropped=3,
+         expected_building={width=2, height=3, pos={x=1, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true,[3]=true},
+                                         [2]={[1]=true}}}},
+        {name='a1_shift_up_left', xmod=-1, ymod=-1, expected_cropped=5,
+         expected_building={width=1, height=2, pos={x=1, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true}}}},
+        {name='a1_shift_up_right', xmod=1, ymod=-1, expected_cropped=5,
+         expected_building={width=1, height=2, pos={x=1, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true}}}},
+        {name='a1_shift_down_left', xmod=-1, ymod=1, expected_cropped=4,
+         expected_building={width=2, height=2, pos={x=0, y=1, z=0},
+                            extent_grid={[1]={[1]=true},
+                                         [2]={[1]=true,[2]=true}}}},
+        {name='a1_shift_down_right', xmod=1, ymod=1, expected_cropped=4,
+         expected_building={width=2, height=2, pos={x=1, y=1, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true},
+                                         [2]={[1]=true}}}},
+        {name='a1_shift_out_up', ymod=-10, expected_cropped=7},
+        {name='a1_shift_out_down', ymod=10, expected_cropped=7},
+        {name='a1_shift_out_left', xmod=-10, expected_cropped=7},
+        {name='a1_shift_out_right', xmod=10, expected_cropped=7},
+    })
+
+    bitmap = {
+        {'a','' ,'a'},
+        {'a','' ,'a'},
+        {'a','a','a'},
+    }
+    make_crop_to_bounds_tests('a', bitmap, {
+        {name='a2_no_crop', expected_cropped=0,
+         expected_building={width=3, height=3, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true,[3]=true},
+                                         [2]={[3]=true},
+                                         [3]={[1]=true,[2]=true,[3]=true}}}},
+        {name='a2_shift_above', zmod=-1, expected_cropped=7},
+        {name='a2_shift_up', ymod=-1, expected_cropped=2,
+         expected_building={width=3, height=2, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true},
+                                         [2]={[2]=true},
+                                         [3]={[1]=true,[2]=true}}}},
+        {name='a2_shift_down', ymod=1, expected_cropped=3,
+         expected_building={width=3, height=2, pos={x=0, y=1, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true},
+                                         [2]={},
+                                         [3]={[1]=true,[2]=true}}}},
+        {name='a2_shift_left', xmod=-1, expected_cropped=3,
+         expected_building={width=2, height=3, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[3]=true},
+                                         [2]={[1]=true,[2]=true,[3]=true}}}},
+        {name='a2_shift_right', xmod=1, expected_cropped=3,
+         expected_building={width=2, height=3, pos={x=1, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true,[3]=true},
+                                         [2]={[3]=true}}}},
+        {name='a2_shift_up_left', xmod=-1, ymod=-1, expected_cropped=4,
+         expected_building={width=2, height=2, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[2]=true},
+                                         [2]={[1]=true,[2]=true}}}},
+        {name='a2_shift_up_right', xmod=1, ymod=-1, expected_cropped=4,
+         expected_building={width=2, height=2, pos={x=1, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true},
+                                         [2]={[2]=true}}}},
+        {name='a2_shift_down_left', xmod=-1, ymod=1, expected_cropped=5,
+         expected_building={width=1, height=2, pos={x=1, y=1, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true}}}},
+        {name='a2_shift_down_right', xmod=1, ymod=1, expected_cropped=5,
+         expected_building={width=1, height=2, pos={x=1, y=1, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true}}}},
+        {name='a2_shift_out_up', ymod=-10, expected_cropped=7},
+        {name='a2_shift_out_down', ymod=10, expected_cropped=7},
+        {name='a2_shift_out_left', xmod=-10, expected_cropped=7},
+        {name='a2_shift_out_right', xmod=10, expected_cropped=7},
+    })
+
+    bitmap = {
+        {'a','a','a'},
+        {'a','' ,'' },
+        {'a','a','a'},
+    }
+    make_crop_to_bounds_tests('a', bitmap, {
+        {name='a3_no_crop', expected_cropped=0,
+         expected_building={width=3, height=3, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true,[3]=true},
+                                         [2]={[1]=true,[3]=true},
+                                         [3]={[1]=true,[3]=true}}}},
+        {name='a3_shift_above', zmod=-1, expected_cropped=7},
+        {name='a3_shift_up', ymod=-1, expected_cropped=3,
+         expected_building={width=3, height=2, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true},
+                                         [2]={[2]=true},
+                                         [3]={[2]=true}}}},
+        {name='a3_shift_down', ymod=1, expected_cropped=3,
+         expected_building={width=3, height=2, pos={x=0, y=1, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true},
+                                         [2]={[1]=true},
+                                         [3]={[1]=true}}}},
+        {name='a3_shift_left', xmod=-1, expected_cropped=3,
+         expected_building={width=2, height=3, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[3]=true},
+                                         [2]={[1]=true,[3]=true}}}},
+        {name='a3_shift_right', xmod=1, expected_cropped=2,
+         expected_building={width=2, height=3, pos={x=1, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true,[3]=true},
+                                         [2]={[1]=true,[3]=true}}}},
+        {name='a3_shift_up_left', xmod=-1, ymod=-1, expected_cropped=5,
+         expected_building={width=2, height=1, pos={x=0, y=1, z=0},
+                            extent_grid={[1]={[1]=true},
+                                         [2]={[1]=true}}}},
+        {name='a3_shift_up_right', xmod=1, ymod=-1, expected_cropped=4,
+         expected_building={width=2, height=2, pos={x=1, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true},
+                                         [2]={[2]=true}}}},
+        {name='a3_shift_down_left', xmod=-1, ymod=1, expected_cropped=5,
+         expected_building={width=2, height=1, pos={x=0, y=1, z=0},
+                            extent_grid={[1]={[1]=true},
+                                         [2]={[1]=true}}}},
+        {name='a3_shift_down_right', xmod=1, ymod=1, expected_cropped=4,
+         expected_building={width=2, height=2, pos={x=1, y=1, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true},
+                                         [2]={[1]=true}}}},
+        {name='a3_shift_out_up', ymod=-10, expected_cropped=7},
+        {name='a3_shift_out_down', ymod=10, expected_cropped=7},
+        {name='a3_shift_out_left', xmod=-10, expected_cropped=7},
+        {name='a3_shift_out_right', xmod=10, expected_cropped=7},
+    })
+
+    bitmap = {
+        {'a','a','a'},
+        {'' ,'' ,'a'},
+        {'a','a','a'},
+    }
+    make_crop_to_bounds_tests('a', bitmap, {
+        {name='a4_no_crop', expected_cropped=0,
+         expected_building={width=3, height=3, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[3]=true},
+                                         [2]={[1]=true,[3]=true},
+                                         [3]={[1]=true,[2]=true,[3]=true}}}},
+        {name='a4_shift_above', zmod=-1, expected_cropped=7},
+        {name='a4_shift_up', ymod=-1, expected_cropped=3,
+         expected_building={width=3, height=2, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[2]=true},
+                                         [2]={[2]=true},
+                                         [3]={[1]=true,[2]=true}}}},
+        {name='a4_shift_down', ymod=1, expected_cropped=3,
+         expected_building={width=3, height=2, pos={x=0, y=1, z=0},
+                            extent_grid={[1]={[1]=true},
+                                         [2]={[1]=true},
+                                         [3]={[1]=true,[2]=true}}}},
+        {name='a4_shift_left', xmod=-1, expected_cropped=2,
+         expected_building={width=2, height=3, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[3]=true},
+                                         [2]={[1]=true,[2]=true,[3]=true}}}},
+        {name='a4_shift_right', xmod=1, expected_cropped=3,
+         expected_building={width=2, height=3, pos={x=1, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[3]=true},
+                                         [2]={[1]=true,[3]=true}}}},
+        {name='a4_shift_up_left', xmod=-1, ymod=-1, expected_cropped=4,
+         expected_building={width=2, height=2, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[2]=true},
+                                         [2]={[1]=true,[2]=true}}}},
+        {name='a4_shift_up_right', xmod=1, ymod=-1, expected_cropped=5,
+         expected_building={width=2, height=1, pos={x=1, y=1, z=0},
+                            extent_grid={[1]={[1]=true},
+                                         [2]={[1]=true}}}},
+        {name='a4_shift_down_left', xmod=-1, ymod=1, expected_cropped=4,
+         expected_building={width=2, height=2, pos={x=0, y=1, z=0},
+                            extent_grid={[1]={[1]=true},
+                                         [2]={[1]=true,[2]=true}}}},
+        {name='a4_shift_down_right', xmod=1, ymod=1, expected_cropped=5,
+         expected_building={width=2, height=1, pos={x=1, y=1, z=0},
+                            extent_grid={[1]={[1]=true},
+                                         [2]={[1]=true}}}},
+        {name='a4_shift_out_up', ymod=-10, expected_cropped=7},
+        {name='a4_shift_out_down', ymod=10, expected_cropped=7},
+        {name='a4_shift_out_left', xmod=-10, expected_cropped=7},
+        {name='a4_shift_out_right', xmod=10, expected_cropped=7},
+    })
+
+    bitmap = {
+        {'' ,'a','' },
+        {'a','' ,'a'},
+        {'' ,'a','' },
+    }
+    make_crop_to_bounds_tests('a', bitmap, {
+        {name='a5_no_crop', expected_cropped=0,
+         expected_building={width=3, height=3, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[2]=true},
+                                         [2]={[1]=true,[3]=true},
+                                         [3]={[2]=true}}}},
+        {name='a5_shift_above', zmod=-1, expected_cropped=4},
+        {name='a5_shift_up', ymod=-1, expected_cropped=1,
+         expected_building={width=3, height=2, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[1]=true},
+                                         [2]={[2]=true},
+                                         [3]={[1]=true}}}},
+        {name='a5_shift_down', ymod=1, expected_cropped=1,
+         expected_building={width=3, height=2, pos={x=0, y=1, z=0},
+                            extent_grid={[1]={[2]=true},
+                                         [2]={[1]=true},
+                                         [3]={[2]=true}}}},
+        {name='a5_shift_left', xmod=-1, expected_cropped=1,
+         expected_building={width=2, height=3, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[3]=true},
+                                         [2]={[2]=true}}}},
+        {name='a5_shift_right', xmod=1, expected_cropped=1,
+         expected_building={width=2, height=3, pos={x=1, y=0, z=0},
+                            extent_grid={[1]={[2]=true},
+                                         [2]={[1]=true,[3]=true}}}},
+        {name='a5_shift_up_left', xmod=-1, ymod=-1, expected_cropped=2,
+         expected_building={width=2, height=2, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[2]=true},
+                                         [2]={[1]=true}}}},
+        {name='a5_shift_up_right', xmod=1, ymod=-1, expected_cropped=2,
+         expected_building={width=2, height=2, pos={x=1, y=0, z=0},
+                            extent_grid={[1]={[1]=true},
+                                         [2]={[2]=true}}}},
+        {name='a5_shift_down_left', xmod=-1, ymod=1, expected_cropped=2,
+         expected_building={width=2, height=2, pos={x=0, y=1, z=0},
+                            extent_grid={[1]={[1]=true},
+                                         [2]={[2]=true}}}},
+        {name='a5_shift_down_right', xmod=1, ymod=1, expected_cropped=2,
+         expected_building={width=2, height=2, pos={x=1, y=1, z=0},
+                            extent_grid={[1]={[2]=true},
+                                         [2]={[1]=true}}}},
+        {name='a5_shift_out_up', ymod=-10, expected_cropped=4},
+        {name='a5_shift_out_down', ymod=10, expected_cropped=4},
+        {name='a5_shift_out_left', xmod=-10, expected_cropped=4},
+        {name='a5_shift_out_right', xmod=10, expected_cropped=4},
+    })
+
+    bitmap = {
+        {'b','b','b'},
+        {'b','b','b'},
+        {'b','b','b'},
+    }
+    make_crop_to_bounds_tests('b', bitmap, {
+        {name='b_no_crop', expected_cropped=0,
+         expected_building={width=3, height=3, pos={x=0, y=0, z=0},
+                            extent_grid={[1]={[1]=true,[2]=true,[3]=true},
+                                         [2]={[1]=true,[2]=true,[3]=true},
+                                         [3]={[1]=true,[2]=true,[3]=true}}}},
+        {name='b_shift_above', zmod=-1, expected_cropped=9},
+        {name='b_shift_up', ymod=-1, expected_cropped=9},
+        {name='b_shift_down', ymod=1, expected_cropped=9},
+        {name='b_shift_left', xmod=-1, expected_cropped=9},
+        {name='b_shift_right', xmod=1, expected_cropped=9},
+        {name='b_shift_up_left', xmod=-1, ymod=-1, expected_cropped=9},
+        {name='b_shift_up_right', xmod=1, ymod=-1, expected_cropped=9},
+        {name='b_shift_down_left', xmod=-1, ymod=1, expected_cropped=9},
+        {name='b_shift_down_right', xmod=1, ymod=1, expected_cropped=9},
+        {name='b_shift_out_up', ymod=-10, expected_cropped=9},
+        {name='b_shift_out_down', ymod=10, expected_cropped=9},
+        {name='b_shift_out_left', xmod=-10, expected_cropped=9},
+        {name='b_shift_out_right', xmod=10, expected_cropped=9},
+    })
+end
+
+function test.check_tiles_and_extents()
+    expect.eq(0, b.check_tiles_and_extents({}, {}), 'no buildings')
+    expect.eq(0, b.check_tiles_and_extents({{'no pos'}},{}), 'invalid building')
+
+    local valid_tiles = {}
+    local function is_valid_tile(pos)
+        return valid_tiles[pos.z] and valid_tiles[pos.z][pos.x]
+            and valid_tiles[pos.z][pos.x][pos.y]
+    end
+
+    local db = {a={is_valid_tile_fn=is_valid_tile,
+                   is_valid_extent_fn=function(bld) return true end},
+                b={is_valid_tile_fn=is_valid_tile,
+                   is_valid_extent_fn=function(bld) return false end}}
+
+    local bld = {type='a', pos={x=0, y=0, z=0}, width=1, height=1,
+                 extent_grid={[1]={[1]=true}}}
+    valid_tiles[0] = {[0]={[0]=true}}
+    expect.eq(0, b.check_tiles_and_extents({bld}, db), 'one valid tile')
+    expect.table_eq({[1]={[1]=true}}, bld.extent_grid)
+
+    bld = {type='a', pos={x=0, y=0, z=0}, width=1, height=1,
+           extent_grid={[1]={[1]=true}}}
+    valid_tiles = {}
+    expect.eq(1, b.check_tiles_and_extents({bld}, db), 'one invalid tile')
+    expect.table_eq({[1]={[1]=false}}, bld.extent_grid)
+
+    bld = {type='a', pos={x=1, y=1, z=1}, width=3, height=3,
+           extent_grid={[1]={[2]=true},
+                        [2]={},
+                        [3]={[1]=true,[3]=true}}}
+    valid_tiles[1] = {[1]={[2]=true},
+                      [2]={},
+                      [3]={[1]=true,[3]=true}}
+    expect.eq(0, b.check_tiles_and_extents({bld}, db),
+              'valid tiles, non-contiguous extent')
+    expect.table_eq({[1]={[2]=true},
+                     [2]={},
+                     [3]={[1]=true,[3]=true}}, bld.extent_grid)
+
+    bld = {type='a', pos={x=1, y=1, z=1}, width=3, height=3,
+           extent_grid={[1]={[2]=true},
+                        [2]={},
+                        [3]={[1]=true,[3]=true}}}
+    valid_tiles = {}
+    expect.eq(3, b.check_tiles_and_extents({bld}, db),
+              'invalid tiles, non-contiguous extent')
+    expect.table_eq({[1]={[2]=false},
+                     [2]={},
+                     [3]={[1]=false,[3]=false}}, bld.extent_grid)
+
+    bld = {type='b', pos={x=1, y=1, z=1}, width=3, height=3,
+           extent_grid={[1]={[1]=true,[2]=true,[3]=true},
+                        [2]={[1]=true,[2]=true,[3]=true},
+                        [3]={[1]=true,[2]=true,[3]=true}}}
+    valid_tiles[1] = {[1]={[1]=true,[2]=true, [3]=true},
+                      [2]={[1]=true,[2]=false,[3]=true},
+                      [3]={[1]=true,[2]=true, [3]=true}}
+    expect.eq(1, b.check_tiles_and_extents({bld}, db), 'invalid extent')
+    expect.table_eq({}, bld.extent_grid)
+end
+
+function test.make_extents()
+    local bld = {width=1, height=1, extent_grid={[1]={[1]=true}}}
+    expect.table_eq({nil, 1}, {b.make_extents(bld, true)}, 'one tile')
+
+    bld = {width=3, height=3, extent_grid={[1]={[2]=true},
+                                           [2]={},
+                                           [3]={[1]=true,[3]=true}}}
+    expect.table_eq({nil, 3}, {b.make_extents(bld, true)}, 'non-contig tiles')
+
+    bld = {width=3, height=3, extent_grid={[1]={[2]=true},
+                                           [2]={},
+                                           [3]={[1]=true,[3]=true}}}
+    local extents, num_tiles = nil, 0
+    dfhack.with_finalize(
+        function() df.delete(extents) end,
+        function()
+            extents, num_tiles = b.make_extents(bld, false)
+            expect.eq(3, num_tiles, 'allocated tiles')
+            expect.eq(0, extents[0])
+            expect.eq(0, extents[1])
+            expect.eq(1, extents[2])
+            expect.eq(1, extents[3])
+            expect.eq(0, extents[4])
+            expect.eq(0, extents[5])
+            expect.eq(0, extents[6])
+            expect.eq(0, extents[7])
+            expect.eq(1, extents[8])
+        end)
+end


### PR DESCRIPTION
- refactor the bounds checking functions in quickfort/map into a proper class
- fix a number of bugs related to processing non-solid extents and cropping extents that are partially out of bounds
- rename `ctx` to `digctx` in quickfort/dig so it isn't confused with the top-level `ctx` (which is also used in that file)