### PR TITLE
[gui/blueprint] allow blueprint phases to be configurable

### DIFF
--- a/test/gui/blueprint.lua
+++ b/test/gui/blueprint.lua
@@ -212,8 +212,7 @@ function test.preset_cursor()
     send_keys('LEAVESCREEN', 'LEAVESCREEN', 'LEAVESCREEN')
 end
 
---auto enter and leave cursor-supporting mode
-
+-- auto enter and leave cursor-supporting mode
 function test.restore_mode()
     guidm.enterSidebarMode(df.ui_sidebar_mode.Stockpiles)
     load_ui()
@@ -446,3 +445,90 @@ function test.name_collision()
 end
 
 -- widgets to configure which blueprint phases to output
+
+function test.phase_preset()
+    dfhack.run_script('gui/blueprint', 'imaname', 'build')
+    local view = b.active_screen
+
+    local phases_view = view.subviews.phases
+    expect.eq('Custom', phases_view.options[phases_view.option_idx])
+
+    for _,sv in ipairs(view.subviews.phases_panel.subviews) do
+        if sv.label and sv.label ~= 'phases' then
+            expect.true_(sv.visible)
+            -- only build should be on; everything else should be off
+            expect.eq(sv.label == 'build' and 'On' or 'Off',
+                      sv.options[sv.option_idx])
+        end
+    end
+    send_keys('LEAVESCREEN') -- leave UI
+end
+
+function test.phase_toggle_visible()
+    local view = load_ui()
+    for _,sv in ipairs(view.subviews.phases_panel.subviews) do
+        if sv.label and sv.label ~= 'phases' then
+            expect.false_(sv.visible)
+        end
+    end
+    send_keys('CUSTOM_A')
+    for _,sv in ipairs(view.subviews.phases_panel.subviews) do
+        if sv.label and sv.label ~= 'phases' then
+            expect.true_(sv.visible)
+        end
+    end
+    send_keys('CUSTOM_A')
+    for _,sv in ipairs(view.subviews.phases_panel.subviews) do
+        if sv.label and sv.label ~= 'phases' then
+            expect.false_(sv.visible)
+        end
+    end
+    send_keys('LEAVESCREEN') -- leave UI
+end
+
+function test.phase_cycle()
+    local view = load_ui()
+    send_keys('CUSTOM_A')
+    for _,sv in ipairs(view.subviews.phases_panel.subviews) do
+        if sv.label and sv.label == 'dig' then
+            expect.eq('On', sv.options[sv.option_idx])
+        end
+    end
+    send_keys('CUSTOM_D')
+    for _,sv in ipairs(view.subviews.phases_panel.subviews) do
+        if sv.label and sv.label == 'dig' then
+            expect.eq('Off', sv.options[sv.option_idx])
+        end
+    end
+    send_keys('CUSTOM_D')
+    for _,sv in ipairs(view.subviews.phases_panel.subviews) do
+        if sv.label and sv.label == 'dig' then
+            expect.eq('On', sv.options[sv.option_idx])
+        end
+    end
+    send_keys('LEAVESCREEN') -- leave UI
+end
+
+function test.phase_set()
+    local mock_print, mock_run = mock.func(), mock.func({'blueprints/dig.csv'})
+    mock.patch({
+            {b, 'print', mock_print},
+            {blueprint, 'run', mock_run},
+        },
+        function()
+            local view = load_ui()
+            -- turn off autodetect and turn all phases except dig off
+            for _,sv in ipairs(view.subviews.phases_panel.subviews) do
+                if sv.label and sv.label ~= 'dig' then
+                    sv.option_idx = 2
+                end
+            end
+            guidm.setCursorPos({x=1, y=2, z=3})
+            send_keys('SELECT', 'SELECT') -- a once-tile blueprint, why not?
+            expect.eq('running: blueprint 1 1 1 blueprint dig --cursor=1,2,3',
+                    mock_print.call_args[1][1])
+            expect.table_eq({'1', '1', '1', 'blueprint', 'dig',
+                             '--cursor=1,2,3'}, mock_run.call_args[1])
+            send_keys('SELECT') -- dismiss the success messagebox
+        end)
+end


### PR DESCRIPTION
add widgets that allow configuration of the blueprint phases

by default, phase labels are not shown (and their hotkeys are not active) and the 'phases' configuration is set to 'Autodetect'. Once the 'phases' hotkey is hit, 'Autodetect' toggles to 'Custom' and the individual phases are listed. Each can be toggled with their hotkey.

This is the last PR for `gui/blueprint` for milestone 1 of the blueprint overhaul plan (DFHack/dfhack#1842)