### PR TITLE
[quickfort] refactor keycodes.lua and add unit tests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ that repo.
 - `quickfort`: fix off-by-one line number accounting in blueprints with implicit #dig modelines
 - `quickfort`: properly detect and error on sub-alias params with no values instead of just failing to apply the alias later (if you really want an empty value, use ``{Empty}`` instead)
 - `quickfort`: improve handling of non-rectangular and non-solid extent-based structures (like fancy-shaped stockpiles and farm plots)
+- `quickfort`: fix conversion of numbers to DF keycodes in ``#query`` blueprints
 
 ## Misc Improvements
 - `devel/annc-monitor`: added ``report enable|disable`` subcommand to filter combat reports

--- a/internal/quickfort/aliases.lua
+++ b/internal/quickfort/aliases.lua
@@ -61,7 +61,7 @@ end
 function push_aliases_file(filepath)
     local num_aliases = push_aliases_reader(
             quickfort_reader.TextReader{filepath=filepath})
-    log('successfully read in %d aliases from "%s"', num_aliases, filepath)
+    log('read in %d aliases from "%s"', num_aliases, filepath)
 end
 
 local function process_text(text, tokens, depth)

--- a/internal/quickfort/aliases.lua
+++ b/internal/quickfort/aliases.lua
@@ -59,9 +59,8 @@ local function push_aliases_reader(reader)
 end
 
 function push_aliases_file(filepath)
-    local num_aliases = push_aliases_reader(quickfort_reader.CsvReader{
-                            filepath=filepath,
-                            line_tokenizer=function(f) return f() end})
+    local num_aliases = push_aliases_reader(
+            quickfort_reader.TextReader{filepath=filepath})
     log('successfully read in %d aliases from "%s"', num_aliases, filepath)
 end
 

--- a/internal/quickfort/command.lua
+++ b/internal/quickfort/command.lua
@@ -25,6 +25,18 @@ local command_switch = {
     undo='do_undo',
 }
 
+function init_ctx(command, blueprint_name, cursor, aliases, dry_run)
+    return {
+        command=command,
+        blueprint_name=blueprint_name,
+        cursor=cursor,
+        aliases=aliases,
+        dry_run=dry_run,
+        stats={},
+        messages={},
+    }
+end
+
 function do_command_internal(ctx, section_name)
     ctx.stats.out_of_bounds = ctx.stats.out_of_bounds or
             {label='Tiles outside map boundary', value=0}
@@ -105,8 +117,8 @@ function do_command(args)
         function() quickfort_common.verbose = false end,
         function()
             local aliases = quickfort_list.get_aliases(blueprint_name)
-            local ctx = {command=command, blueprint_name=blueprint_name,
-                         cursor=cursor, stats={}, messages={}, aliases=aliases, dry_run=dry_run}
+            local ctx = init_ctx(command, blueprint_name, cursor, aliases,
+                                 dry_run)
             do_command_internal(ctx, section_name)
             finish_command(ctx, section_name, quiet)
             if command == 'run' then

--- a/internal/quickfort/dialog.lua
+++ b/internal/quickfort/dialog.lua
@@ -204,8 +204,8 @@ local function dialog_command(command, text)
                         quickfort_parse.format_command(
                             command, blueprint_name, section_name)))
     local aliases = quickfort_list.get_aliases(blueprint_name)
-    local ctx = {command=command, blueprint_name=blueprint_name, cursor=cursor,
-                 stats={}, messages={}, aliases=aliases}
+    local ctx = quickfort_command.init_ctx(command, blueprint_name, cursor,
+                                           aliases, false)
     quickfort_command.do_command_internal(ctx, section_name)
     quickfort_command.finish_command(ctx, section_name, true)
     if command == 'run' and #ctx.messages > 0 then

--- a/internal/quickfort/keycodes.lua
+++ b/internal/quickfort/keycodes.lua
@@ -6,35 +6,49 @@ if not dfhack_flags.module then
 end
 
 local quickfort_common = reqscript('internal/quickfort/common')
+local quickfort_reader = reqscript('internal/quickfort/reader')
 local log = quickfort_common.log
 
 local keycodes_file = 'data/init/interface.txt'
 
-local interface_txt_mtime = nil
-local keycodes = {}
+local interface_txt_mtime, keycodes = nil, nil
 
-local function init_keycodes()
-    local mtime = dfhack.filesystem.mtime(keycodes_file)
-    if interface_txt_mtime == mtime then return end
-    local file = io.open(keycodes_file)
-    if not file then
-        qerror(string.format('failed to open file: "%s"', keycodes_file))
-    end
-    -- initialize with "Empty" pseudo-keycode that expands to a 0-length list
+-- number keys (but not numpad number keys) can appear as either "SYM:0:%d" or
+-- "KEY:%d". we arbitrarily choose to standardize on the "KEY" format so we know
+-- how to find the mappings later.
+local function canonicalize_keyspec(keyspec)
+    local _, _, number = string.find(keyspec, '^%[SYM:0:(%d)%]')
+    if not number then return keyspec end
+    return ('[KEY:%d]'):format(number)
+end
+
+local function reload_keycodes(reader)
+    -- add "Empty" pseudo-keycode that expands to a 0-length list
     keycodes = {['[SYM:0:Empty]']={}}
-    local cur_binding = nil
-    for line in file:lines() do
-        line = string.gsub(line, '[\r\n]*$', '')
-        _, _, binding = string.find(line, '^%[BIND:([0-9_A-Z]+):.*$')
+    local num_keycodes, cur_binding, line = 0, nil, reader:get_next_row()
+    while line do
+        local _, _, binding = string.find(line, '^%[BIND:([0-9_A-Z]+):.*')
         if binding then
             cur_binding = binding
         elseif cur_binding and #line > 0 then
             -- it's a keycode definition
+            line = canonicalize_keyspec(line)
             if not keycodes[line] then keycodes[line] = {} end
             table.insert(keycodes[line], cur_binding)
+            num_keycodes = num_keycodes + 1
         end
+        line = reader:get_next_row()
     end
-    log('successfully read in keycodes from "%s"', keycodes_file)
+    return num_keycodes
+end
+
+function init_keycodes()
+    local mtime = dfhack.filesystem.mtime(keycodes_file)
+    if interface_txt_mtime == mtime then return end
+    local num_keycodes =
+            reload_keycodes(quickfort_reader.TextReader{filepath=keycodes_file})
+    log('successfully read in %d keycodes from "%s"',
+        num_keycodes, keycodes_file)
     interface_txt_mtime = mtime
 end
 
@@ -42,7 +56,6 @@ end
 -- with shift, ctrl, or alt modifiers recorded in the modifiers table.
 -- returns a list of all the keycodes that the input could translate to
 function get_keycodes(code, modifiers)
-    init_keycodes()
     if not code then return nil end
     local mod = 0
     if modifiers['shift'] then
@@ -61,4 +74,12 @@ function get_keycodes(code, modifiers)
         key = string.format('[SYM:%d:%s]', mod, code)
     end
     return keycodes[key]
+end
+
+if dfhack.internal.IN_TEST then
+    unit_test_hooks = {
+        canonicalize_keyspec=canonicalize_keyspec,
+        reload_keycodes=reload_keycodes,
+        get_keycodes=get_keycodes,
+    }
 end

--- a/internal/quickfort/meta.lua
+++ b/internal/quickfort/meta.lua
@@ -42,9 +42,8 @@ local function do_meta(zlevel, grid, ctx)
             {label='Blueprints applied', value=0, always=true}
 
     -- ensure we process blueprints in the declared order
-    local cells = quickfort_parse.get_ordered_grid_cells(grid)
     local saved_zlevel = ctx.cursor.z
-    for _, cell in ipairs(cells) do
+    for _, cell in ipairs(quickfort_parse.get_ordered_grid_cells(grid)) do
         local section_name =
                 get_section_name(cell.cell, cell.text, ctx.sheet_name)
         print(string.format('applying blueprint: "%s"', section_name))
@@ -54,14 +53,6 @@ local function do_meta(zlevel, grid, ctx)
     end
 end
 
-function do_run(zlevel, grid, ctx)
-    do_meta(zlevel, grid, ctx)
-end
-
-function do_orders(zlevel, grid, ctx)
-    do_meta(zlevel, grid, ctx)
-end
-
-function do_undo(zlevel, grid, ctx)
-    do_meta(zlevel, grid, ctx)
-end
+do_run = do_meta
+do_orders = do_meta
+do_undo = do_meta

--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -432,7 +432,7 @@ local function new_reader(filepath, sheet_name, max_cols)
         return quickfort_reader.CsvReader{
             filepath=filepath,
             max_cols=max_cols,
-            line_tokenizer=tokenize_next_csv_line,
+            row_tokenizer=tokenize_next_csv_line,
         }
     end
 end

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -97,6 +97,7 @@ function do_run(zlevel, grid, ctx)
     stats.query_tiles = stats.query_tiles or
             {label='Tiles modified', value=0}
 
+    quickfort_keycodes.init_keycodes()
     load_aliases(ctx)
 
     local dry_run = ctx.dry_run

--- a/test/quickfort/keycodes_unit.lua
+++ b/test/quickfort/keycodes_unit.lua
@@ -1,0 +1,67 @@
+local k = reqscript('internal/quickfort/keycodes').unit_test_hooks
+local quickfort_reader = reqscript('internal/quickfort/reader')
+
+function test.module()
+    expect.error_match(
+        'this script cannot be called directly',
+        function() dfhack.run_script('internal/quickfort/keycodes') end)
+end
+
+MockFile = defclass(MockFile, nil)
+MockFile.ATTRS{i=0, lines={}}
+function MockFile:close() end
+function MockFile:reset(lines) self.lines, self.i = lines, 0 end
+function MockFile:read()
+    self.i = self.i + 1
+    return self.lines[self.i]
+end
+
+local function mock_open()
+    return MockFile{}
+end
+
+function test.canonicalize_keyspec()
+    expect.eq('somethingrandom', k.canonicalize_keyspec('somethingrandom'))
+    expect.eq('[KEY:a]', k.canonicalize_keyspec('[KEY:a]'))
+    expect.eq('[KEY:5]', k.canonicalize_keyspec('[KEY:5]'))
+    expect.eq('[KEY:5]', k.canonicalize_keyspec('[SYM:0:5]'))
+    expect.eq('[SYM:1:5]', k.canonicalize_keyspec('[SYM:1:5]'))
+end
+
+function test.reload_and_get_keycodes()
+    local reader = quickfort_reader.TextReader{open_fn=mock_open}
+
+    expect.eq(0, k.reload_keycodes(reader), 'empty keycode input')
+    expect.nil_(k.get_keycodes())
+    expect.nil_(k.get_keycodes('a', {}))
+
+    reader.source:reset(
+       {
+        '[BIND:A_KEY:IGNORE]',
+        '[KEY:a]',
+        '[BIND:B_KEY:IGNORE]',
+        '[KEY:b]',
+        '[KEY:B]',
+        '[SYM:0:5]',
+        '[BIND:C_KEY:IGNORE]',
+        '[KEY:5]',
+        '[BIND:D_KEY:IGNORE]',
+        '[SYM:1:d]',
+        '[BIND:E_KEY:IGNORE]',
+        '[SYM:2:d]',
+        '[BIND:F_KEY:IGNORE]',
+        '[SYM:4:d]',
+        '[BIND:G_KEY:IGNORE]',
+        '[SYM:6:d]',
+       })
+    expect.eq(9, k.reload_keycodes(reader), 'full keycode input')
+    expect.nil_(k.get_keycodes('A', {}))
+    expect.table_eq({'A_KEY'}, k.get_keycodes('a', {}))
+    expect.table_eq({'B_KEY'}, k.get_keycodes('b', {}))
+    expect.table_eq({'B_KEY'}, k.get_keycodes('B', {}))
+    expect.table_eq({'B_KEY', 'C_KEY'}, k.get_keycodes('5', {}))
+    expect.table_eq({'D_KEY'}, k.get_keycodes('d', {shift=true}))
+    expect.table_eq({'E_KEY'}, k.get_keycodes('d', {ctrl=true}))
+    expect.table_eq({'F_KEY'}, k.get_keycodes('d', {alt=true}))
+    expect.table_eq({'G_KEY'}, k.get_keycodes('d', {ctrl=true, alt=true}))
+end

--- a/test/quickfort/parse_unit.lua
+++ b/test/quickfort/parse_unit.lua
@@ -393,7 +393,8 @@ function test.trim_token()
 end
 
 MockReader = defclass(MockReader, quickfort_reader.Reader)
-MockReader.ATTRS{lines={}, i=0}
+MockReader.ATTRS{lines={}, i=0,
+                 open_fn=function() return {close=function() end} end}
 function MockReader:reset(lines) self.lines, self.i = lines, 0 end
 function MockReader:get_next_row_raw()
     self.i = self.i + 1


### PR DESCRIPTION
- fix handling of numeric keycodes
- don't recheck interface.txt for reloading on every keycode, just once per blueprint
- refactor reader classes and add a TextReader class for reading lines of text. CsvReader now inherits from TextReader
- other bits of random cleanup