### PR TITLE
[gui/blueprint] gracefully handle relaunches while the ui is still active

### DIFF
--- a/gui/blueprint.lua
+++ b/gui/blueprint.lua
@@ -188,6 +188,13 @@ function BlueprintUI:commit(pos)
     }:show()
 end
 
-if not dfhack_flags.module then
-    BlueprintUI{}:show()
+if dfhack_flags.module then
+    return
 end
+
+if active_screen then
+    active_screen:dismiss()
+end
+
+active_screen = BlueprintUI{}
+active_screen:show()

--- a/test/gui/blueprint.lua
+++ b/test/gui/blueprint.lua
@@ -203,6 +203,30 @@ end
 --auto enter and leave cursor-supporting mode
 
 -- clear and reshow ui if gui/blueprint is run while currently shown
+function test.replace_ui()
+    dfhack.run_script('gui/blueprint')
+    expect.eq('dfhack/lua/blueprint', dfhack.gui.getCurFocus(true))
+    local view = b.active_screen
+    expect.true_(not not view)
+    dfhack.run_script('gui/blueprint')
+    expect.eq('dfhack/lua/blueprint', dfhack.gui.getCurFocus(true))
+    expect.true_(not not b.active_screen)
+    expect.ne(view, b.active_screen)
+    send_keys('LEAVESCREEN') -- cancel out of ui
+    expect.nil_(dfhack.gui.getCurFocus(true):find('^dfhack/'),
+                'ensure the original ui is not still on the stack')
+end
+
+function test.reset_ui()
+    dfhack.run_script('gui/blueprint')
+    send_keys('SELECT') -- set cursor position
+    expect.true_(not not b.active_screen.mark)
+    dfhack.run_script('gui/blueprint')
+    expect.nil_(b.active_screen.mark)
+    send_keys('LEAVESCREEN') -- cancel out of ui
+    expect.nil_(dfhack.gui.getCurFocus(true):find('^dfhack/'),
+                'ensure the original ui is not still on the stack')
+end
 
 -- mouse support for selecting boundary tiles
 


### PR DESCRIPTION
resets and replaces the currently visible ui if the script is launched over an instance of itself.