### PR TITLE
[gui/load-screen] prepare to use library string split

### DIFF
--- a/gui/load-screen.lua
+++ b/gui/load-screen.lua
@@ -520,7 +520,7 @@ function mkscreen()
 end
 
 if initialized == nil then
-    local major_version = tonumber(dfhack.getDFVersion():split('.')[2])
+    local major_version = tonumber(dfhack.getDFVersion():split('.', true)[2])
     if not major_version or major_version < 40 then
         qerror('gui/load-screen only supports DF 0.40.xx and above')
     end


### PR DESCRIPTION
Step 1 of DFHack/dfhack#1888

this is a noop for the current implementation, since the extra parameter will just get ignored, but this allows `gui/load-screen` to continue working when we add the library implementation of `string:split` and remove the override in `gui/load-screen`