### PR TITLE
[gui/blueprint] get into an appropriate mode on display

### DIFF
--- a/gui/blueprint.lua
+++ b/gui/blueprint.lua
@@ -112,6 +112,9 @@ function BlueprintUI:onAboutToShow()
     end
 
     self.saved_mode = df.global.ui.main.mode
+    if dfhack.gui.getCurFocus(true):find('^dfhack/') then
+        self.saved_mode = df.ui_sidebar_mode.Default
+    end
     switch_ui_sidebar_mode(df.ui_sidebar_mode.LookAround)
 end
 

--- a/gui/blueprint.lua
+++ b/gui/blueprint.lua
@@ -78,34 +78,6 @@ function BlueprintUI:init()
     }
 end
 
--- the sidebar modes that we know how to get back to
-local basic_ui_sidebar_modes = {
-    [df.ui_sidebar_mode.Default]='',
-    [df.ui_sidebar_mode.QueryBuilding]='D_BUILDJOB',
-    [df.ui_sidebar_mode.LookAround]='D_LOOK',
-    [df.ui_sidebar_mode.BuildingItems]='D_BUILDITEM',
-    [df.ui_sidebar_mode.Stockpiles]='D_STOCKPILES',
-    [df.ui_sidebar_mode.Zones]='D_CIVZONE',
-}
-
--- Send ESC keycodes until we get to dwarfmode/Default and then enter the
--- specified sidebar mode. If we don't get to Default after 10 presses of ESC,
--- error. The target sidebar mode must be a member of basic_ui_sidebar_modes.
-local function switch_ui_sidebar_mode(sidebar_mode)
-    for i=1,10 do
-        if df.global.ui.main.mode == df.ui_sidebar_mode.Default and
-                dfhack.gui.getCurFocus(true) == 'dwarfmode/Default' then
-            if sidebar_mode ~= df.ui_sidebar_mode.Default then
-                gui.simulateInput(dfhack.gui.getCurViewscreen(true),
-                                basic_ui_sidebar_modes[sidebar_mode])
-            end
-            return
-        end
-        gui.simulateInput(dfhack.gui.getCurViewscreen(true), 'LEAVESCREEN')
-    end
-    qerror('Unable to get into target sidebar mode from current UI viewscreen.')
-end
-
 function BlueprintUI:onAboutToShow()
     if not dfhack.isMapLoaded() then
         qerror('Please load a fortress map.')
@@ -115,14 +87,14 @@ function BlueprintUI:onAboutToShow()
     if dfhack.gui.getCurFocus(true):find('^dfhack/') then
         self.saved_mode = df.ui_sidebar_mode.Default
     end
-    switch_ui_sidebar_mode(df.ui_sidebar_mode.LookAround)
+    guidm.enterSidebarMode(df.ui_sidebar_mode.LookAround)
 end
 
 function BlueprintUI:onDismiss()
     if not basic_ui_sidebar_modes[self.saved_mode] then
         self.saved_mode = df.ui_sidebar_mode.Default
     end
-    switch_ui_sidebar_mode(self.saved_mode)
+    guidm.enterSidebarMode(self.saved_mode)
 end
 
 function BlueprintUI:on_mark(pos)

--- a/gui/blueprint.lua
+++ b/gui/blueprint.lua
@@ -91,7 +91,7 @@ function BlueprintUI:onAboutToShow()
 end
 
 function BlueprintUI:onDismiss()
-    if not basic_ui_sidebar_modes[self.saved_mode] then
+    if not guidm.SIDEBAR_MODE_KEYS[self.saved_mode] then
         self.saved_mode = df.ui_sidebar_mode.Default
     end
     guidm.enterSidebarMode(self.saved_mode)

--- a/test/gui/blueprint.lua
+++ b/test/gui/blueprint.lua
@@ -194,7 +194,7 @@ end
 --auto enter and leave cursor-supporting mode
 
 function test.restore_mode()
-    df.global.ui.main.mode = df.ui_sidebar_mode.Stockpiles
+    guidm.enterSidebarMode(df.ui_sidebar_mode.Stockpiles)
     load_ui()
     expect.eq(df.ui_sidebar_mode.LookAround, df.global.ui.main.mode)
     send_keys('LEAVESCREEN') -- cancel out of ui
@@ -202,8 +202,9 @@ function test.restore_mode()
     send_keys('LEAVESCREEN') -- get back to Default mode
 end
 
-function test.restore_default_on_unknown_mode()
-    df.global.ui.main.mode = df.ui_sidebar_mode.Burrows
+function test.restore_default_on_unsupported_mode()
+    guidm.enterSidebarMode(df.ui_sidebar_mode.Default)
+    send_keys('D_BURROWS')
     load_ui()
     expect.eq(df.ui_sidebar_mode.LookAround, df.global.ui.main.mode)
     send_keys('LEAVESCREEN') -- cancel out of ui

--- a/test/gui/blueprint.lua
+++ b/test/gui/blueprint.lua
@@ -49,7 +49,7 @@ function test.minimal_happy_path()
             expect.table_eq({'2', '3', '-4', 'blueprint', '--cursor=10,20,33'},
                             mock_run.call_args[1])
             send_keys('SELECT') -- dismiss the success messagebox
-            while view:isActive() do delay() end -- wait for view to disappear
+            delay_until(view:callback('isDismissed'))
             expect.nil_(dfhack.gui.getCurFocus(true):find('^dfhack/'))
         end)
 end
@@ -93,7 +93,7 @@ function test.cancel_selection()
                             '--cursor=11,22,27'},
                             mock_run.call_args[1])
             send_keys('SELECT') -- dismiss the success messagebox
-            while view:isActive() do delay() end -- wait for view to disappear
+            delay_until(view:callback('isDismissed'))
             expect.nil_(dfhack.gui.getCurFocus(true):find('^dfhack/'))
         end)
 end


### PR DESCRIPTION
depends on DFHack/dfhack#1884 and DFHack/dfhack#1887

and restore previous mode on dismiss

The mode switching logic is very similar to what is used in quickfort's `query.lua` and what was copied to the `mass-remove` script. Does it belong in the library? If so, where?