### PR TITLE
New script: prioritize - monitors job creation and boosts priority for configurable job types

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ that repo.
 # Future
 
 ## New Scripts
+- `prioritize`: automatically boosts the priority of current and/or future jobs of the selected types
 - `reveal-adv-map`: exposes/hides all world map tiles in adventure mode
 
 ## Fixes

--- a/prioritize.lua
+++ b/prioritize.lua
@@ -116,8 +116,13 @@ local function status()
     if first then print('Not automatically prioritizing any jobs.') end
 end
 
+-- encapsulate this in a function so unit tests can mock it out
+function get_postings()
+    return df.global.world.jobs.postings
+end
+
 local function for_all_live_postings(cb)
-    for _,posting in ipairs(df.global.world.jobs.postings) do
+    for _,posting in ipairs(get_postings()) do
         if posting.job and not posting.flags.dead then
             cb(posting)
         end
@@ -159,7 +164,7 @@ local function remove_watch(job_types, quiet)
     for job_type in pairs(job_types) do
         if not watched_job_types[job_type] then
             if not quiet then
-                print('Skipping unwatched type: '..df.job_type[job_type])
+                print('Skipping unwatched type: ' .. df.job_type[job_type])
             end
         else
             watched_job_types[job_type] = nil

--- a/prioritize.lua
+++ b/prioritize.lua
@@ -1,0 +1,243 @@
+-- Boosts the priority of jobs of the selected types
+--[====[
+
+prioritize
+==========
+
+The prioritize script sets the ``do_now`` flag on all of the specified types of
+jobs that are currently ready to be picked up by a dwarf. This will force them
+to complete the jobs as soon as possible. This script can also continue to
+monitor creation of new jobs and automatically boost the priority of newly
+created jobs of specific types.
+
+This is most useful for ensuring important (but low-priority -- according to DF)
+tasks don't get indefinitely ignored in busy forts. The list of monitored job
+types is cleared whenever you load a new map, so you can add a line like the one
+below to your onMapLoad.init file to ensure important job types are always
+completed promptly in your forts::
+
+    prioritize -a StoreItemInVehicle PullLever DestroyBuilding RemoveConstruction
+
+Also see the ``do-job-now`` `tweak` for adding a hotkey to the jobs screen that
+can toggle the priority of specific individual jobs and the `do-task-now`
+script, which sets the priority of jobs related to the selected
+job/unit/item/building/order.
+
+Usage::
+
+    prioritize [<options>] [<job_type> ...]
+
+Examples:
+
+``prioritize``
+    Prints out which job types are being automatically prioritized and how many
+    jobs of each type we have modified since we started watching them.
+
+``prioritize ConstructBuilding DestroyBuilding``
+    Prioritizes all current building construction and destruction jobs.
+
+``prioritize -a StoreItemInVehicle``
+    Prioritizes all current and future vehicle loading jobs.
+
+``prioritize -d StoreItemInVehicle``
+    Stops automatically prioritizing new vehicle loading jobs.
+
+Options:
+
+:``-a``, ``--add``:
+    Prioritize all current and future new jobs of the specified job types.
+:``-d``, ``--delete``:
+    Stop automatically prioritizing new jobs of the specified job types.
+:``-h``, ``--help``:
+    Show help text.
+:``-j``, ``--jobs``:
+    Print out how many jobs of each type there are. This is useful for
+    discovering the types of the jobs which you can prioritize right now. If any
+    job types are specified, only returns the current count for those types.
+:``-q``, ``--quiet``:
+    Suppress informational output (error messages are still printed).
+:``-r``, ``--registry``:
+    Print out the full list of valid job types.
+]====]
+
+local argparse = require('argparse')
+local eventful = require('plugins.eventful')
+
+-- set of job types that we are watching
+watched_job_types = watched_job_types or {}
+
+eventful.enableEvent(eventful.eventType.UNLOAD, 1)
+eventful.enableEvent(eventful.eventType.JOB_INITIATED, 5)
+
+local function clear_watched_job_types()
+    watched_job_types = {}
+    eventful.onUnload.prioritize = nil
+    eventful.onJobInitiated.prioritize = nil
+end
+
+local function boost_job_if_member(job, job_types)
+    if job_types[job.job_type] and not job.flags.do_now then
+        job.flags.do_now = true
+        return true
+    end
+    return false
+end
+
+local function on_new_job(job)
+    if boost_job_if_member(job, watched_job_types) then
+        watched_job_types[job.job_type] = watched_job_types[job.job_type] + 1
+    end
+end
+
+local function has_elements(collection)
+    for _,_ in pairs(collection) do return true end
+    return false
+end
+
+local function update_handlers()
+    if has_elements(watched_job_types) then
+        eventful.onUnload.prioritize = clear_watched_job_types
+        eventful.onJobInitiated.prioritize = on_new_job
+    else
+        clear_watched_job_types()
+    end
+end
+
+local function status()
+    local first = true
+    for k,v in pairs(watched_job_types) do
+        if first then
+            print('Automatically prioritizing jobs of type:')
+            first = false
+        end
+        print(('  ') .. df.job_type[k])
+    end
+    if first then print('Not automatically prioritizing any jobs.') end
+end
+
+local function for_all_live_postings(cb)
+    for _,posting in ipairs(df.global.world.jobs.postings) do
+        if posting.job and not posting.flags.dead then
+            cb(posting)
+        end
+    end
+end
+
+local function boost(job_types, quiet)
+    local count = 0
+    for_all_live_postings(
+        function(posting)
+            if boost_job_if_member(posting.job, job_types) then
+                count = count + 1
+            end
+        end)
+    if not quiet then
+        print(('Prioritized %d jobs.'):format(count))
+    end
+end
+
+local function boost_and_watch(job_types, quiet)
+    boost(job_types, quiet)
+    for job_type in pairs(job_types) do
+        if watched_job_types[job_type] then
+            if not quiet then
+                print('Skipping already-watched type: '..df.job_type[job_type])
+            end
+        else
+            watched_job_types[job_type] = 0
+            if not quiet then
+                print('Automatically prioritizing future jobs of type: ' ..
+                    df.job_type[job_type])
+            end
+        end
+    end
+    update_handlers()
+end
+
+local function remove_watch(job_types, quiet)
+    for job_type in pairs(job_types) do
+        if not watched_job_types[job_type] then
+            if not quiet then
+                print('Skipping unwatched type: '..df.job_type[job_type])
+            end
+        else
+            watched_job_types[job_type] = nil
+            if not quiet then
+                print('No longer automatically prioritizing jobs of type: ' ..
+                      df.job_type[job_type])
+            end
+        end
+    end
+    update_handlers()
+end
+
+local function current_jobs(job_types)
+    local job_counts_by_type = {}
+    local filtered = has_elements(job_types)
+    for_all_live_postings(
+        function(posting)
+            local job_type = posting.job.job_type
+            if filtered and not job_types[job_type] then return end
+            if not job_counts_by_type[job_type] then
+                job_counts_by_type[job_type] = 0
+            end
+            job_counts_by_type[job_type] = job_counts_by_type[job_type] + 1
+        end)
+    local first = true
+    for k,v in pairs(job_counts_by_type) do
+        if first then
+            print('Current job counts by type:')
+            first = false
+        end
+        print(('%d\t%s'):format(v, df.job_type[k]))
+    end
+    if first then print('No current jobs.') end
+end
+
+local function registry()
+    print('Valid job types:')
+    for k,v in ipairs(df.job_type) do
+        if v and df.job_type[v] and v:find('^%u%l') then
+            print('  ' .. v)
+        end
+    end
+end
+
+local function parse_commandline(args)
+    local opts = {action=status}
+    local positionals = argparse.processArgsGetopt(args, {
+            {'a', 'add', handler=function() opts.action = boost_and_watch end},
+            {'d', 'delete', handler=function() opts.action = remove_watch end},
+            {'h', 'help', handler=function() opts.help = true end},
+            {'j', 'jobs', handler=function() opts.action = current_jobs end},
+            {'q', 'quiet', handler=function() opts.quiet = true end},
+            {'r', 'registry', handler=function() opts.action = registry end},
+        })
+
+    if positionals[1] == 'help' then opts.help = true end
+    if opts.help then return opts end
+
+    -- validate the specified job types and convert the list to a map
+    local job_types = {}
+    for _,jtype in ipairs(positionals) do
+        if not df.job_type[jtype] then
+            dfhack.printerr(('Ignoring unknown job type: "%s". Run' ..
+               ' "prioritize -r" for a list of valid job types.'):format(jtype))
+        else
+            job_types[df.job_type[jtype]] = true
+        end
+    end
+    opts.job_types = job_types
+
+    if #job_types >= 1 then
+        if opts.action == status then opts.action = boost end
+    end
+
+    return opts
+end
+
+-- main script
+local opts = parse_commandline({...})
+if opts.help then print(dfhack.script_help()) return end
+
+opts.action(opts.job_types, opts.quiet)

--- a/prioritize.lua
+++ b/prioritize.lua
@@ -7,9 +7,9 @@ prioritize
 
 The prioritize script sets the ``do_now`` flag on all of the specified types of
 jobs that are currently ready to be picked up by a dwarf. This will force them
-to complete the jobs as soon as possible. This script can also continue to
-monitor creation of new jobs and automatically boost the priority of newly
-created jobs of specific types.
+to complete those jobs as soon as possible. This script can also continue to
+monitor creation of new jobs and automatically boost the priority of jobs of
+the specified types.
 
 This is most useful for ensuring important (but low-priority -- according to DF)
 tasks don't get indefinitely ignored in busy forts. The list of monitored job
@@ -30,16 +30,16 @@ Examples:
 
 ``prioritize``
     Prints out which job types are being automatically prioritized and how many
-    jobs of each type we have modified since we started watching them.
+    jobs of each type we have prioritized since we started watching them.
+
+``prioritize -j``
+    Prints out the list of active job types that you can prioritize right now.
 
 ``prioritize ConstructBuilding DestroyBuilding``
     Prioritizes all current building construction and destruction jobs.
 
 ``prioritize -a StoreItemInVehicle``
     Prioritizes all current and future vehicle loading jobs.
-
-``prioritize -d StoreItemInVehicle``
-    Stops automatically prioritizing new vehicle loading jobs.
 
 Options:
 

--- a/prioritize.lua
+++ b/prioritize.lua
@@ -17,12 +17,10 @@ types is cleared whenever you load a new map, so you can add a line like the one
 below to your onMapLoad.init file to ensure important job types are always
 completed promptly in your forts::
 
-    prioritize -a StoreItemInVehicle PullLever DestroyBuilding RemoveConstruction
+    prioritize -a StoreItemInVehicle PullLever DestroyBuilding RemoveConstruction RecoverWounded FillPond DumpItem SlaughterAnimal
 
 Also see the ``do-job-now`` `tweak` for adding a hotkey to the jobs screen that
-can toggle the priority of specific individual jobs and the `do-task-now`
-script, which sets the priority of jobs related to the selected
-job/unit/item/building/order.
+can toggle the priority of specific individual jobs.
 
 Usage::
 

--- a/test/prioritize.lua
+++ b/test/prioritize.lua
@@ -2,88 +2,223 @@ local eventful = require('plugins.eventful')
 local prioritize = reqscript('prioritize')
 local p = prioritize.unit_test_hooks
 
--- mock out persistent state and external dependencies
+-- mock out state and external dependencies
 local mock_eventful_onUnload, mock_eventful_onJobInitiated = {}, {}
+local mock_print = mock.func()
 local mock_watched_job_types = {}
+local function get_mock_watched_job_types() return mock_watched_job_types end
 local mock_postings = {}
 local function get_mock_postings() return mock_postings end
 local function test_wrapper(test_fn)
-    mock.patch({{eventful, 'onUnload', {}},
-                {eventful, 'onJobInitiated', {}},
-                {prioritize, 'watched_job_types', mock_watched_job_types},
+    mock.patch({{eventful, 'onUnload', mock_eventful_onUnload},
+                {eventful, 'onJobInitiated', mock_eventful_onJobInitiated},
+                {prioritize, 'print', mock_print},
+                {prioritize, 'get_watched_job_types',
+                 get_mock_watched_job_types},
                 {prioritize, 'get_postings', get_mock_postings}},
                test_fn)
     mock_eventful_onUnload, mock_eventful_onJobInitiated = {}, {}
-    mock_watched_job_types = {}
-    mock_postings = {}
+    mock_print = mock.func()
+    mock_watched_job_types, mock_postings = {}, {}
 end
 config.wrapper = test_wrapper
 
 local DIG, EAT, REST = df.job_type.Dig, df.job_type.Eat, df.job_type.Rest
-function test.print_current_jobs()
-    local mock_print = mock.func()
-    mock.patch(prioritize, 'print', mock_print, function()
-            p.print_current_jobs({})
-            expect.eq(1, mock_print.call_count)
-            expect.eq('No current jobs.', mock_print.call_args[1][1])
-        end)
 
+function test.status()
+    p.status()
+    expect.eq(1, mock_print.call_count)
+    expect.eq('Not automatically prioritizing any jobs.',
+              mock_print.call_args[1][1])
+
+    mock_watched_job_types[REST] = 5
+    p.status()
+    expect.eq(3, mock_print.call_count)
+    expect.eq('Automatically prioritized jobs:', mock_print.call_args[2][1])
+    expect.true_(mock_print.call_args[3][1]:find('Rest'))
+end
+
+function test.boost()
+    mock_postings = {{job={job_type=DIG, flags={}}, flags={}},
+                     {job={job_type=DIG, flags={}}, flags={}},
+                     {job={job_type=EAT, flags={}}, flags={dead=true}},
+                     {job={job_type=EAT, flags={}}, flags={}},
+                     {job={job_type=REST, flags={}}, flags={dead=true}}}
+    local expected_postings =
+            {{job={job_type=DIG, flags={}}, flags={}},
+             {job={job_type=DIG, flags={}}, flags={}},
+             {job={job_type=EAT, flags={}}, flags={dead=true}},
+             {job={job_type=EAT, flags={do_now=true}}, flags={}},
+             {job={job_type=REST, flags={}}, flags={dead=true}}}
+    p.boost({[EAT]=true})
+    expect.eq(1, mock_print.call_count)
+    expect.eq('Prioritized 1 job.', mock_print.call_args[1][1])
+    expect.table_eq(expected_postings, mock_postings)
+end
+
+function test.boost_quiet()
+    mock_postings = {{job={job_type=DIG, flags={}}, flags={}},
+                     {job={job_type=DIG, flags={}}, flags={}},
+                     {job={job_type=EAT, flags={}}, flags={dead=true}},
+                     {job={job_type=EAT, flags={}}, flags={}},
+                     {job={job_type=REST, flags={}}, flags={dead=true}}}
+    local expected_postings =
+            {{job={job_type=DIG, flags={}}, flags={}},
+             {job={job_type=DIG, flags={}}, flags={}},
+             {job={job_type=EAT, flags={}}, flags={dead=true}},
+             {job={job_type=EAT, flags={do_now=true}}, flags={}},
+             {job={job_type=REST, flags={}}, flags={dead=true}}}
+    p.boost({[EAT]=true}, true)
+    expect.eq(0, mock_print.call_count)
+    expect.table_eq(expected_postings, mock_postings)
+end
+
+function test.boost_and_watch()
+    p.boost_and_watch({[DIG]=true})
+    expect.eq(2, mock_print.call_count)
+    expect.true_(mock_print.call_args[1][1]:find('^Prioritized'))
+    expect.true_(mock_print.call_args[2][1]:find('^Automatically'))
+    expect.table_eq({[DIG]=0}, mock_watched_job_types)
+
+    p.boost_and_watch({[DIG]=true})
+    expect.eq(4, mock_print.call_count)
+    expect.true_(mock_print.call_args[3][1]:find('^Prioritized'))
+    expect.true_(mock_print.call_args[4][1]:find('^Skipping'))
+    expect.table_eq({[DIG]=0}, mock_watched_job_types)
+end
+
+function test.boost_and_watch_quiet()
+    p.boost_and_watch({[DIG]=true}, true)
+    expect.eq(0, mock_print.call_count)
+    expect.table_eq({[DIG]=0}, mock_watched_job_types)
+
+    p.boost_and_watch({[DIG]=true}, true)
+    expect.eq(0, mock_print.call_count)
+    expect.table_eq({[DIG]=0}, mock_watched_job_types)
+end
+
+function test.remove_watch()
+    p.remove_watch({[DIG]=true})
+    expect.eq(1, mock_print.call_count)
+    expect.true_(mock_print.call_args[1][1]:find('Skipping unwatched'))
+    expect.table_eq({}, mock_watched_job_types)
+
+    mock_watched_job_types[DIG] = 0
+    p.remove_watch({[DIG]=true})
+    expect.eq(2, mock_print.call_count)
+    expect.true_(mock_print.call_args[2][1]:find('No longer'))
+end
+
+function test.remove_watch_quiet()
+    p.remove_watch({[DIG]=true}, true)
+    expect.eq(0, mock_print.call_count)
+    expect.table_eq({}, mock_watched_job_types)
+
+    mock_watched_job_types[DIG] = 0
+    p.remove_watch({[DIG]=true}, true)
+    expect.eq(0, mock_print.call_count)
+    expect.table_eq({}, mock_watched_job_types)
+end
+
+function test.eventful_hook_lifecycle()
+    expect.nil_(mock_eventful_onUnload.prioritize)
+    expect.nil_(mock_eventful_onJobInitiated.prioritize)
+
+    p.boost_and_watch({[DIG]=true}, true)
+    expect.table_eq({[DIG]=0}, mock_watched_job_types)
+
+    expect.eq(p.clear_watched_job_types, mock_eventful_onUnload.prioritize)
+    expect.eq(p.on_new_job, mock_eventful_onJobInitiated.prioritize)
+
+    p.remove_watch({[DIG]=true}, true)
+    expect.table_eq({}, mock_watched_job_types)
+
+    expect.nil_(mock_eventful_onUnload.prioritize)
+    expect.nil_(mock_eventful_onJobInitiated.prioritize)
+end
+
+function test.eventful_callbacks()
+    -- unwatched job
+    local job = {job_type=DIG, flags={}}
+    local expected = {job_type=DIG, flags={}}
+    p.on_new_job(job)
+    expect.table_eq(expected, job)
+
+    -- watched job
+    local expected = {job_type=DIG, flags={do_now=true}}
+    p.boost_and_watch({[DIG]=true}, true)
+    p.on_new_job(job)
+    expect.table_eq(expected, job)
+
+    -- map unload
+    p.clear_watched_job_types()
+    expect.table_eq({}, mock_watched_job_types)
+    expect.nil_(mock_eventful_onUnload.prioritize)
+    expect.nil_(mock_eventful_onJobInitiated.prioritize)
+end
+
+function test.print_current_jobs_empty()
+    p.print_current_jobs({})
+    expect.eq(1, mock_print.call_count)
+    expect.eq('No current jobs.', mock_print.call_args[1][1])
+end
+
+function test.print_current_jobs_full()
     mock_postings = {{job={job_type=DIG}, flags={}},
                      {job={job_type=DIG}, flags={}},
                      {job={job_type=EAT}, flags={dead=true}},
                      {job={job_type=EAT}, flags={}},
                      {job={job_type=REST}, flags={dead=true}}}
-    mock_print = mock.func()
-    mock.patch(prioritize, 'print', mock_print, function()
-            p.print_current_jobs({})
-            expect.eq('Current job counts by type:', mock_print.call_args[1][1])
-            local result = {}
-            for i,v in ipairs(mock_print.call_args) do
-                if i == 1 then goto continue end
-                local _,_,num,job_type = v[1]:find('(%d+)%s+(%S+)')
-                expect.ne(nil, num)
-                expect.nil_(result[job_type])
-                result[job_type] = num
-                ::continue::
-            end
-            expect.table_eq({[df.job_type[DIG]]='2', [df.job_type[EAT]]='1'},
-                            result)
-        end)
+    p.print_current_jobs({})
+    expect.eq(3, mock_print.call_count)
+    expect.eq('Current job counts by type:', mock_print.call_args[1][1])
+    local result = {}
+    for i,v in ipairs(mock_print.call_args) do
+        if i == 1 then goto continue end
+        local _,_,num,job_type = v[1]:find('(%d+)%s+(%S+)')
+        expect.ne(nil, num)
+        expect.nil_(result[job_type])
+        result[job_type] = num
+        ::continue::
+    end
+    expect.table_eq({[df.job_type[DIG]]='2', [df.job_type[EAT]]='1'}, result)
+end
 
-    mock_print = mock.func()
-    mock.patch(prioritize, 'print', mock_print, function()
-            p.print_current_jobs({[EAT]=true})
-            expect.eq('Current job counts by type:', mock_print.call_args[1][1])
-            local result = {}
-            for i,v in ipairs(mock_print.call_args) do
-                if i == 1 then goto continue end
-                local _,_,num,job_type = v[1]:find('(%d+)%s+(%S+)')
-                expect.ne(nil, num)
-                expect.nil_(result[job_type])
-                result[job_type] = num
-                ::continue::
-            end
-            expect.table_eq({[df.job_type[EAT]]='1'}, result)
-        end)
+function test.print_current_jobs_filtered()
+    mock_postings = {{job={job_type=DIG}, flags={}},
+                     {job={job_type=DIG}, flags={}},
+                     {job={job_type=EAT}, flags={dead=true}},
+                     {job={job_type=EAT}, flags={}},
+                     {job={job_type=REST}, flags={dead=true}}}
+    p.print_current_jobs({[EAT]=true})
+    expect.eq(2, mock_print.call_count)
+    expect.eq('Current job counts by type:', mock_print.call_args[1][1])
+    local result = {}
+    for i,v in ipairs(mock_print.call_args) do
+        if i == 1 then goto continue end
+        local _,_,num,job_type = v[1]:find('(%d+)%s+(%S+)')
+        expect.ne(nil, num)
+        expect.nil_(result[job_type])
+        result[job_type] = num
+        ::continue::
+    end
+    expect.table_eq({[df.job_type[EAT]]='1'}, result)
 end
 
 function test.print_registry()
-    local mock_print = mock.func()
-    mock.patch(prioritize, 'print', mock_print, function()
-            p.print_registry()
-            expect.lt(0, mock_print.call_count)
-            for i,v in ipairs(mock_print.call_args) do
-                local out = v[1]:trim()
-                if i == 1 then
-                    expect.eq('Valid job types:', out)
-                    goto continue
-                end
-                expect.ne('nil', tostring(out))
-                expect.true_(out:find('^%u%l'))
-                expect.ne('NONE', out)
-                ::continue::
-            end
-        end)
+    p.print_registry()
+    expect.lt(0, mock_print.call_count)
+    for i,v in ipairs(mock_print.call_args) do
+        local out = v[1]:trim()
+        if i == 1 then
+            expect.eq('Valid job types:', out)
+            goto continue
+        end
+        expect.ne('nil', tostring(out))
+        expect.true_(out:find('^%u%l'))
+        expect.ne('NONE', out)
+        ::continue::
+    end
 end
 
 function test.parse_commandline()

--- a/test/prioritize.lua
+++ b/test/prioritize.lua
@@ -1,0 +1,57 @@
+config.mode = 'fortress'
+
+local p = reqscript('prioritize').unit_test_hooks
+
+function test.parse_commandline()
+    expect.table_eq({help=true}, p.parse_commandline{'help'})
+    expect.table_eq({help=true}, p.parse_commandline{'-h'})
+    expect.table_eq({help=true}, p.parse_commandline{'--help'})
+
+    expect.table_eq({action=p.status, job_types={}}, p.parse_commandline{})
+    expect.table_eq({action=p.boost, job_types={[df.job_type['Suture']]=true}},
+                    p.parse_commandline{'Suture'})
+    expect.printerr_match('Ignoring unknown job type',
+        function()
+            expect.table_eq({action=p.status, job_types={}},
+                            p.parse_commandline{'XSutureX'})
+        end)
+    expect.printerr_match('Ignoring unknown job type',
+        function()
+            expect.table_eq({action=p.boost,
+                             job_types={[df.job_type['Suture']]=true}},
+                            p.parse_commandline{'XSutureX', 'Suture'})
+        end)
+
+    expect.table_eq({action=p.status, job_types={}, quiet=true},
+                    p.parse_commandline{'-q'})
+    expect.table_eq({action=p.status, job_types={}, quiet=true},
+                    p.parse_commandline{'--quiet'})
+
+    expect.table_eq({action=p.boost_and_watch,
+                     job_types={[df.job_type['Suture']]=true}},
+                    p.parse_commandline{'-a', 'Suture'})
+    expect.table_eq({action=p.boost_and_watch,
+                     job_types={[df.job_type['Suture']]=true}},
+                    p.parse_commandline{'--add', 'Suture'})
+
+    expect.table_eq({action=p.remove_watch,
+                     job_types={[df.job_type['Suture']]=true}},
+                    p.parse_commandline{'-d', 'Suture'})
+    expect.table_eq({action=p.remove_watch,
+                     job_types={[df.job_type['Suture']]=true}},
+                    p.parse_commandline{'--delete', 'Suture'})
+
+    expect.table_eq({action=p.print_current_jobs, job_types={}},
+                    p.parse_commandline{'-j'})
+    expect.table_eq({action=p.print_current_jobs,
+                     job_types={[df.job_type['Suture']]=true}},
+                    p.parse_commandline{'-j', 'Suture'})
+    expect.table_eq({action=p.print_current_jobs,
+                     job_types={[df.job_type['Suture']]=true}},
+                    p.parse_commandline{'--jobs', 'Suture'})
+
+    expect.table_eq({action=p.print_registry, job_types={}},
+                    p.parse_commandline{'-r'})
+    expect.table_eq({action=p.print_registry, job_types={}},
+                    p.parse_commandline{'--registry'})
+end

--- a/test/prioritize.lua
+++ b/test/prioritize.lua
@@ -1,6 +1,90 @@
-config.mode = 'fortress'
+local eventful = require('plugins.eventful')
+local prioritize = reqscript('prioritize')
+local p = prioritize.unit_test_hooks
 
-local p = reqscript('prioritize').unit_test_hooks
+-- mock out persistent state and external dependencies
+local mock_eventful_onUnload, mock_eventful_onJobInitiated = {}, {}
+local mock_watched_job_types = {}
+local mock_postings = {}
+local function get_mock_postings() return mock_postings end
+local function test_wrapper(test_fn)
+    mock.patch({{eventful, 'onUnload', {}},
+                {eventful, 'onJobInitiated', {}},
+                {prioritize, 'watched_job_types', mock_watched_job_types},
+                {prioritize, 'get_postings', get_mock_postings}},
+               test_fn)
+    mock_eventful_onUnload, mock_eventful_onJobInitiated = {}, {}
+    mock_watched_job_types = {}
+    mock_postings = {}
+end
+config.wrapper = test_wrapper
+
+local DIG, EAT, REST = df.job_type.Dig, df.job_type.Eat, df.job_type.Rest
+function test.print_current_jobs()
+    local mock_print = mock.func()
+    mock.patch(prioritize, 'print', mock_print, function()
+            p.print_current_jobs({})
+            expect.eq(1, mock_print.call_count)
+            expect.eq('No current jobs.', mock_print.call_args[1][1])
+        end)
+
+    mock_postings = {{job={job_type=DIG}, flags={}},
+                     {job={job_type=DIG}, flags={}},
+                     {job={job_type=EAT}, flags={dead=true}},
+                     {job={job_type=EAT}, flags={}},
+                     {job={job_type=REST}, flags={dead=true}}}
+    mock_print = mock.func()
+    mock.patch(prioritize, 'print', mock_print, function()
+            p.print_current_jobs({})
+            expect.eq('Current job counts by type:', mock_print.call_args[1][1])
+            local result = {}
+            for i,v in ipairs(mock_print.call_args) do
+                if i == 1 then goto continue end
+                local _,_,num,job_type = v[1]:find('(%d+)%s+(%S+)')
+                expect.ne(nil, num)
+                expect.nil_(result[job_type])
+                result[job_type] = num
+                ::continue::
+            end
+            expect.table_eq({[df.job_type[DIG]]='2', [df.job_type[EAT]]='1'},
+                            result)
+        end)
+
+    mock_print = mock.func()
+    mock.patch(prioritize, 'print', mock_print, function()
+            p.print_current_jobs({[EAT]=true})
+            expect.eq('Current job counts by type:', mock_print.call_args[1][1])
+            local result = {}
+            for i,v in ipairs(mock_print.call_args) do
+                if i == 1 then goto continue end
+                local _,_,num,job_type = v[1]:find('(%d+)%s+(%S+)')
+                expect.ne(nil, num)
+                expect.nil_(result[job_type])
+                result[job_type] = num
+                ::continue::
+            end
+            expect.table_eq({[df.job_type[EAT]]='1'}, result)
+        end)
+end
+
+function test.print_registry()
+    local mock_print = mock.func()
+    mock.patch(prioritize, 'print', mock_print, function()
+            p.print_registry()
+            expect.lt(0, mock_print.call_count)
+            for i,v in ipairs(mock_print.call_args) do
+                local out = v[1]:trim()
+                if i == 1 then
+                    expect.eq('Valid job types:', out)
+                    goto continue
+                end
+                expect.ne('nil', tostring(out))
+                expect.true_(out:find('^%u%l'))
+                expect.ne('NONE', out)
+                ::continue::
+            end
+        end)
+end
 
 function test.parse_commandline()
     expect.table_eq({help=true}, p.parse_commandline{'help'})


### PR DESCRIPTION
The prioritize script sets the `do_now` flag on all of the specified types of jobs that are currently ready to be picked up by a dwarf. This will force them to complete the jobs as soon as possible. This script can also continue to monitor creation of new jobs and automatically boost the priority of newly created jobs of specific types.

This is most useful for ensuring important (but low-priority -- according to DF) tasks don't get indefinitely ignored in busy forts. The list of monitored job types is cleared whenever you load a new map, so you can add a line like the one below to your `onMapLoad.init` file to ensure important job types are always completed promptly in your forts:
```
    prioritize -a StoreItemInVehicle PullLever DestroyBuilding RemoveConstruction RecoverWounded FillPond DumpItem SlaughterAnimal
```

This implementation uses the `eventful` plugin to hook the creation of jobs so it can automatically modify new jobs. It cleans up after itself and unregisters the callbacks when no tracked job types remain (or when a map is unloaded).