### PR TITLE
[quickfort] refactor quickfort/set and add unit tests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ that repo.
 - `quickfort`: improved handling of non-rectangular and non-solid extent-based structures (like fancy-shaped stockpiles and farm plots)
 - `quickfort`: fixed conversion of numbers to DF keycodes in ``#query`` blueprints
 - `quickfort`: fixed an off-by-one error when cropping buildings that cross the map edge
+- `quickfort`: properly reset config to default values in ``quickfort reset`` even if if the ``dfhack-config/quickfort/quickfort.txt`` config file doesn't mention all config vars. aso now works even if the config file doesn't exist
 
 ## Misc Improvements
 - `devel/annc-monitor`: added ``report enable|disable`` subcommand to filter combat reports

--- a/internal/quickfort/command.lua
+++ b/internal/quickfort/command.lua
@@ -13,7 +13,7 @@ local quickfort_orders = reqscript('internal/quickfort/orders')
 local quickfort_parse = reqscript('internal/quickfort/parse')
 
 local mode_modules = {}
-for mode, _ in pairs(quickfort_common.valid_modes) do
+for mode, _ in pairs(quickfort_parse.valid_modes) do
     if mode ~= 'ignore' and mode ~= 'aliases' then
         mode_modules[mode] = reqscript('internal/quickfort/'..mode)
     end

--- a/internal/quickfort/common.lua
+++ b/internal/quickfort/common.lua
@@ -5,18 +5,6 @@ if not dfhack_flags.module then
     qerror('this script cannot be called directly')
 end
 
--- keep deprecated settings in the table so we don't break existing configs
-settings = {
-    blueprints_dir={value='blueprints'},
-    buildings_use_blocks={value=false, deprecated=true},
-    force_interactive_build={value=false, deprecated=true},
-    force_marker_mode={value=false},
-    query_unsafe={value=false},
-    stockpiles_max_barrels={value=-1},
-    stockpiles_max_bins={value=-1},
-    stockpiles_max_wheelbarrows={value=0},
-}
-
 verbose = false
 
 function log(...)

--- a/internal/quickfort/common.lua
+++ b/internal/quickfort/common.lua
@@ -5,20 +5,6 @@ if not dfhack_flags.module then
     qerror('this script cannot be called directly')
 end
 
-local utils = require('utils')
-
-valid_modes = utils.invert({
-    'dig',
-    'build',
-    'place',
-    'zone',
-    'query',
-    'meta',
-    'notes',
-    'ignore',
-    'aliases',
-})
-
 -- keep deprecated settings in the table so we don't break existing configs
 settings = {
     blueprints_dir={value='blueprints'},

--- a/internal/quickfort/dig.lua
+++ b/internal/quickfort/dig.lua
@@ -15,6 +15,7 @@ local utils = require('utils')
 local quickfort_common = reqscript('internal/quickfort/common')
 local quickfort_map = reqscript('internal/quickfort/map')
 local quickfort_parse = reqscript('internal/quickfort/parse')
+local quickfort_set = reqscript('internal/quickfort/set')
 
 local log = quickfort_common.log
 
@@ -554,7 +555,7 @@ local function dig_tile(digctx, db_entry)
         else
             if not db_entry.skip_marker_mode then
                 local marker_mode = db_entry.marker_mode or
-                        quickfort_common.settings['force_marker_mode'].value
+                        quickfort_set.get_setting('force_marker_mode')
                 digctx.occupancy.dig_marked = marker_mode
             end
             if db_entry.use_priority then

--- a/internal/quickfort/list.lua
+++ b/internal/quickfort/list.lua
@@ -221,7 +221,7 @@ function do_list(args)
             {'m', 'mode', hasArg=true,
              handler=function(optarg) filter_mode = optarg end},
         })
-    if filter_mode and not quickfort_common.valid_modes[filter_mode] then
+    if filter_mode and not quickfort_parse.valid_modes[filter_mode] then
         qerror(string.format('invalid mode: "%s"', filter_mode))
     end
     local list = do_list_internal(show_library, show_hidden)

--- a/internal/quickfort/list.lua
+++ b/internal/quickfort/list.lua
@@ -7,13 +7,13 @@ end
 
 local utils = require('utils')
 local xlsxreader = require('plugins.xlsxreader')
-local quickfort_common = reqscript('internal/quickfort/common')
 local quickfort_parse = reqscript('internal/quickfort/parse')
+local quickfort_set = reqscript('internal/quickfort/set')
 
 -- blueprint_name is relative to the blueprints dir
 function get_blueprint_filepath(blueprint_name)
     return string.format("%s/%s",
-                         quickfort_common.settings['blueprints_dir'].value,
+                         quickfort_set.get_setting('blueprints_dir'),
                          blueprint_name)
 end
 
@@ -90,7 +90,7 @@ local num_library_blueprints = 0
 
 local function scan_blueprints()
     local paths = dfhack.filesystem.listdir_recursive(
-        quickfort_common.settings['blueprints_dir'].value, nil, false)
+        quickfort_set.get_setting('blueprints_dir'), nil, false)
     blueprints, blueprint_modes = {}, {}
     local library_blueprints = {}
     for _, v in ipairs(paths) do

--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -5,8 +5,20 @@ if not dfhack_flags.module then
     qerror('this script cannot be called directly')
 end
 
-local quickfort_common = reqscript('internal/quickfort/common')
+local utils = require('utils')
 local quickfort_reader = reqscript('internal/quickfort/reader')
+
+valid_modes = utils.invert({
+    'dig',
+    'build',
+    'place',
+    'zone',
+    'query',
+    'meta',
+    'notes',
+    'ignore',
+    'aliases',
+})
 
 -- returns a tuple of {keys, extent} where keys is a string and extent is of the
 -- format: {width, height, specified}, where width and height are numbers and
@@ -243,7 +255,7 @@ returns nil if the modeline is invalid.
 local function parse_modeline(modeline, filename, modeline_id)
     if not modeline then return nil end
     local _, mode_end, mode = string.find(modeline, '^#([%l]+)')
-    if not mode or not quickfort_common.valid_modes[mode] then return nil end
+    if not mode or not valid_modes[mode] then return nil end
     local modeline_data, comment_start =
             parse_markers(modeline, mode_end+1, filename)
     local _, _, comment = string.find(modeline, '^%s*(.-)%s*$', comment_start)

--- a/internal/quickfort/place.lua
+++ b/internal/quickfort/place.lua
@@ -20,6 +20,8 @@ local quickfort_common = reqscript('internal/quickfort/common')
 local quickfort_building = reqscript('internal/quickfort/building')
 local quickfort_orders = reqscript('internal/quickfort/orders')
 local quickfort_query = reqscript('internal/quickfort/query')
+local quickfort_set = reqscript('internal/quickfort/set')
+
 local log = quickfort_common.log
 
 local function is_valid_stockpile_tile(pos)
@@ -168,7 +170,7 @@ end
 local function init_containers(db_entry, ntiles, fields)
     if db_entry.want_barrels then
         local max_barrels = db_entry.num_barrels or
-                quickfort_common.settings['stockpiles_max_barrels'].value
+                quickfort_set.get_setting('stockpiles_max_barrels')
         if max_barrels < 0 or max_barrels >= ntiles then
             fields.max_barrels = ntiles
         else
@@ -178,7 +180,7 @@ local function init_containers(db_entry, ntiles, fields)
     end
     if db_entry.want_bins then
         local max_bins = db_entry.num_bins or
-                quickfort_common.settings['stockpiles_max_bins'].value
+                quickfort_set.get_setting('stockpiles_max_bins')
         if max_bins < 0 or max_bins >= ntiles then
             fields.max_bins = ntiles
         else
@@ -188,7 +190,7 @@ local function init_containers(db_entry, ntiles, fields)
     end
     if db_entry.want_wheelbarrows or db_entry.num_wheelbarrows then
         local max_wb = db_entry.num_wheelbarrows or
-                quickfort_common.settings['stockpiles_max_wheelbarrows'].value
+                quickfort_set.get_setting('stockpiles_max_wheelbarrows')
         if max_wb < 0 then max_wb = 1 end
         if max_wb >= ntiles - 1 then
             fields.max_wheelbarrows = ntiles - 1

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -12,6 +12,7 @@ local quickfort_common = reqscript('internal/quickfort/common')
 local quickfort_aliases = reqscript('internal/quickfort/aliases')
 local quickfort_keycodes = reqscript('internal/quickfort/keycodes')
 local quickfort_map = reqscript('internal/quickfort/map')
+local quickfort_set = reqscript('internal/quickfort/set')
 
 local log = quickfort_common.log
 local common_aliases_filename = 'hack/data/quickfort/aliases-common.txt'
@@ -110,7 +111,7 @@ function do_run(zlevel, grid, ctx)
         for x, cell_and_text in pairs(row) do
             local pos = xyz2pos(x, y, zlevel)
             local cell, text = cell_and_text.cell, cell_and_text.text
-            if not quickfort_common.settings['query_unsafe'].value and
+            if not quickfort_set.get_setting('query_unsafe') and
                     not is_queryable_tile(pos) then
                 print(string.format(
                         'no building at coordinates (%d, %d, %d); skipping ' ..
@@ -140,7 +141,7 @@ function do_run(zlevel, grid, ctx)
             end
             -- sanity checks for common blueprint mistakes
             if not dry_run
-                    and not quickfort_common.settings['query_unsafe'].value then
+                    and not quickfort_set.get_setting('query_unsafe') then
                 local cursor = guidm.getCursorPos()
                 if not is_same_coord(pos, cursor) then
                     qerror(string.format(

--- a/internal/quickfort/set.lua
+++ b/internal/quickfort/set.lua
@@ -5,42 +5,88 @@ if not dfhack_flags.module then
     qerror('this script cannot be called directly')
 end
 
-local quickfort_common = reqscript('internal/quickfort/common')
+local quickfort_reader = reqscript('internal/quickfort/reader')
+
+local config_file = 'dfhack-config/quickfort/quickfort.txt'
+
+-- keep deprecated settings in the table so we don't break existing configs
+local settings = {
+    blueprints_dir={default_value='blueprints'},
+    buildings_use_blocks={default_value=false, deprecated=true},
+    force_interactive_build={default_value=false, deprecated=true},
+    force_marker_mode={default_value=false},
+    query_unsafe={default_value=false},
+    stockpiles_max_barrels={default_value=-1},
+    stockpiles_max_bins={default_value=-1},
+    stockpiles_max_wheelbarrows={default_value=0},
+}
 
 local valid_booleans = {
     ['true']=true,
     ['1']=true,
     ['on']=true,
+    ['y']=true,
+    ['yes']=true,
     ['false']=false,
     ['0']=false,
     ['off']=false,
+    ['n']=false,
+    ['no']=false,
 }
 
+function get_setting(key)
+    local setting = settings[key]
+    if not setting then error(string.format('invalid setting: "%s"', key)) end
+    return setting.value ~= nil and setting.value or setting.default_value
+end
+
 local function set_setting(key, value)
-    if quickfort_common.settings[key] == nil then
+    if settings[key] == nil then
         qerror(string.format('error: invalid setting: "%s"', key))
     end
-    if type(quickfort_common.settings[key].value) == 'boolean' then
+    if type(settings[key].default_value) == 'boolean' then
         if valid_booleans[value] == nil then
             qerror(string.format('error: invalid boolean: "%s"', value))
         end
         value = valid_booleans[value]
-    elseif type(quickfort_common.settings[key].value) == 'number' then
-        if tonumber(value) == nil then
+    elseif type(settings[key].default_value) == 'number' then
+        local num_val = tonumber(value)
+        if not num_val then
             qerror(string.format('error: invalid integer: "%s"', value))
         end
-        value = math.floor(tonumber(value))
+        value = math.floor(num_val)
     end
-    quickfort_common.settings[key].value = value
+    settings[key].value = value
 end
 
-local function read_config(filename)
-    print(string.format('reading configuration from "%s"', filename))
-    for line in io.lines(filename) do
+local function read_settings(reader)
+    print(string.format('reading quickfort configuration from "%s"',
+                        reader.filepath))
+    local line = reader:get_next_row()
+    while line do
         local _, _, key, value = string.find(line, '^%s*([%a_]+)%s*=%s*(%S.*)')
         if (key) then
             set_setting(key, value)
         end
+        line = reader:get_next_row()
+    end
+end
+
+local function reset_to_defaults()
+    for _,v in pairs(settings) do
+        v.value = nil
+    end
+end
+
+local function reset_settings(get_reader_fn)
+    local reader = nil
+    local init_reader = function() reader = get_reader_fn() end
+    reset_to_defaults()
+    local ok, err = pcall(init_reader)
+    if ok then
+        read_settings(reader)
+    else
+        print(string.format('%s; using internal defaults', tostring(err)))
     end
 end
 
@@ -48,7 +94,7 @@ local function print_settings()
     print('active settings:')
     local width = 1
     local settings_arr = {}
-    for k,v in pairs(quickfort_common.settings) do
+    for k,v in pairs(settings) do
         if not v.deprecated then
             if #k > width then width = #k end
             table.insert(settings_arr, k)
@@ -56,8 +102,7 @@ local function print_settings()
     end
     table.sort(settings_arr)
     for _, k in ipairs(settings_arr) do
-        print(string.format('  %-'..width..'s = %s',
-                            k, quickfort_common.settings[k].value))
+        print(string.format('  %-'..width..'s = %s', k, get_setting(k)))
     end
 end
 
@@ -67,16 +112,29 @@ function do_set(args)
         qerror('error: expected "quickfort set [<key> <value>]"')
     end
     set_setting(args[1], args[2])
-    print(string.format('successfully set %s to "%s"',
-                        args[1], quickfort_common.settings[args[1]].value))
+    print(string.format('%s now set to "%s"', args[1], get_setting(args[1])))
 end
 
 function do_reset()
-    read_config('dfhack-config/quickfort/quickfort.txt')
+    local get_reader_fn = function()
+        return quickfort_reader.TextReader{filepath=config_file}
+    end
+    reset_settings(get_reader_fn)
 end
 
-if not initialized then
+if not initialized and not dfhack.internal.IN_TEST then
     -- this is the first time we're initializing the environment
     do_reset()
     initialized = true
+end
+
+if dfhack.internal.IN_TEST then
+    unit_test_hooks = {
+        settings=settings,
+        get_setting=get_setting,
+        set_setting=set_setting,
+        read_settings=read_settings,
+        reset_to_defaults=reset_to_defaults,
+        reset_settings=reset_settings,
+    }
 end

--- a/test/quickfort/common_unit.lua
+++ b/test/quickfort/common_unit.lua
@@ -1,4 +1,4 @@
-local common = reqscript('internal/quickfort/common')
+local quickfort_common = reqscript('internal/quickfort/common')
 
 function test.module()
     expect.error_match(
@@ -6,27 +6,21 @@ function test.module()
         function() dfhack.run_script('internal/quickfort/common') end)
 end
 
-function test.settings()
-    for _,v in pairs(common.settings) do
-        expect.ne(v.value, nil)
-    end
-end
-
 function test.log()
     local mock_print = mock.func()
     mock.patch(
         {
-            {common, 'verbose', false},
-            {common, 'print', mock_print},
+            {quickfort_common, 'verbose', false},
+            {quickfort_common, 'print', mock_print},
         },
         function()
-            common.log('should not log')
+            quickfort_common.log('should not log')
             expect.eq(0, mock_print.call_count)
-            common.verbose = true
-            common.log('should log')
+            quickfort_common.verbose = true
+            quickfort_common.log('should log')
             expect.eq(1, mock_print.call_count)
-            common.verbose = false
-            common.log('should not log')
+            quickfort_common.verbose = false
+            quickfort_common.log('should not log')
             expect.eq(1, mock_print.call_count)
         end)
 end
@@ -35,17 +29,17 @@ function test.logfn()
     local mock_print = mock.func()
     mock.patch(
         {
-            {common, 'verbose', false},
-            {common, 'print', mock_print},
+            {quickfort_common, 'verbose', false},
+            {quickfort_common, 'print', mock_print},
         },
         function()
-            common.logfn(mock_print, 'should not log')
+            quickfort_common.logfn(mock_print, 'should not log')
             expect.eq(0, mock_print.call_count)
-            common.verbose = true
-            common.logfn(mock_print, 'should log')
+            quickfort_common.verbose = true
+            quickfort_common.logfn(mock_print, 'should log')
             expect.eq(1, mock_print.call_count)
-            common.verbose = false
-            common.logfn(mock_print, 'should not log')
+            quickfort_common.verbose = false
+            quickfort_common.logfn(mock_print, 'should not log')
             expect.eq(1, mock_print.call_count)
         end)
 end

--- a/test/quickfort/set_unit.lua
+++ b/test/quickfort/set_unit.lua
@@ -1,0 +1,125 @@
+local quickfort_reader = reqscript('internal/quickfort/reader')
+local quickfort_set = reqscript('internal/quickfort/set')
+local s = quickfort_set.unit_test_hooks
+
+function test.module()
+    expect.error_match(
+        'this script cannot be called directly',
+        function() dfhack.run_script('internal/quickfort/set') end)
+end
+
+function test.settings_have_defaults()
+    for _,v in pairs(s.settings) do
+        expect.ne(v.default_value, nil)
+    end
+end
+
+function test.get_setting()
+    expect.eq('blueprints', s.get_setting('blueprints_dir'))
+    s.set_setting('blueprints_dir', '/tmp')
+    expect.eq('/tmp', s.get_setting('blueprints_dir'))
+
+    s.reset_to_defaults()
+    expect.false_(s.get_setting('query_unsafe'))
+    s.set_setting('query_unsafe', 'true')
+    expect.true_(s.get_setting('query_unsafe'))
+
+    expect.error_match('invalid setting',
+                       function() s.get_setting('unknown_setting') end)
+end
+
+function test.set_setting()
+    expect.error_match('invalid setting',
+                       function() s.set_setting('unknown_setting', '-') end)
+
+    expect.error_match('invalid boolean',
+                       function() s.set_setting('query_unsafe', '-') end)
+    s.set_setting('query_unsafe', 'true')
+    expect.true_(s.get_setting('query_unsafe'))
+    s.set_setting('query_unsafe', 'false')
+    expect.false_(s.get_setting('query_unsafe'))
+
+    expect.error_match('invalid integer',
+                       function() s.set_setting('stockpiles_max_bins', '-') end)
+    s.set_setting('stockpiles_max_bins', '10')
+    expect.eq(10, s.get_setting('stockpiles_max_bins'))
+    s.set_setting('stockpiles_max_bins', '11.999')
+    expect.eq(11, s.get_setting('stockpiles_max_bins'))
+
+    s.set_setting('blueprints_dir', '.')
+    expect.eq('.', s.get_setting('blueprints_dir'))
+    s.set_setting('blueprints_dir', '/tmp')
+    expect.eq('/tmp', s.get_setting('blueprints_dir'))
+end
+
+MockFile = defclass(MockFile, nil)
+MockFile.ATTRS{i=0, lines={}}
+function MockFile:close() end
+function MockFile:reset(lines) self.lines, self.i = lines, 0 end
+function MockFile:read()
+    self.i = self.i + 1
+    return self.lines[self.i]
+end
+
+local function mock_open()
+    return MockFile{}
+end
+
+function test.read_settings()
+    local mock_reader =
+            quickfort_reader.TextReader{filepath='f', open_fn=mock_open}
+    local mock_file = mock_reader.source
+
+    local mock_print = mock.func()
+    mock.patch(quickfort_set, 'print', mock_print,
+        function()
+            s.reset_to_defaults()
+            mock_file:reset{'#comment',
+                            'query_unsafe=true',
+                            'blueprints_dir = a dir'}
+            s.read_settings(mock_reader)
+            expect.true_(s.get_setting('query_unsafe'))
+            expect.eq('a dir', s.get_setting('blueprints_dir'))
+        end)
+
+    mock.patch(quickfort_set, 'print', mock_print,
+        function()
+            mock_file:reset{'bad_var=something'}
+            expect.error_match('invalid setting',
+                               function() s.read_settings(mock_reader) end)
+        end)
+end
+
+function test.reset_to_defaults()
+    s.set_setting('stockpiles_max_bins', '10')
+    expect.eq(10, s.get_setting('stockpiles_max_bins'))
+    s.reset_to_defaults()
+    expect.eq(-1, s.get_setting('stockpiles_max_bins'))
+end
+
+function test.reset_settings()
+    local mock_reader =
+            quickfort_reader.TextReader{filepath='f', open_fn=mock_open}
+    local mock_file = mock_reader.source
+
+    local mock_print = mock.func()
+    mock.patch(quickfort_set, 'print', mock_print,
+        function()
+            mock_file:reset{'query_unsafe=true'}
+            s.reset_to_defaults()
+            expect.false_(s.get_setting('query_unsafe'))
+            s.set_setting('blueprints_dir', '.')
+            s.reset_settings(function() return mock_reader end)
+            expect.true_(s.get_setting('query_unsafe'))
+            expect.eq('blueprints', s.get_setting('blueprints_dir'))
+        end)
+
+    mock_print = mock.func()
+    mock.patch(quickfort_set, 'print', mock_print,
+        function()
+            s.reset_settings(function() qerror('err') end)
+            expect.eq(1, mock_print.call_count)
+            expect.eq('err; using internal defaults',
+                      mock_print.call_args[1][1])
+        end)
+end


### PR DESCRIPTION
solves the following bugs:
- if the config file didn't mention a config var, it wouldn't get reset to defaults when `quickfort reset` was called
- instead of crashing, we now use built-in defaults when the `dfhack-config/quickfort/quickfort.txt` config file is not found

internal changes:
- move the `settings` table from common into set and wraps it in an API so calling code doesn't have to be aware of the internal structure of the table. default values are now stored along with the current value so we can reset to defaults reliably.
- use the new TextReader class to read the config file instead of using `io.open()` directly (enables unit testing)
- move the `valid_modes` table into quickfort/parse. common now only has logging functions.