### PR TITLE
[quickfort] support --cursor option

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -34,6 +34,7 @@ that repo.
 
 ## Misc Improvements
 - `devel/annc-monitor`: added ``report enable|disable`` subcommand to filter combat reports
+- `quickfort`: now supports the ``--cursor`` option for running a blueprint at specific coordinates instead of starting at the game cursor position
 - `quickfort`: now prints more helpful error messages for invalid modeline markers
 - `quickfort`: added support for extra space characters in blueprints
 - `quickfort`: now prints a warning when an invalid alias is encountered instead of silently ignoring it

--- a/internal/quickfort/command.lua
+++ b/internal/quickfort/command.lua
@@ -75,18 +75,30 @@ function finish_command(ctx, section_name, quiet)
     end
 end
 
+local function parse_cursor(arg)
+    local _, _, x, y, z = arg:find('^(%d+),(%d+),(%d+)$')
+    if not x then
+        qerror(('invalid argument for --cursor option: "%s"; expected format' ..
+                ' is "<x>,<y>,<z>", for example: "30,60,150"'):format(arg))
+    end
+    return {x=tonumber(x), y=tonumber(y), z=tonumber(z)}
+end
+
 function do_command(args)
     local command = args.action
     if not command or not command_switch[command] then
         qerror(string.format('invalid command: "%s"', command))
     end
+    local cursor = guidm.getCursorPos()
     local quiet, verbose, dry_run, section_name = false, false, false, nil
     local other_args = utils.processArgsGetopt(args, {
-            {'q', 'quiet', handler=function() quiet = true end},
-            {'v', 'verbose', handler=function() verbose = true end},
+            {'c', 'cursor', hasArg=true,
+             handler=function(optarg) cursor = parse_cursor(optarg) end},
             {'d', 'dry-run', handler=function() dry_run = true end},
             {'n', 'name', hasArg=true,
              handler=function(optarg) section_name = optarg end},
+            {'q', 'quiet', handler=function() quiet = true end},
+            {'v', 'verbose', handler=function() verbose = true end},
         })
     local blueprint_name = other_args[1]
     if not blueprint_name or blueprint_name == '' then
@@ -102,13 +114,12 @@ function do_command(args)
         mode = quickfort_list.get_blueprint_mode(blueprint_name, section_name)
     end
 
-    local cursor = guidm.getCursorPos()
     if not cursor then
         if command == 'orders' or mode == 'notes' then
             cursor = {x=0, y=0, z=0}
         else
             qerror('please position the game cursor at the blueprint start ' ..
-                   'location')
+                   'location or use the --cursor option')
         end
     end
 

--- a/internal/quickfort/command.lua
+++ b/internal/quickfort/command.lua
@@ -76,7 +76,7 @@ function finish_command(ctx, section_name, quiet)
 end
 
 local function parse_cursor(arg)
-    local _, _, x, y, z = arg:find('^(%d+),(%d+),(%d+)$')
+    local _, _, x, y, z = arg:find('^(-?%d+),(-?%d+),(-?%d+)$')
     if not x then
         qerror(('invalid argument for --cursor option: "%s"; expected format' ..
                 ' is "<x>,<y>,<z>", for example: "30,60,150"'):format(arg))

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -68,14 +68,18 @@ Usage:
 
 **<options>** can be zero or more of:
 
+:``-c``, ``--cursor <x>,<y>,<z>``:
+    Use the specified map coordinates instead of the current cursor position for
+    the blueprint cursor start position. If this option is specified, then an
+    active game map cursor is not necessary.
+``-d``, ``--dry-run``
+    Go through all the motions and print statistics on what would be done, but
+    don't actually change any game state.
 ``-q``, ``--quiet``
     Don't report on what actions were taken (error messages are still shown).
 ``-v``, ``--verbose``
     Output extra debugging information. This is especially useful if the
     blueprint isn't being applied like you expect.
-``-d``, ``--dry-run``
-    Go through all the motions and print statistics on what would be done, but
-    don't actually change any game state.
 
 Example commands::
 

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -68,7 +68,7 @@ Usage:
 
 **<options>** can be zero or more of:
 
-:``-c``, ``--cursor <x>,<y>,<z>``:
+``-c``, ``--cursor <x>,<y>,<z>``
     Use the specified map coordinates instead of the current cursor position for
     the blueprint cursor start position. If this option is specified, then an
     active game map cursor is not necessary.

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -194,14 +194,18 @@ undo    Applies the inverse of the specified blueprint. Dig tiles are
 
 <options> can be zero or more of:
 
+-c, --cursor <x>,<y>,<z>
+    Use the specified map coordinates instead of the current cursor position for
+    the blueprint cursor start position. If this option is specified, then an
+    active game map cursor is not necessary.
+-d, --dry-run
+    Go through all the motions and print statistics on what would be done, but
+    don't actually change any game state.
 -q, --quiet
     Don't report on what actions were taken (error messages are still shown).
 -v, --verbose
     Output extra debugging information. This is especially useful if the
     blueprint isn't being applied like you expect.
--d, --dry-run
-    Go through all the motions and print statistics on what would be done, but
-    don't actually change any game state.
 
 For more info, see:
 https://docs.dfhack.org/en/stable/docs/_auto/base.html#quickfort and


### PR DESCRIPTION
and alphabetize options in help text and in the code

inspired by the new `blueprint` `--cursor` option. it will also be useful for functional testing so we don't have to muck around with sidebar modes or the game cursor in the test code.

note that it's fine if the cursor is off the map. after cropping, there may still be in-bounds tiles