### PR TITLE
[quickfort] be more quiet when --quiet is passed

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -37,6 +37,7 @@ that repo.
 - `quickfort`: now prints more helpful error messages for invalid modeline markers
 - `quickfort`: added support for extra space characters in blueprints
 - `quickfort`: now prints a warning when an invalid alias is encountered instead of silently ignoring it
+- `quickfort`: is now more quiet when the ``--quiet`` parameter is specified
 - `setfps`: improved error handling
 
 # 0.47.05-r1

--- a/internal/quickfort/command.lua
+++ b/internal/quickfort/command.lua
@@ -63,10 +63,10 @@ end
 
 function finish_command(ctx, section_name, quiet)
     if ctx.command == 'orders' then quickfort_orders.create_orders(ctx) end
-    print(string.format('%s successfully completed',
-                        quickfort_parse.format_command(
-                            ctx.command, ctx.blueprint_name, section_name)))
     if not quiet then
+        print(string.format('%s successfully completed',
+                            quickfort_parse.format_command(
+                                ctx.command, ctx.blueprint_name, section_name)))
         for _,stat in pairs(ctx.stats) do
             if stat.always or stat.value > 0 then
                 print(string.format('  %s: %d', stat.label, stat.value))

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -69,7 +69,7 @@ Usage:
 **<options>** can be zero or more of:
 
 ``-q``, ``--quiet``
-    Don't report on what actions were taken (error messages are still shown).
+    Suppress non-error console output.
 ``-v``, ``--verbose``
     Output extra debugging information. This is especially useful if the
     blueprint isn't being applied like you expect.
@@ -191,7 +191,7 @@ undo    Applies the inverse of the specified blueprint. Dig tiles are
 <options> can be zero or more of:
 
 -q, --quiet
-    Don't report on what actions were taken (error messages are still shown).
+    Suppress non-error console output.
 -v, --verbose
     Output extra debugging information. This is especially useful if the
     blueprint isn't being applied like you expect.


### PR DESCRIPTION
suppresses all console output when running quickfort in functional tests