### PR TITLE
devel/query + dwarf-op cleanup

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -41,6 +41,7 @@ that repo.
 - `devel/query`: added support for selecting a Lua script (e.g. `dorf_tables`)
 - `devel/query`: added support for selecting a Json file (e.g. dwarf_profiles.json)
 - `devel/query`: removed options ``-listall``, ``-listfields``, and ``-listkeys`` - these are now simply default behaviour
+- `devel/query`: ``-table`` now accepts the same abbreviations (global names, ``unit``, ``screen``, etc.) as `lua` and `gui/gm-editor`
 - `dorf_tables`: integrated `devel/query` to show the table definitions when requested with ``-list``
 - `geld`: fixed ``-help`` option
 - `gui/gm-editor`: made search case-insensitive

--- a/devel/query.lua
+++ b/devel/query.lua
@@ -337,7 +337,7 @@ function getSelectionData()
     local path_info = nil
     if args.table then
         debugf(0,"table selection")
-        selection = findTable(args.table)
+        selection = utils.df_expr_to_ref(args.table)
         path_info = args.table
         path_info_pattern = path_info
     elseif args.json then
@@ -615,30 +615,6 @@ function findPath(t, path)
         end
     end
     --debugf(1,"returning",curTable)
-    return curTable
-end
-
-function findTable(path) --this is the tricky part
-    tableParts = {}
-    for word in string.gmatch(path, '([^.]+)') do --thanks stack overflow
-        table.insert(tableParts, word)
-    end
-    curTable = nil
-    for k,v in pairs(tableParts) do
-        if curTable == nil then
-            if _G[v] ~= nil then
-                curTable = _G[v]
-            else
-                qerror("Table not recognized: " .. v)
-            end
-        else
-            if curTable[v] ~= nil then
-                curTable = curTable[v]
-            else
-                qerror("Table not recognized: " .. v)
-            end
-        end
-    end
     return curTable
 end
 

--- a/devel/query.lua
+++ b/devel/query.lua
@@ -598,20 +598,17 @@ end
 
 function findPath(t, path)
     debugf(0,string.format("findPath(%s, %s)",t, path))
-    curTable = t
-    keyParts = {}
-    for word in string.gmatch(path, '([^.]+)') do --thanks stack overflow
-        table.insert(keyParts, word)
-    end
+    local curTable = t
     if not curTable then
-        qerror("Looks like we're borked somehow.")
+        error("no table to search")
     end
+    local keyParts = string.split(path, '.', true)
     for _,v in pairs(keyParts) do
         if v and curTable[v] ~= nil then
             debugf(1,"found something",v,curTable,curTable[v])
             curTable = curTable[v]
         else
-            qerror("Table not recognized: " .. v)
+            qerror("Key not found: " .. v)
         end
     end
     --debugf(1,"returning",curTable)

--- a/devel/query.lua
+++ b/devel/query.lua
@@ -611,7 +611,7 @@ function findPath(t, path)
             debugf(1,"found something",v,curTable,curTable[v])
             curTable = curTable[v]
         else
-            qerror("Table" .. v .. " does not exist.")
+            qerror("Table not recognized: " .. v)
         end
     end
     --debugf(1,"returning",curTable)
@@ -629,13 +629,13 @@ function findTable(path) --this is the tricky part
             if _G[v] ~= nil then
                 curTable = _G[v]
             else
-                qerror("Table" .. v .. " does not exist.")
+                qerror("Table not recognized: " .. v)
             end
         else
             if curTable[v] ~= nil then
                 curTable = curTable[v]
             else
-                qerror("Table" .. v .. " does not exist.")
+                qerror("Table not recognized: " .. v)
             end
         end
     end

--- a/devel/query.lua
+++ b/devel/query.lua
@@ -570,28 +570,6 @@ function is_exceeding_maxlength(index)
 end
 
 --Section: table helpers
-function safe_pairs(t, keys_only)
-    if keys_only then
-        local mt = debug.getmetatable(t)
-        if mt and mt._index_table then
-            local idx = 0
-            return function()
-                idx = idx + 1
-                if mt._index_table[idx] then
-                    return mt._index_table[idx]
-                end
-            end
-        end
-    end
-    local ret = table.pack(pcall(function() return pairs(t) end))
-    local ok = ret[1]
-    table.remove(ret, 1)
-    if ok then
-        return table.unpack(ret)
-    else
-        return function() end
-    end
-end
 
 function isEmpty(t)
     for _,_ in safe_pairs(t) do

--- a/dwarf-op.lua
+++ b/dwarf-op.lua
@@ -520,11 +520,8 @@ function GenerateStatValue(stat, atr_lvl)
 end
 
 function LoopStatsTable(statsTable, callback)
-    local ok,f,t,k = pcall(pairs,statsTable)
-    if ok then
-        for k,v in f,t,k do
-            callback(v)
-        end
+    for k, v in safe_pairs(statsTable) do
+        callback(v)
     end
 end
 


### PR DESCRIPTION
This switches these scripts over to use the new `safe_pairs()` library function from https://github.com/DFHack/dfhack/pull/1917, and also improves some other things I spotted while I was at it.

@cppcooper feel free to take a look