### PR TITLE
[gui/blueprint] support editable names for blueprint files

### DIFF
--- a/gui/blueprint.lua
+++ b/gui/blueprint.lua
@@ -126,8 +126,9 @@ function NamePanel:detect_name_collision()
 
     local paths = dfhack.filesystem.listdir_recursive('blueprints', nil, false)
     for _,v in ipairs(paths) do
-        if v.path:startswith(name) and
-                v.path:sub(suffix_pos,suffix_pos):find('[.-]') then
+        if (v.isdir and v.path..'/' == name) or
+                (v.path:startswith(name) and
+                 v.path:sub(suffix_pos,suffix_pos):find('[.-]')) then
             self.has_name_collision = true
             return
         end

--- a/gui/blueprint.lua
+++ b/gui/blueprint.lua
@@ -23,6 +23,7 @@ local blueprint = require('plugins.blueprint')
 local dialogs = require('gui.dialogs')
 local gui = require('gui')
 local guidm = require('gui.dwarfmode')
+local utils = require('utils')
 local widgets = require('gui.widgets')
 
 ResizingPanel = defclass(ResizingPanel, widgets.Panel)
@@ -84,6 +85,67 @@ function ActionPanel:get_area_text()
     return ('%dx%dx%d (%d tile%s)'):format(width, height, depth, tiles, plural)
 end
 
+NamePanel = defclass(NamePanel, ResizingPanel)
+NamePanel.ATTRS{
+    name='blueprint',
+}
+function NamePanel:init()
+    self:addviews{
+        widgets.EditField{
+            view_id='name',
+            frame={t=0,h=1},
+            key='CUSTOM_N',
+            active=false,
+            text=self.name,
+            on_change=self:callback('detect_name_collision'),
+        },
+        widgets.Label{
+            view_id='name_help',
+            frame={t=1,l=2},
+            text={{text=self:callback('get_name_help', 1),
+                   pen=self:callback('get_help_pen')}, '\n',
+                  {text=self:callback('get_name_help', 2),
+                   pen=self:callback('get_help_pen')}}
+        },
+    }
+
+    self:detect_name_collision()
+end
+function NamePanel:detect_name_collision()
+    -- don't let base names start with a slash - it would get ignored by
+    -- the blueprint plugin later anyway
+    local name = utils.normalizePath(self.subviews.name.text):gsub('^/','')
+    self.subviews.name.text = name
+
+    if name == '' then
+        self.has_name_collision = false
+        return
+    end
+
+    local suffix_pos = #name + 1
+
+    local paths = dfhack.filesystem.listdir_recursive('blueprints', nil, false)
+    for _,v in ipairs(paths) do
+        if v.path:startswith(name) and
+                v.path:sub(suffix_pos,suffix_pos):find('[.-]') then
+            self.has_name_collision = true
+            return
+        end
+    end
+    self.has_name_collision = false
+end
+function NamePanel:get_name_help(line_number)
+    if self.has_name_collision then
+        return ({'Warning: may overwrite',
+                 'existing files.'})[line_number]
+    end
+    return ({'Set base name for the',
+             'generated blueprint files.'})[line_number]
+end
+function NamePanel:get_help_pen()
+    return self.has_name_collision and COLOR_RED or COLOR_GREY
+end
+
 BlueprintUI = defclass(BlueprintUI, guidm.MenuOverlay)
 BlueprintUI.ATTRS {
     presets={},
@@ -100,6 +162,7 @@ function BlueprintUI:init()
         widgets.Label{text='Blueprint'},
         widgets.Label{text=summary, text_pen=COLOR_GREY},
         ActionPanel{get_mark_fn=function() return self.mark end},
+        NamePanel{name=self.presets.name},
         widgets.Label{view_id='cancel_label',
                       text={{text=function() return self:get_cancel_label() end,
                              key='LEAVESCREEN', key_sep=': ',
@@ -205,6 +268,31 @@ function BlueprintUI:onRenderBody()
 end
 
 function BlueprintUI:onInput(keys)
+    -- the 'name' edit field must have its 'active' state managed at this level.
+    -- we also have to implement 'cancel edit' logic here
+    local name_view = self.subviews.name
+    if not name_view.active and keys[name_view.key] then
+        self.saved_name = name_view.text
+        if name_view.text == 'blueprint' then
+            name_view.text = ''
+            name_view:on_change()
+        end
+        name_view.active = true
+        return true
+    end
+    if name_view.active then
+        if keys.SELECT or keys.LEAVESCREEN then
+            name_view.active = false
+            if keys.LEAVESCREEN or name_view.text == '' then
+                name_view.text = self.saved_name
+                name_view:on_change()
+            end
+            return true
+        end
+        name_view:onInput(keys)
+        return true
+    end
+
     if self:inputToSubviews(keys) then return true end
 
     local pos = nil
@@ -241,7 +329,7 @@ function BlueprintUI:commit(pos)
         depth = -depth
     end
 
-    local name = 'blueprint'
+    local name = self.subviews.name.text
     local params = {tostring(width), tostring(height), tostring(depth), name}
 
     -- set cursor to top left corner of the *uppermost* z-level

--- a/test/gui/blueprint.lua
+++ b/test/gui/blueprint.lua
@@ -1,5 +1,10 @@
+local function test_wrapper(test_fn)
+    mock.patch(dfhack.filesystem, 'listdir_recursive', mock.func({}), test_fn)
+end
+
 config = {
     mode = 'fortress',
+    wrapper = test_wrapper,
 }
 
 local b = reqscript('gui/blueprint')
@@ -201,7 +206,8 @@ function test.preset_cursor()
     local view = b.active_screen
     expect.table_eq({x=11, y=12, z=13}, guidm.getCursorPos())
     expect.true_(not not view.mark)
-    send_keys('LEAVESCREEN', 'LEAVESCREEN') -- cancel selection and ui
+    -- cancel selection, ui, and look mode
+    send_keys('LEAVESCREEN', 'LEAVESCREEN', 'LEAVESCREEN')
 end
 
 --auto enter and leave cursor-supporting mode
@@ -342,5 +348,67 @@ function test.render_status_line()
 end
 
 -- edit widget for setting the blueprint name
+function test.preset_basename()
+    dfhack.run_script('gui/blueprint', 'imaname')
+    local view = b.active_screen
+    expect.eq('imaname', view.subviews.name.text)
+    send_keys('LEAVESCREEN') -- leave UI
+end
+
+function test.edit_basename()
+    local view = load_ui()
+    local name_widget = view.subviews.name
+    expect.eq('blueprint', name_widget.text)
+    send_keys('CUSTOM_N')
+    expect.eq('', name_widget.text)
+    view:onInput({_STRING=string.byte('h')})
+    view:onInput({_STRING=string.byte('i')})
+    send_keys('SELECT')
+    expect.eq('hi', name_widget.text)
+    send_keys('LEAVESCREEN') -- leave UI
+end
+
+function test.cancel_name_edit()
+    local view = load_ui()
+    local name_widget = view.subviews.name
+    expect.eq('blueprint', name_widget.text)
+    send_keys('CUSTOM_N')
+    expect.eq('', name_widget.text)
+    view:onInput({_STRING=string.byte('h')})
+    view:onInput({_STRING=string.byte('i')})
+    send_keys('LEAVESCREEN') -- cancel edit
+    expect.eq('blueprint', name_widget.text)
+    send_keys('LEAVESCREEN') -- leave UI
+end
+
+function test.name_no_collision()
+    mock.patch(dfhack.filesystem, 'listdir_recursive',
+               mock.func({{path='blue-dig.csv'}}),
+        function()
+            local view = load_ui()
+            view:updateLayout()
+            local name_help_label = view.subviews.name_help
+            local name_help_text_pos = {x=name_help_label.frame_body.x1,
+                                        y=name_help_label.frame_body.y1}
+            view:onRender()
+            expect.eq('Set', get_screen_word(name_help_text_pos))
+            send_keys('LEAVESCREEN') -- cancel ui
+        end)
+end
+
+function test.name_collision()
+    mock.patch(dfhack.filesystem, 'listdir_recursive',
+               mock.func({{path='blueprint-dig.csv'}}),
+        function()
+            local view = load_ui()
+            view:updateLayout()
+            local name_help_label = view.subviews.name_help
+            local name_help_text_pos = {x=name_help_label.frame_body.x1,
+                                        y=name_help_label.frame_body.y1}
+            view:onRender()
+            expect.eq('Warning:', get_screen_word(name_help_text_pos))
+            send_keys('LEAVESCREEN') -- cancel ui
+        end)
+end
 
 -- widgets to configure which blueprint phases to output


### PR DESCRIPTION
Add an edit widget so generated blueprint names are customizable. A warning is displayed if the generated files might overwrite existing blueprints. Hitting ESC while editing (or hitting ENTER while the edit field is blank) aborts the edit and restores the previous name. The blueprint name can be initialized on the commandline.

I felt like I had to get slightly creative to manage the state of the edit widget. The edit widget is not self-contained in that it can't manage it's own "active" state (it doesn't get notified of the activation hotkey if it isn't already active). I'm not sure if anything needs to change here right now, but it seems like "self-activating" widgets could use some more thought and API design.

There is a soft dependency on DFHack/dfhack#1892. Everything will work fine without that PR, but the tests that don't otherwise mock out `dfhack.filesystem.listdir_recursive()` will scan the real directory tree. This has no effect on the tests other than the (negligible) extra time it takes to do the IO, but my preference is to prevent tests from doing IO unless they absolutely need to.