### PR TITLE
[quickfort] internal cleanup

### DIFF
--- a/internal/quickfort/list.lua
+++ b/internal/quickfort/list.lua
@@ -91,7 +91,7 @@ local num_library_blueprints = 0
 local function scan_blueprints()
     local paths = dfhack.filesystem.listdir_recursive(
         quickfort_set.get_setting('blueprints_dir'), nil, false)
-    blueprints, blueprint_modes = {}, {}
+    blueprints, blueprint_modes, file_scope_aliases = {}, {}, {}
     local library_blueprints = {}
     for _, v in ipairs(paths) do
         local is_library = string.find(v.path, '^library/') ~= nil

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -81,10 +81,6 @@ local function switch_ui_sidebar_mode(sidebar_mode)
     qerror('Unable to get into query mode from current UI viewscreen.')
 end
 
-local function is_same_coord(pos1, pos2)
-    return pos1.x == pos2.x and pos1.y == pos2.y and pos1.z == pos2.z
-end
-
 -- If a tile starts or ends with one of these focus strings, the start and end
 -- focus strings can differ without us flagging it as an error.
 local exempt_focus_strings = utils.invert({
@@ -143,7 +139,7 @@ function do_run(zlevel, grid, ctx)
             if not dry_run
                     and not quickfort_set.get_setting('query_unsafe') then
                 local cursor = guidm.getCursorPos()
-                if not is_same_coord(pos, cursor) then
+                if not same_xyz(pos, cursor) then
                     qerror(string.format(
                         'expected to be at cursor position (%d, %d, %d) on ' ..
                         'screen "%s" but cursor is at (%d, %d, %d); there ' ..


### PR DESCRIPTION
minor fixes; nothing user visible

- clear file_scope_aliases table when rescanning files for listing (prevents table from getting cluttered with data in files that no longer exist)
- use library `same_xyz` instead of duplicate custom fn `same_pos`