### PR TITLE
[quickfort] fix error in error message when label not found

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ that repo.
 
 ## Fixes
 - `quickfort`: allow machines (e.g. screw pumps) to be built on ramps just like DF allows
+- `quickfort`: fix error message when the requested label is not found in the blueprint file
 
 ## Misc Improvements
 - `gui/gm-editor`: made search case-insensitive

--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -332,7 +332,7 @@ local function process_levels(reader, label, start_cursor_coord)
                 label_str = string.format('label "%s" not found', label)
             end
             qerror(string.format(
-                    "%s in %s", label_str, reader:description()))
+                    "%s in %s", label_str, reader.filepath))
         end
         modeline = parse_modeline(row_tokens[1], reader.filepath,
                                   modeline_id)

--- a/test/quickfort/parse_unit.lua
+++ b/test/quickfort/parse_unit.lua
@@ -449,8 +449,14 @@ function test.process_levels()
     local reader = MockReader{}
     local start = {x=10, y=20, z=30}
 
-    -- label not found
-    expect.error(function() parse.process_levels(reader, '1', start) end)
+    -- label not found (no data)
+    expect.error_match('no data found',
+                       function() parse.process_levels(reader, nil, start) end)
+
+    -- label not found (mismatch)
+    reader:reset({{'#build'},{'Tl'}})
+    expect.error_match('not found',
+                       function() parse.process_levels(reader, '2', start) end)
 
     -- implicit #dig modeline
     reader:reset({{'d'}})


### PR DESCRIPTION
undetected by the unit tests since I had just checked `expect.error` instead of `expect.error_match`. unit tests also fixed. New mantra: "`expect.error` considered harmful".