### PR TITLE
bodyswap: handle companions

### DIFF
--- a/bodyswap.lua
+++ b/bodyswap.lua
@@ -76,8 +76,10 @@ function createNemesis(unit)
 end
 
 function isPet(nemesis)
-  if nemesis.unit and nemesis.unit.relationship_ids.Pet ~= -1 then
-    return true
+  if nemesis.unit then
+    if nemesis.unit.relationship_ids.Pet ~= -1 then
+      return true
+    end
   elseif nemesis.figure then -- in case the unit is offloaded
     for  _, link in ipairs(nemesis.figure.histfig_links) do
       if link._type == df.histfig_hf_link_pet_ownerst then


### PR DESCRIPTION
Requires DFHack/df-structures#426.

Fix: 
- Prior party members no longer tag along after bodyswapping and reloading the map.

Improvement:
- Companions of bodyswapping targets are now added to the adventurer party (when swapping into a member of a previous party, for example) and can be swapped into using the in-game tactical party system.