### PR TITLE
Added reveal-adv-map.lua

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,9 @@ that repo.
 
 # Future
 
+## New Scripts
+- `reveal-adv-map`: exposes/hides all world map tiles in adventure mode
+
 # 0.47.05-r2
 
 ## New Scripts

--- a/questport.lua
+++ b/questport.lua
@@ -3,9 +3,17 @@
 
 questport
 =========
-Sends your adventurer to the location of your quest log map cursor.
-Usable from travel mode or on foot.
-Can be used in situations where fast travel is normally prohibited.
+Teleports your adventurer to the location of your quest log map cursor.
+
+To use, simply open your quest log, move the cursor to your target location,
+and run the script. Note that this can be done both within and outside of
+fast travel mode, and it is possible to questport in situations where
+fast travel is normally prohibited.
+
+It is currently not possible to questport into inaccessible locations like
+ocean and mountain tiles.
+
+See `reveal-adv-map` if you wish to teleport into hidden map tiles.
 
 ]====]
 

--- a/questport.lua
+++ b/questport.lua
@@ -5,9 +5,9 @@ questport
 =========
 Teleports your adventurer to the location of your quest log map cursor.
 
-To use, simply open your quest log, move the cursor to your target location,
-and run the script. Note that this can be done both within and outside of
-fast travel mode, and it is possible to questport in situations where
+Use by opening the quest log map and moving the cursor to your target location
+before running the script. Note that this can be done both within and outside of
+fast travel mode, and that it is possible to questport in situations where
 fast travel is normally prohibited.
 
 It is currently not possible to questport into inaccessible locations like

--- a/reveal-adv-map.lua
+++ b/reveal-adv-map.lua
@@ -1,0 +1,68 @@
+-- Exposes/hides the entire world map in adventure mode.
+-- author: Atomic Chicken
+
+--@ module = true
+
+local usage = [====[
+
+reveal-adv-map
+==============
+
+This script can be used to either reveal or hide all tiles on the
+world map in adventure mode (visible when viewing the quest log
+or fast travelling, for example).
+
+Note that the script does not reveal hidden lairs, camps, etc.
+See `reveal-hidden-sites` for this functionality.
+
+Arguments::
+
+    -hide
+        Include this if you want to hide all world tiles instead
+        of revealing them
+
+]====]
+
+local utils = require 'utils'
+local validArgs = utils.invert({
+  'hide',
+  'help'
+})
+local args = utils.processArgs({...}, validArgs)
+
+if dfhack_flags.module then
+  return
+end
+
+if args.help then
+  print(usage)
+  return
+end
+
+function revealAdvMap(hide)
+  local world = df.global.world.world_data
+  for world_x = 0, world.world_width-1, 1 do
+    for world_y = 0, world.world_height-1, 1 do
+      df.global.world.world_data.region_map[world_x]:_displace(world_y).flags.discovered = not hide
+    end
+  end
+-- update the quest log configuration if it is already open (restricts map cursor movement):
+  local view = dfhack.gui.getCurViewscreen()
+  if view._type == df.viewscreen_adventure_logst then
+    local player = view.player_region
+    if hide then
+      view.cursor.x = player.x
+      view.cursor.y = player.y
+    end
+    view.min_discovered.x = (hide and player.x) or 0
+    view.min_discovered.y = (hide and player.y) or 0
+    view.max_discovered.x = (hide and player.x) or world.world_width-1
+    view.max_discovered.y = (hide and player.y) or world.world_height-1
+  end
+end
+
+if df.global.gamemode ~= df.game_mode.ADVENTURE then
+  qerror("This script can only be used in adventure mode!")
+end
+
+revealAdvMap(args.hide and true)

--- a/reveal-adv-map.lua
+++ b/reveal-adv-map.lua
@@ -24,20 +24,6 @@ Arguments::
 ]====]
 
 local utils = require 'utils'
-local validArgs = utils.invert({
-  'hide',
-  'help'
-})
-local args = utils.processArgs({...}, validArgs)
-
-if dfhack_flags.module then
-  return
-end
-
-if args.help then
-  print(usage)
-  return
-end
 
 function revealAdvMap(hide)
   local world = df.global.world.world_data
@@ -59,6 +45,21 @@ function revealAdvMap(hide)
     view.max_discovered.x = (hide and player.x) or world.world_width-1
     view.max_discovered.y = (hide and player.y) or world.world_height-1
   end
+end
+
+local validArgs = utils.invert({
+  'hide',
+  'help'
+})
+local args = utils.processArgs({...}, validArgs)
+
+if dfhack_flags.module then
+  return
+end
+
+if args.help then
+  print(usage)
+  return
 end
 
 if df.global.gamemode ~= df.game_mode.ADVENTURE then

--- a/reveal-hidden-sites.lua
+++ b/reveal-hidden-sites.lua
@@ -12,6 +12,9 @@ thus making them visible on the map.
 
 Usable in both fortress and adventure mode.
 
+See `reveal-adv-map` if you also want to expose
+hidden world map tiles in adventure mode.
+
 ]====]
 
 local count = 0


### PR DESCRIPTION
Whenever a new adventure mode game is started, world tiles in the player's vicinity are flagged as `discovered` and those that are not are hidden from view. This script either reveals or hides the entire adv mode world map by toggling this flag accordingly.