### PR TITLE
[quickfort] fix cropping of tiles that lie on a map edge axis

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,7 +29,7 @@ that repo.
 - `quickfort`: changed to properly detect and report an error on sub-alias params with no values instead of just failing to apply the alias later (if you really want an empty value, use ``{Empty}`` instead)
 - `quickfort`: improved handling of non-rectangular and non-solid extent-based structures (like fancy-shaped stockpiles and farm plots)
 - `quickfort`: fixed conversion of numbers to DF keycodes in ``#query`` blueprints
-- `quickfort`: fixed an off-by-one error when cropping buildings that cross the map edge
+- `quickfort`: fixed various errors with cropping across the map edge
 - `quickfort`: properly reset config to default values in ``quickfort reset`` even if if the ``dfhack-config/quickfort/quickfort.txt`` config file doesn't mention all config vars. aso now works even if the config file doesn't exist
 
 ## Misc Improvements

--- a/internal/quickfort/dig.lua
+++ b/internal/quickfort/dig.lua
@@ -600,9 +600,9 @@ local function do_run_impl(zlevel, grid, ctx)
                         extent_adjacent=extent_adjacent,
                         on_map_edge=bounds:is_on_map_edge(extent_pos)
                     }
-                    if not bounds:is_within_map_bounds(digctx.pos) and
-                            not digctx.on_map_edge then
-                        log('coordinates out of bounds; skipping')
+                    if not bounds:is_on_map(digctx.pos) then
+                        log('coordinates out of bounds; skipping (%d, %d, %d)',
+                            digctx.pos.x, digctx.pos.y, digctx.pos.z)
                         stats.out_of_bounds.value =
                                 stats.out_of_bounds.value + 1
                     else

--- a/internal/quickfort/map.lua
+++ b/internal/quickfort/map.lua
@@ -29,44 +29,36 @@ function MapBoundsChecker:init()
     self.x_max, self.y_max, self.z_max = dims.x - 1, dims.y - 1, dims.z - 1
 end
 
-function MapBoundsChecker:is_within_map_bounds_x(x)
-    return x > self.x_min and x < self.x_max
+-- returns true if the coordinates are on the map and are more than gap tiles
+-- from the edges. gap defaults to 0.
+function MapBoundsChecker:is_on_map(pos, gap)
+    gap = gap or 0
+    return self:is_on_map_x(pos.x, gap) and
+           self:is_on_map_y(pos.y, gap) and
+           self:is_on_map_z(pos.z)
 end
 
-function MapBoundsChecker:is_within_map_bounds_y(y)
-    return y > self.y_min and y < self.y_max
+-- returns true if the coordinates are on the map and are more than gap tiles
+-- from the edges, considering only the x coord. gap defaults to 0.
+function MapBoundsChecker:is_on_map_x(x, gap)
+    gap = gap or 0
+    return x >= self.x_min + gap and x <= self.x_max - gap
 end
 
-function MapBoundsChecker:is_within_map_bounds_z(z)
+-- returns true if the coordinates are on the map and are more than gap tiles
+-- from the edges, considering only the y coord. gap defaults to 0.
+function MapBoundsChecker:is_on_map_y(y, gap)
+    gap = gap or 0
+    return y >= self.y_min + gap and y <= self.y_max - gap
+end
+
+-- returns true if the coordinates are on the map and are more than gap tiles
+-- from the edges. gap defaults to 0.
+function MapBoundsChecker:is_on_map_z(z)
     return z >= self.z_min and z <= self.z_max
 end
 
-function MapBoundsChecker:is_within_map_bounds(pos)
-    return self:is_within_map_bounds_x(pos.x) and
-            self:is_within_map_bounds_y(pos.y) and
-            self:is_within_map_bounds_z(pos.z)
-end
-
-function MapBoundsChecker:is_on_map_edge_x(x)
-    return x == self.x_min or x == self.x_max
-end
-
-function MapBoundsChecker:is_on_map_edge_y(y)
-    return y == self.y_min or y == self.y_max
-end
-
+-- returns true if the coordinates are on one of the edge tiles of the map
 function MapBoundsChecker:is_on_map_edge(pos)
-    return self:is_on_map_edge_x(pos.x) or self:is_on_map_edge_y(pos.y)
-end
-
-function MapBoundsChecker:is_on_map_x(x)
-    return self:is_within_map_bounds_x(x) or self:is_on_map_edge_x(x)
-end
-
-function MapBoundsChecker:is_on_map_y(y)
-    return self:is_within_map_bounds_y(y) or self:is_on_map_edge_y(y)
-end
-
-function MapBoundsChecker:is_on_map_z(z)
-    return self:is_within_map_bounds_z(z)
+    return self:is_on_map(pos) and not self:is_on_map(pos, 1)
 end

--- a/test/quickfort/map_unit.lua
+++ b/test/quickfort/map_unit.lua
@@ -9,70 +9,11 @@ end
 local dims = {x=3, y=4, z=5}
 local bounds = m.MapBoundsChecker{dims=dims}
 
-function test.is_within_map_bounds_x()
-    expect.false_(bounds:is_within_map_bounds_x(-2))
-    expect.false_(bounds:is_within_map_bounds_x(-1))
-    expect.false_(bounds:is_within_map_bounds_x(0))
-    expect.true_(bounds:is_within_map_bounds_x(1))
-    expect.false_(bounds:is_within_map_bounds_x(2))
-    expect.false_(bounds:is_within_map_bounds_x(3))
-    expect.false_(bounds:is_within_map_bounds_x(4))
-end
-
-function test.is_within_map_bounds_y()
-    expect.false_(bounds:is_within_map_bounds_y(-2))
-    expect.false_(bounds:is_within_map_bounds_y(-1))
-    expect.false_(bounds:is_within_map_bounds_y(0))
-    expect.true_(bounds:is_within_map_bounds_y(1))
-    expect.true_(bounds:is_within_map_bounds_y(2))
-    expect.false_(bounds:is_within_map_bounds_y(3))
-    expect.false_(bounds:is_within_map_bounds_y(4))
-    expect.false_(bounds:is_within_map_bounds_y(5))
-end
-
-function test.is_within_map_bounds_z()
-    expect.false_(bounds:is_within_map_bounds_z(-2))
-    expect.false_(bounds:is_within_map_bounds_z(-1))
-    expect.true_(bounds:is_within_map_bounds_z(0))
-    expect.true_(bounds:is_within_map_bounds_z(1))
-    expect.true_(bounds:is_within_map_bounds_z(2))
-    expect.true_(bounds:is_within_map_bounds_z(3))
-    expect.true_(bounds:is_within_map_bounds_z(4))
-    expect.false_(bounds:is_within_map_bounds_z(5))
-    expect.false_(bounds:is_within_map_bounds_z(6))
-end
-
-function test.is_within_map_bounds()
-    expect.false_(bounds:is_within_map_bounds({x=10, y=1, z=1}), 'bad x')
-    expect.false_(bounds:is_within_map_bounds({x=1, y=10, z=1}), 'bad y')
-    expect.false_(bounds:is_within_map_bounds({x=1, y=1, z=10}), 'bad z')
-    expect.true_(bounds:is_within_map_bounds({x=1, y=1, z=1}), 'good')
-end
-
-function test.is_on_map_edge_x()
-    expect.false_(bounds:is_on_map_edge_x(-1))
-    expect.true_(bounds:is_on_map_edge_x(0))
-    expect.false_(bounds:is_on_map_edge_x(1))
-    expect.false_(bounds:is_on_map_edge_x(1))
-    expect.true_(bounds:is_on_map_edge_x(2))
-    expect.false_(bounds:is_on_map_edge_x(3))
-end
-
-function test.is_on_map_edge_y()
-    expect.false_(bounds:is_on_map_edge_y(-1))
-    expect.true_(bounds:is_on_map_edge_y(0))
-    expect.false_(bounds:is_on_map_edge_y(1))
-    expect.false_(bounds:is_on_map_edge_y(2))
-    expect.true_(bounds:is_on_map_edge_y(3))
-    expect.false_(bounds:is_on_map_edge_y(4))
-end
-
-function test.is_on_map_edge()
-    expect.false_(bounds:is_on_map_edge({x=1, y=1, z=1}), 'not x or y')
-    expect.true_(bounds:is_on_map_edge({x=0, y=1, z=1}), 'on x left')
-    expect.true_(bounds:is_on_map_edge({x=2, y=1, z=1}), 'on x right')
-    expect.true_(bounds:is_on_map_edge({x=1, y=0, z=1}), 'on y top')
-    expect.true_(bounds:is_on_map_edge({x=1, y=3, z=1}), 'on y bottom')
+function test.is_on_map()
+    expect.false_(bounds:is_on_map({x=10, y=1, z=1}), 'bad x')
+    expect.false_(bounds:is_on_map({x=1, y=10, z=1}), 'bad y')
+    expect.false_(bounds:is_on_map({x=1, y=1, z=10}), 'bad z')
+    expect.true_(bounds:is_on_map({x=1, y=1, z=1}), 'good')
 end
 
 function test.is_on_map_x()
@@ -106,4 +47,14 @@ function test.is_on_map_z()
     expect.true_(bounds:is_on_map_z(4))
     expect.false_(bounds:is_on_map_z(5))
     expect.false_(bounds:is_on_map_z(6))
+end
+
+function test.is_on_map_edge()
+    expect.false_(bounds:is_on_map_edge({x=1, y=1, z=1}), 'not x or y')
+    expect.true_(bounds:is_on_map_edge({x=0, y=1, z=1}), 'on x left')
+    expect.true_(bounds:is_on_map_edge({x=2, y=1, z=1}), 'on x right')
+    expect.true_(bounds:is_on_map_edge({x=1, y=0, z=1}), 'on y top')
+    expect.true_(bounds:is_on_map_edge({x=1, y=3, z=1}), 'on y bottom')
+    expect.false_(bounds:is_on_map_edge({x=0, y=-1, z=1}), 'on x but bad y')
+    expect.false_(bounds:is_on_map_edge({x=-1, y=0, z=1}), 'on y but bad x')
 end


### PR DESCRIPTION
but are out of bounds in the other edge axis (e.g. x=0, y=-1)

found while testing #284

as a byproduct of fixing this bug, this PR significantly simplifies the `map.lua` code.