### PR TITLE
[gui/blueprint] show selected area dimensions when moving cursor

### DIFF
--- a/gui/blueprint.lua
+++ b/gui/blueprint.lua
@@ -53,6 +53,7 @@ ActionPanel.ATTRS{
 function ActionPanel:init()
     self:addviews{
         widgets.Label{
+            view_id='action_label',
             text={{text=self:callback('get_action_text')}},
             frame={t=0},
         },
@@ -99,7 +100,8 @@ function BlueprintUI:init()
         widgets.Label{text='Blueprint'},
         widgets.Label{text=summary, text_pen=COLOR_GREY},
         ActionPanel{get_mark_fn=function() return self.mark end},
-        widgets.Label{text={{text=function() return self:get_cancel_label() end,
+        widgets.Label{view_id='cancel_label',
+                      text={{text=function() return self:get_cancel_label() end,
                              key='LEAVESCREEN', key_sep=': ',
                              on_activate=function() self:on_cancel() end}}},
     }

--- a/gui/blueprint.lua
+++ b/gui/blueprint.lua
@@ -124,7 +124,6 @@ end
 
 function BlueprintUI:on_mark(pos)
     self.mark = pos
-    self:updateSubviewLayout()
     self:updateLayout()
 end
 
@@ -138,15 +137,16 @@ end
 function BlueprintUI:on_cancel()
     if self.mark then
         self.mark = nil
-        self:updateSubviewLayout()
         self:updateLayout()
     else
         self:dismiss()
     end
 end
 
-function BlueprintUI:postUpdateLayout()
-    -- lay out subviews, adding an extra line of space between widgets
+function BlueprintUI:updateLayout(parent_rect)
+    -- set frame boundaries and calculate subframe heights
+    BlueprintUI.super.updateLayout(self, parent_rect)
+    -- vertically lay out subviews, adding an extra line of space between each
     local y = 0
     for _,subview in ipairs(self.subviews) do
         subview.frame.t = y
@@ -154,6 +154,7 @@ function BlueprintUI:postUpdateLayout()
             y = y + subview.frame.h + 1
         end
     end
+    -- recalculate widget frames
     self:updateSubviewLayout()
 end
 

--- a/test/gui/blueprint.lua
+++ b/test/gui/blueprint.lua
@@ -304,10 +304,10 @@ end
 -- live status line showing the dimensions of the currently selected area
 function test.render_status_line()
     local view = load_ui()
+    view:updateLayout()
     local status_label = view.subviews.selected_area
     local status_text_pos = {x=status_label.frame_body.x1,
                              y=status_label.frame_body.y1}
-    view:updateLayout()
     view:onRender()
     expect.false_(status_label.visible)
     guidm.setCursorPos({x=10, y=20, z=30})

--- a/test/gui/blueprint.lua
+++ b/test/gui/blueprint.lua
@@ -116,6 +116,7 @@ end
 
 function test.render_labels()
     local view = load_ui()
+    view:updateLayout()
     view:onRender()
     local action_label = view.subviews.action_label
     local action_word_pos = {x=action_label.frame_body.x1+11,
@@ -306,6 +307,7 @@ function test.render_status_line()
     local status_label = view.subviews.selected_area
     local status_text_pos = {x=status_label.frame_body.x1,
                              y=status_label.frame_body.y1}
+    view:updateLayout()
     view:onRender()
     expect.false_(status_label.visible)
     guidm.setCursorPos({x=10, y=20, z=30})

--- a/test/gui/blueprint.lua
+++ b/test/gui/blueprint.lua
@@ -110,6 +110,10 @@ local function get_screen_word(screen_pos)
     return str
 end
 
+local function get_cancel_word_pos(cancel_label)
+    return {x=cancel_label.frame_body.x1+5, y=cancel_label.frame_body.y1}
+end
+
 function test.render_labels()
     local view = load_ui()
     view:onRender()
@@ -117,19 +121,17 @@ function test.render_labels()
     local action_word_pos = {x=action_label.frame_body.x1+11,
                              y=action_label.frame_body.y1}
     local cancel_label = view.subviews[4]
-    local cancel_word_pos = {x=cancel_label.frame_body.x1+5,
-                             y=cancel_label.frame_body.y1}
     expect.eq('first', get_screen_word(action_word_pos))
-    expect.eq('Back', get_screen_word(cancel_word_pos))
+    expect.eq('Back', get_screen_word(get_cancel_word_pos(cancel_label)))
     guidm.setCursorPos({x=10, y=20, z=30})
     send_keys('SELECT')
     view:onRender()
     expect.eq('second', get_screen_word(action_word_pos))
-    expect.eq('Cancel', get_screen_word(cancel_word_pos))
+    expect.eq('Cancel', get_screen_word(get_cancel_word_pos(cancel_label)))
     send_keys('LEAVESCREEN') -- cancel selection
     view:onRender()
     expect.eq('first', get_screen_word(action_word_pos))
-    expect.eq('Back', get_screen_word(cancel_word_pos))
+    expect.eq('Back', get_screen_word(get_cancel_word_pos(cancel_label)))
     send_keys('LEAVESCREEN') -- leave UI
     expect.nil_(dfhack.gui.getCurFocus(true):find('^dfhack/'))
 end
@@ -299,6 +301,33 @@ function test.set_with_mouse()
 end
 
 -- live status line showing the dimensions of the currently selected area
+function test.render_status_line()
+    local view = load_ui()
+    local status_label = view.subviews[3].subviews.selected_area
+    local status_text_pos = {x=status_label.frame_body.x1,
+                             y=status_label.frame_body.y1}
+    view:onRender()
+    expect.false_(status_label.visible)
+    guidm.setCursorPos({x=10, y=20, z=30})
+    send_keys('SELECT')
+    view:onRender()
+    expect.true_(status_label.visible)
+    expect.eq('1x1x1', get_screen_word(status_text_pos))
+
+    send_keys('CURSOR_LEFT', 'CURSOR_DOWN', 'CURSOR_DOWN')
+    view:onRender()
+    expect.eq('2x3x1', get_screen_word(status_text_pos))
+
+    send_keys('CURSOR_UP_Z', 'CURSOR_UP_Z', 'CURSOR_UP_Z')
+    view:onRender()
+    expect.eq('2x3x4', get_screen_word(status_text_pos))
+
+    send_keys('LEAVESCREEN') -- cancel selection
+    view:onRender()
+    expect.false_(status_label.visible)
+
+    send_keys('LEAVESCREEN') -- leave UI
+end
 
 -- edit widget for setting the blueprint name
 

--- a/test/gui/blueprint.lua
+++ b/test/gui/blueprint.lua
@@ -117,10 +117,10 @@ end
 function test.render_labels()
     local view = load_ui()
     view:onRender()
-    local action_label = view.subviews[3].subviews[1]
+    local action_label = view.subviews.action_label
     local action_word_pos = {x=action_label.frame_body.x1+11,
                              y=action_label.frame_body.y1}
-    local cancel_label = view.subviews[4]
+    local cancel_label = view.subviews.cancel_label
     expect.eq('first', get_screen_word(action_word_pos))
     expect.eq('Back', get_screen_word(get_cancel_word_pos(cancel_label)))
     guidm.setCursorPos({x=10, y=20, z=30})
@@ -303,7 +303,7 @@ end
 -- live status line showing the dimensions of the currently selected area
 function test.render_status_line()
     local view = load_ui()
-    local status_label = view.subviews[3].subviews.selected_area
+    local status_label = view.subviews.selected_area
     local status_text_pos = {x=status_label.frame_body.x1,
                              y=status_label.frame_body.y1}
     view:onRender()


### PR DESCRIPTION
In addition to the dynamic status line that displays the selected area after the initial mark has been set, this commit introduces auto-resize functionality for the action panel. The ResizingPanel subclass will also be used for the upcoming Phases panel, which changes height based on whether phases should be autodetected or set manually.

The sequence I have to follow to get the layout set seems somewhat inefficient and I'm wondering if there is a better way to do it. I have to set the component widget positions after I know their heights, i.e. in `BlueprintUI:postUpdateLayout()`, but the widgets won't know their heights until `BlueprintUI:updateSubviewLayout()` is called, but the widgets *also* need to be re-laid out after their positions have been set so their subframes can be recomputed. So I end up having to rerun layout methods until properties are done shuffling. I've played around with the sequence, but I haven't found anything better than what I already have. In particular, I can't move any logic to a `preUpdateLayout()` method (which could otherwise remove the need to lay out subcomponents twice) since frames don't exist until subcomponents are done with their initial layout. Layout doesn't happen so often that I'm too worried about the inefficiency, though.