### PR TITLE
migrate scripts to use common string functions

### DIFF
--- a/assign-attributes.lua
+++ b/assign-attributes.lua
@@ -117,12 +117,12 @@ local function generate_medians_table(race)
         assert(creature ~= nil)
         for _, raw in ipairs(creature.raws) do
             if string.match(raw.value, "PHYS_ATT_RANGE") then
-                local token_parts = utils.split_string(raw.value, ":")
+                local token_parts = raw.value:split(":")
                 --     part 1         *2*    3   4   5   *6*   7    8    9
                 -- [PHYS_ATT_RANGE:STRENGTH:450:950:1150:1250:1350:1550:2250]
                 medians.PHYSICAL[token_parts[2]] = tonumber(token_parts[6])
             elseif string.match(raw.value, "MENT_ATT_RANGE") then
-                local token_parts = utils.split_string(raw.value, ":")
+                local token_parts = raw.value:split(":")
                 --     part 1         *2*    3   4   5   *6*   7    8    9
                 -- [MENT_ATT_RANGE:PATIENCE:450:950:1150:1250:1350:1550:2250]
                 medians.MENTAL[token_parts[2]] = tonumber(token_parts[6])

--- a/assign-preferences.lua
+++ b/assign-preferences.lua
@@ -256,7 +256,7 @@ local preference_functions = {
     -- ---------------- LIKECREATURE ---------------- --
     LIKECREATURE = function(token)
         local creature_id
-        local parts = utils.split_string(token, ":")
+        local parts = token:split(":")
         if #parts == 1 then
             creature_id = parts[1]
         else
@@ -368,7 +368,7 @@ local preference_functions = {
     -- ---------------- HATECREATURE ---------------- --
     HATECREATURE = function(token)
         local creature_id
-        local parts = utils.split_string(token, ":")
+        local parts = token:split(":")
         if #parts == 1 then
             creature_id = parts[1]
         else
@@ -402,7 +402,7 @@ local preference_functions = {
     LIKEITEM = function(token)
         local item_type
         local item_subtype = -1
-        local parts = utils.split_string(token, ":")
+        local parts = token:split(":")
         if #parts == 1 then
             item_type = df.item_type[parts[1]]
         else
@@ -444,7 +444,7 @@ local preference_functions = {
     -- ---------------- LIKEPLANT ---------------- --
     LIKEPLANT = function(token)
         local plant_id
-        local parts = utils.split_string(token, ":")
+        local parts = token:split(":")
         if #parts == 1 then
             plant_id = parts[1]
         else
@@ -477,7 +477,7 @@ local preference_functions = {
     -- ---------------- LIKETREE ---------------- --
     LIKETREE = function(token)
         local plant_id
-        local parts = utils.split_string(token, ":")
+        local parts = token:split(":")
         if #parts == 1 then
             plant_id = parts[1]
         else
@@ -510,7 +510,7 @@ local preference_functions = {
     -- ---------------- LIKECOLOR ---------------- --
     LIKECOLOR = function(token)
         local color_name
-        local parts = utils.split_string(token, ":")
+        local parts = token:split(":")
         if #parts == 1 then
             color_name = parts[1]
         else
@@ -544,7 +544,7 @@ local preference_functions = {
     -- ---------------- LIKESHAPE ---------------- --
     LIKESHAPE = function(token)
         local shape_name
-        local parts = utils.split_string(token, ":")
+        local parts = token:split(":")
         if #parts == 1 then
             shape_name = parts[1]
         else

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -250,7 +250,7 @@ function GmEditorUi:find_id(force_dialog)
         return a.weight > b.weight
     end)
     local message = {{pen=COLOR_LIGHTRED, text="Note: "}}
-    for _, line in ipairs(utils.split_string(raw_message, '\n')) do
+    for _, line in ipairs(raw_message:split('\n')) do
         table.insert(message, line)
         table.insert(message, NEWLINE)
     end

--- a/gui/mod-manager.lua
+++ b/gui/mod-manager.lua
@@ -247,7 +247,7 @@ function manager:formDescription()
     if self.selected.description then
         return self.selected.description
         --[[
-        local str=require('utils').split_string(self.selected.description,"\n")
+        local str=self.selected.description:split("\n")
         for _,s in ipairs(str) do
             table.insert(ret,{text=s})
             table.insert(ret,NEWLINE)

--- a/gui/prerelease-warning.lua
+++ b/gui/prerelease-warning.lua
@@ -87,17 +87,17 @@ yourself, please report this to your pack's maintainer.]]
 
 path = dfhack.getHackPath():lower()
 if #pack_message > 0 and (path:find('lnp') or path:find('starter') or path:find('newb') or path:find('lazy') or path:find('pack')) then
-    for _, v in pairs(utils.split_string(pack_message, '\n')) do
+    for _, v in pairs(pack_message:split('\n')) do
         table.insert(message, NEWLINE)
         table.insert(message, {text=v, pen=COLOR_LIGHTMAGENTA})
     end
 end
 
-for _, v in pairs(utils.split_string([[
+for _, v in pairs(([[
 
 REMINDER: Please report any issues you encounter while
 using this DFHack build on GitHub (github.com/dfhack/dfhack/issues)
-or the Bay12 forums (dfhack.org/bay12).]], '\n')) do
+or the Bay12 forums (dfhack.org/bay12).]]):split('\n')) do
     table.insert(message, NEWLINE)
     table.insert(message, {text=v, pen=COLOR_LIGHTCYAN})
 end
@@ -107,7 +107,7 @@ nightly_message = [[
 You appear to be using a nightly build of DFHack. If you
 experience problems, check dfhack.org/builds for updates.]]
 if dfhack.getDFHackBuildID() ~= '' then
-    for _, v in pairs(utils.split_string(nightly_message, '\n')) do
+    for _, v in pairs(nightly_message:split('\n')) do
         table.insert(message, NEWLINE)
         table.insert(message, {text=v, pen=COLOR_LIGHTGREEN})
     end

--- a/gui/settings-manager.lua
+++ b/gui/settings-manager.lua
@@ -32,7 +32,7 @@ function dup_table(tbl)
 end
 
 function set_variable(name, value)
-    local parts = name:split('.')
+    local parts = name:split('.', true)
     local last_field = table.remove(parts, #parts)
     parent = _G
     for _, field in pairs(parts) do

--- a/gui/unit-info-viewer.lua
+++ b/gui/unit-info-viewer.lua
@@ -189,22 +189,6 @@ function isBlank(x)
     return not not x:find("^%s*$")
 end
 
---http://lua-users.org/wiki/StringRecipes  (removed indents since I am not using them)
-function wrap(str, limit)--, indent, indent1)
- --indent = indent or ""
- --indent1 = indent1 or indent
- local limit = limit or 72
- local here = 1 ---#indent1
- return str:gsub("(%s+)()(%S+)()",    --indent1..str:gsub(
-  function(sp, st, word, fi)
-  if fi-here > limit then
-   here = st -- - #indent
-   return "\n"..word --..indent..word
-  end
- end)
-end
-
-
 --------------------------------------------------
 ---------------------- Time ----------------------
 --------------------------------------------------
@@ -604,7 +588,7 @@ function UnitInfoViewer:onGetSelectedUnit()
  return self.ident.unit
 end
 function UnitInfoViewer:insert_chunk(str,pen)
- local lines = utils.split_string( wrap(str,self.frame_width) , NEWLINE )
+ local lines = str:wrap(self.frame_width):split(NEWLINE)
  for i = 1,#lines do
   table.insert(self.text,{text=lines[i],pen=pen})
   table.insert(self.text,NEWLINE)

--- a/install-info.lua
+++ b/install-info.lua
@@ -47,7 +47,7 @@ log_version('Is map loaded', 'isMapLoaded')
 function log_command(cmd)
     log('\nOutput of "' .. cmd .. '":')
     local output = select(1, dfhack.run_command_silent(cmd))
-    for _, line in pairs(utils.split_string(output, '\n')) do
+    for _, line in pairs(output:split('\n')) do
         log('    ' .. line)
     end
 end


### PR DESCRIPTION
First part of step 5 of DFHack/dfhack#1888

Note that there ended up being one more place (`settings-manager`) that needed the `plain` parameter set to `true` for non-pattern delimiters.

All changes were manually tested by running the scripts with appropriate parameters and confirming coverage with luacov:

```
[DFHack]# assign-attributes -attributes [ STRENGTH 2 ]
[DFHack]# assign-preferences -reset -likematerial [ INORGANIC:ALABASTER PLANT:WILLOW:WOOD ] -likecreature SPARROW -likeitem [ WOOD ITEM_WEAPON:ITEM_WEAPON_AXE_BATTLE ] -likeplant BERRIES_STRAW -liketree OAK -likecolor AQUA -likeshape STAR -hatecreature SPIDER_JUMPING
[DFHack]# gui/gm-editor, scan to something that's not an ID (I used birth_year of a unit) and hit shift-i
[DFHack]# gui/mod-manager (nothing to check since the code change was in a comment)
[DFHack]# gui/prerelease-warning force (1 usage of 3 covered, but they're all of the same form)
[DFHack]# gui/settings-manager (set MACRO_MS and default embark size)
[DFHack]# gui/unit-info-viewer (on any unit)
[DFHack]# install-info
```