### PR TITLE
[prioritize] Differentiate StoreItemInStockpile jobs by hauler labor and CustomReaction jobs by reaction name

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,7 +17,7 @@ that repo.
 - `autonick`: gives dwarves unique nicknames
 - `build-now`: instantly completes planned building constructions
 - `do-job-now`: makes a job involving current selection high priority
-- `prioritize`: automatically boosts the priority of current and/or future jobs of specified types, such as hauling food or pulling levers
+- `prioritize`: automatically boosts the priority of current and/or future jobs of specified types, such as hauling food, tanning hides, or pulling levers
 - `reveal-adv-map`: exposes/hides all world map tiles in adventure mode
 
 ## Fixes

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,7 +17,7 @@ that repo.
 - `autonick`: gives dwarves unique nicknames
 - `build-now`: instantly completes planned building constructions
 - `do-job-now`: makes a job involving current selection high priority
-- `prioritize`: automatically boosts the priority of current and/or future jobs of the selected types
+- `prioritize`: automatically boosts the priority of current and/or future jobs of specified types, such as hauling food or pulling levers
 - `reveal-adv-map`: exposes/hides all world map tiles in adventure mode
 
 ## Fixes

--- a/prioritize.lua
+++ b/prioritize.lua
@@ -6,21 +6,23 @@ prioritize
 ==========
 
 The prioritize script sets the ``do_now`` flag on all of the specified types of
-jobs that are currently ready to be picked up by a dwarf. This will force them
-to complete those jobs as soon as possible. This script can also continue to
-monitor creation of new jobs and automatically boost the priority of jobs of
-the specified types.
+jobs that are ready to be picked up by a dwarf but not yet assigned to a dwarf.
+This will force them to get assigned and completed as soon as possible.
 
-This is most useful for ensuring important (but low-priority -- according to DF)
+This script can also continue to monitor new jobs and automatically boost the
+priority of jobs of the specified types.
+
+This is useful for ensuring important (but low-priority -- according to DF)
 tasks don't get indefinitely ignored in busy forts. The list of monitored job
 types is cleared whenever you load a new map, so you can add a section like the
 one below to your ``onMapLoad.init`` file to ensure important job types are
 always completed promptly in your forts::
 
-    prioritize -a StoreItemInVehicle StoreItemInBag StoreItemInBarrel PullLever
-    prioritize -a DestroyBuilding RemoveConstruction RecoverWounded DumpItem
-    prioritize -a CleanSelf SlaughterAnimal PrepareRawFish ExtractFromRawFish
     prioritize -a --haul-labor=Food StoreItemInStockpile
+    prioritize -a PullLever CleanSelf RecoverWounded DumpItem
+    prioritize -a DestroyBuilding RemoveConstruction
+    prioritize -a StoreItemInVehicle StoreItemInBag StoreItemInBarrel
+    prioritize -a SlaughterAnimal PrepareRawFish ExtractFromRawFish
 
 Tanning hides is also a time-sensitive task, but it doesn't have a specific job
 type associated with it. You can prioritize them via::
@@ -28,6 +30,17 @@ type associated with it. You can prioritize them via::
    prioritize -a CustomReaction
 
 but this is likely to prioritize other, unrelated jobs as well.
+
+It is important to automatically prioritize only the *most* important job types.
+If you add too many job types, or if there are simply too many jobs of those
+types in your fort, the other tasks in your fort can get ignored. This causes
+the same problem the ``prioritize`` script is designed to solve. The example
+commands above have been extensively playtested and are a good default set. If
+you need a bunch of jobs of a specific type prioritized *right now*, consider
+running ``prioritize`` without the ``-a`` parameter, which only affects
+currently available jobs. For example::
+
+    prioritize ConstructBuilding
 
 Also see the ``do-job-now`` `tweak` for adding a hotkey to the jobs screen that
 can toggle the priority of specific individual jobs and the `do-job-now`
@@ -56,20 +69,20 @@ Examples:
 Options:
 
 :``-a``, ``--add``:
-    Prioritize all current and future new jobs of the specified job types.
+    Prioritize all current and future jobs of the specified job types.
 :``-d``, ``--delete``:
     Stop automatically prioritizing new jobs of the specified job types.
 :``-h``, ``--help``:
     Show help text.
 :``-j``, ``--jobs``:
-    Print out how many jobs of each type there are. This is useful for
-    discovering the types of the jobs which you can prioritize right now. If any
-    job types are specified, only returns the current count for those types.
+    Print out how many unassigned jobs of each type there are. This is useful
+    for discovering the types of the jobs that you can prioritize right now. If
+    any job types are specified, only returns the count for those types.
 :``-l``, ``--haul-labor`` <labor>[,<labor>...]:
     For StoreItemInStockpile jobs, restrict prioritization to the specified
     hauling labor(s). Valid types are: "Stone", "Wood", "Body", "Food",
     "Refuse", "Item", "Furniture", and "Animals". If not specified, defaults to
-    all.
+    matching all StoreItemInStockpile jobs.
 :``-q``, ``--quiet``:
     Suppress informational output (error messages are still printed).
 :``-r``, ``--registry``:
@@ -79,9 +92,9 @@ Options:
 local argparse = require('argparse')
 local eventful = require('plugins.eventful')
 
--- set of job types that we are watching. maps job_type=number to
--- {num_prioritized=number, unit_labors=map of type to num_prioritized} this
--- needs to be global so we don't lose player-set state when the script is
+-- set of job types that we are watching. maps job_type (as a number) to
+-- {num_prioritized=number, hauler_matchers=map of type to num_prioritized}
+-- this needs to be global so we don't lose player-set state when the script is
 -- reparsed. Also a getter function that can be mocked out by unit tests.
 g_watched_job_matchers = g_watched_job_matchers or {}
 function get_watched_job_matchers() return g_watched_job_matchers end

--- a/prioritize.lua
+++ b/prioritize.lua
@@ -12,25 +12,24 @@ This will force them to get assigned and completed as soon as possible.
 This script can also continue to monitor new jobs and automatically boost the
 priority of jobs of the specified types.
 
-This is useful for ensuring important (but low-priority -- according to DF)
-tasks don't get indefinitely ignored in busy forts. The list of monitored job
-types is cleared whenever you load a new map, so you can add a section like the
-one below to your ``onMapLoad.init`` file to ensure important job types are
-always completed promptly in your forts::
+This is useful for ensuring important (but low-priority -- according to DF) jobs
+don't get indefinitely ignored in busy forts. The list of monitored job types is
+cleared whenever you unload a map, so you can add a section like the one below
+to your ``onMapLoad.init`` file to ensure important and time-sensitive job types
+are always completed promptly in your forts::
 
-    prioritize -a --haul-labor=Food StoreItemInStockpile
+    prioritize -a --haul-labor=Food,Body StoreItemInStockpile
     prioritize -a --reaction-name=TAN_A_HIDE CustomReaction
-    prioritize -a PullLever CleanSelf RecoverWounded DumpItem
-    prioritize -a DestroyBuilding RemoveConstruction
-    prioritize -a StoreItemInVehicle StoreItemInBag StoreItemInBarrel
-    prioritize -a SlaughterAnimal PrepareRawFish ExtractFromRawFish
+    prioritize -a PrepareRawFish ExtractFromRawFish CleanSelf
 
 It is important to automatically prioritize only the *most* important job types.
 If you add too many job types, or if there are simply too many jobs of those
 types in your fort, the other tasks in your fort can get ignored. This causes
-the same problem the ``prioritize`` script is designed to solve. The example
-commands above have been extensively playtested and are a good default set. If
-you need a bunch of jobs of a specific type prioritized *right now*, consider
+the same problem the ``prioritize`` script is designed to solve. See the
+`onMapLoad-dreamfort-init` file in the ``hack/examples/init`` folder for a more
+complete, playtested set of job types to automatically prioritize.
+
+If you need a bunch of jobs of a specific type prioritized *right now*, consider
 running ``prioritize`` without the ``-a`` parameter, which only affects
 currently available (but unassigned) jobs. For example::
 
@@ -38,7 +37,7 @@ currently available (but unassigned) jobs. For example::
 
 Also see the ``do-job-now`` `tweak` for adding a hotkey to the jobs screen that
 can toggle the priority of specific individual jobs and the `do-job-now`
-script, which sets the priority of jobs related to the current selected
+script, which boosts the priority of current jobs related to the selected
 job/unit/item/building/order.
 
 Usage::
@@ -73,13 +72,13 @@ Options:
     for discovering the types of the jobs that you can prioritize right now. If
     any job types are specified, only returns the count for those types.
 :``-l``, ``--haul-labor`` <labor>[,<labor>...]:
-    For StoreItemInStockpile jobs, restrict prioritization to the specified
-    hauling labor(s). Valid types are: "Stone", "Wood", "Body", "Food",
-    "Refuse", "Item", "Furniture", and "Animals". If not specified, defaults to
-    matching all StoreItemInStockpile jobs.
+    For StoreItemInStockpile jobs, match only the specified hauling labor(s).
+    Valid <labor> strings are: "Stone", "Wood", "Body", "Food", "Refuse",
+    "Item", "Furniture", and "Animals". If not specified, defaults to matching
+    all StoreItemInStockpile jobs.
 :``-n``, ``--reaction-name`` <name>[,<name>...]:
-    For CustomReaction jobs, restrict prioritization to the specified reaction
-    name(s). See the registry output (``-r``) for the full list. If not,
+    For CustomReaction jobs, match only the specified reaction name(s). See the
+    registry output (``-r``) for the full list of reaction names. If not
     specified, defaults to matching all CustomReaction jobs.
 :``-q``, ``--quiet``:
     Suppress informational output (error messages are still printed).
@@ -185,14 +184,10 @@ local function update_handlers()
 end
 
 local function get_annotation_str(annotation)
-    if not annotation then
-        return nil
-    end
     return (' (%s)'):format(annotation)
 end
 
 local function get_unit_labor_str(unit_labor)
-    if not unit_labor then return nil end
     local labor_str = df.unit_labor[unit_labor]
     return ('%s%s'):format(labor_str:sub(6,6), labor_str:sub(7):lower())
 end
@@ -437,8 +432,7 @@ local function remove_watch(job_matchers, opts)
                 function(jm) return jm.reaction_matchers end,
                 function(jm)
                     jm.reaction_matchers = {}
-                    for _,v in ipairs(get_reactions())
-                            do
+                    for _,v in ipairs(get_reactions()) do
                         jm.reaction_matchers[v.code] = 0
                     end
                     return jm.reaction_matchers

--- a/test/prioritize.lua
+++ b/test/prioritize.lua
@@ -30,12 +30,12 @@ local DIG, EAT, REST = df.job_type.Dig, df.job_type.Eat, df.job_type.Rest
 local STORE_ITEM_IN_STOCKPILE = df.job_type.StoreItemInStockpile
 local SUTURE = df.job_type.Suture
 
-local HAUL_FOOD, HAUL_ITEM = df.unit_labor.HAUL_FOOD, df.unit_labor.HAUL_ITEM
-
 local HAUL_STONE, HAUL_WOOD = df.unit_labor.HAUL_STONE, df.unit_labor.HAUL_WOOD
 local HAUL_BODY, HAUL_FOOD = df.unit_labor.HAUL_BODY, df.unit_labor.HAUL_FOOD
-local HAUL_REFUSE, HAUL_ITEM = df.unit_labor.HAUL_REFUSE, df.unit_labor.HAUL_ITEM
-local HAUL_FURNITURE, HAUL_ANIMALS = df.unit_labor.HAUL_FURNITURE, df.unit_labor.HAUL_ANIMALS
+local HAUL_REFUSE = df.unit_labor.HAUL_REFUSE
+local HAUL_ITEM = df.unit_labor.HAUL_ITEM
+local HAUL_FURNITURE = df.unit_labor.HAUL_FURNITURE
+local HAUL_ANIMALS = df.unit_labor.HAUL_ANIMALS
 
 function test.status()
     p.status()
@@ -47,7 +47,7 @@ function test.status()
     p.status()
     expect.eq(3, mock_print.call_count)
     expect.eq('Automatically prioritized jobs:', mock_print.call_args[2][1])
-    expect.find('Rest', mock_print.call_args[3][1])
+    expect.str_find('Rest', mock_print.call_args[3][1])
 end
 
 function test.status_labor()
@@ -61,7 +61,7 @@ function test.status_labor()
     p.status()
     expect.eq(3, mock_print.call_count)
     expect.eq('Automatically prioritized jobs:', mock_print.call_args[2][1])
-    expect.find('Stockpile.*Body', mock_print.call_args[3][1])
+    expect.str_find('Stockpile.*Body', mock_print.call_args[3][1])
 end
 
 function test.boost()
@@ -102,14 +102,14 @@ end
 function test.boost_and_watch()
     p.boost_and_watch({[DIG]={num_prioritized=0}}, {})
     expect.eq(2, mock_print.call_count)
-    expect.find('^Prioritized', mock_print.call_args[1][1])
-    expect.find('^Automatically', mock_print.call_args[2][1])
+    expect.str_find('^Prioritized', mock_print.call_args[1][1])
+    expect.str_find('^Automatically', mock_print.call_args[2][1])
     expect.table_eq({[DIG]={num_prioritized=0}}, mock_watched_job_matchers)
 
     p.boost_and_watch({[DIG]={num_prioritized=0}}, {})
     expect.eq(4, mock_print.call_count)
-    expect.find('^Prioritized', mock_print.call_args[3][1])
-    expect.find('^Skipping', mock_print.call_args[4][1])
+    expect.str_find('^Prioritized', mock_print.call_args[3][1])
+    expect.str_find('^Skipping', mock_print.call_args[4][1])
     expect.table_eq({[DIG]={num_prioritized=0}}, mock_watched_job_matchers)
 end
 
@@ -126,13 +126,13 @@ end
 function test.remove_watch()
     p.remove_watch({[DIG]={num_prioritized=0}}, {})
     expect.eq(1, mock_print.call_count)
-    expect.find('Skipping unwatched', mock_print.call_args[1][1])
+    expect.str_find('Skipping unwatched', mock_print.call_args[1][1])
     expect.table_eq({}, mock_watched_job_matchers)
 
     mock_watched_job_matchers[DIG] = {num_prioritized=0}
     p.remove_watch({[DIG]={num_prioritized=0}}, {})
     expect.eq(2, mock_print.call_count)
-    expect.find('No longer', mock_print.call_args[2][1])
+    expect.str_find('No longer', mock_print.call_args[2][1])
 end
 
 function test.remove_watch_quiet()
@@ -161,16 +161,16 @@ function test.boost_and_watch_labor()
                             hauler_matchers={[HAUL_ITEM]=0}}},
                       {})
     expect.eq(2, mock_print.call_count)
-    expect.find('^Prioritized 2', mock_print.call_args[1][1])
-    expect.find('^Automatically', mock_print.call_args[2][1])
+    expect.str_find('^Prioritized 2', mock_print.call_args[1][1])
+    expect.str_find('^Automatically', mock_print.call_args[2][1])
     expect.table_eq({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=0,
                             hauler_matchers={[HAUL_ITEM]=0}}},
                     mock_watched_job_matchers)
 
     p.boost_and_watch({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=0}}, {})
     expect.eq(4, mock_print.call_count)
-    expect.find('^Prioritized 1', mock_print.call_args[3][1])
-    expect.find('^Automatically', mock_print.call_args[4][1])
+    expect.str_find('^Prioritized 1', mock_print.call_args[3][1])
+    expect.str_find('^Automatically', mock_print.call_args[4][1])
     expect.table_eq({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=0}},
                     mock_watched_job_matchers)
 end
@@ -178,23 +178,23 @@ end
 function test.boost_and_watch_store_all_labors()
     p.boost_and_watch({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=0}}, {})
     expect.eq(2, mock_print.call_count)
-    expect.find('^Prioritized 0', mock_print.call_args[1][1])
-    expect.find('^Automatically', mock_print.call_args[2][1])
+    expect.str_find('^Prioritized 0', mock_print.call_args[1][1])
+    expect.str_find('^Automatically', mock_print.call_args[2][1])
     expect.table_eq({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=0}},
                     mock_watched_job_matchers)
 
     p.boost_and_watch({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=0}}, {})
     expect.eq(4, mock_print.call_count)
-    expect.find('^Prioritized 0', mock_print.call_args[3][1])
-    expect.find('^Skipping', mock_print.call_args[4][1])
+    expect.str_find('^Prioritized 0', mock_print.call_args[3][1])
+    expect.str_find('^Skipping', mock_print.call_args[4][1])
     expect.table_eq({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=0}},
                     mock_watched_job_matchers)
 
     p.boost_and_watch({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=0,
                             hauler_matchers={[HAUL_ITEM]=0}}}, {})
     expect.eq(6, mock_print.call_count)
-    expect.find('^Prioritized 0', mock_print.call_args[3][1])
-    expect.find('^Skipping.*Item', mock_print.call_args[4][1])
+    expect.str_find('^Prioritized 0', mock_print.call_args[3][1])
+    expect.str_find('^Skipping.*Item', mock_print.call_args[4][1])
     expect.table_eq({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=0}},
                     mock_watched_job_matchers)
 end
@@ -203,8 +203,8 @@ function test.boost_and_watch_store_add_labors()
     p.boost_and_watch({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=0,
                             hauler_matchers={[HAUL_ITEM]=0}}}, {})
     expect.eq(2, mock_print.call_count)
-    expect.find('^Prioritized 0', mock_print.call_args[1][1])
-    expect.find('^Automatically.*Item', mock_print.call_args[2][1])
+    expect.str_find('^Prioritized 0', mock_print.call_args[1][1])
+    expect.str_find('^Automatically.*Item', mock_print.call_args[2][1])
     expect.table_eq({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=0,
                             hauler_matchers={[HAUL_ITEM]=0}}},
                     mock_watched_job_matchers)
@@ -212,8 +212,8 @@ function test.boost_and_watch_store_add_labors()
     p.boost_and_watch({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=0,
                             hauler_matchers={[HAUL_FOOD]=0}}}, {})
     expect.eq(4, mock_print.call_count)
-    expect.find('^Prioritized 0', mock_print.call_args[3][1])
-    expect.find('^Automatically.*Food', mock_print.call_args[4][1])
+    expect.str_find('^Prioritized 0', mock_print.call_args[3][1])
+    expect.str_find('^Automatically.*Food', mock_print.call_args[4][1])
     expect.table_eq({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=0,
                             hauler_matchers={[HAUL_ITEM]=0, [HAUL_FOOD]=0}}},
                     mock_watched_job_matchers)
@@ -221,8 +221,8 @@ function test.boost_and_watch_store_add_labors()
     p.boost_and_watch({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=0,
                             hauler_matchers={[HAUL_FOOD]=0}}}, {})
     expect.eq(6, mock_print.call_count)
-    expect.find('^Prioritized 0', mock_print.call_args[5][1])
-    expect.find('^Skipping.*Food', mock_print.call_args[6][1])
+    expect.str_find('^Prioritized 0', mock_print.call_args[5][1])
+    expect.str_find('^Skipping.*Food', mock_print.call_args[6][1])
     expect.table_eq({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=0,
                             hauler_matchers={[HAUL_ITEM]=0, [HAUL_FOOD]=0}}},
                     mock_watched_job_matchers)
@@ -236,7 +236,7 @@ function test.remove_one_labor_from_all()
                             hauler_matchers={[HAUL_FOOD]=0}}},
                       {})
     expect.eq(1, mock_print.call_count)
-    expect.find('No longer.*Food', mock_print.call_args[1][1])
+    expect.str_find('No longer.*Food', mock_print.call_args[1][1])
     expect.table_eq({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=5,
         hauler_matchers={[HAUL_STONE]=0, [HAUL_WOOD]=0, [HAUL_BODY]=0,
                          [HAUL_REFUSE]=0, [HAUL_ITEM]=0, [HAUL_FURNITURE]=0,
@@ -247,7 +247,7 @@ function test.remove_one_labor_from_all()
                             hauler_matchers={[HAUL_FOOD]=0}}},
                       {})
     expect.eq(2, mock_print.call_count)
-    expect.find('Skipping.*Food', mock_print.call_args[2][1])
+    expect.str_find('Skipping.*Food', mock_print.call_args[2][1])
     expect.table_eq({[STORE_ITEM_IN_STOCKPILE]={num_prioritized=5,
         hauler_matchers={[HAUL_STONE]=0, [HAUL_WOOD]=0, [HAUL_BODY]=0,
                          [HAUL_REFUSE]=0, [HAUL_ITEM]=0, [HAUL_FURNITURE]=0,
@@ -380,7 +380,7 @@ function test.print_registry()
             goto continue
         end
         expect.ne('nil', tostring(out))
-        expect.find('^%u%l', out)
+        expect.str_find('^%u%l', out)
         expect.ne('NONE', out)
         ::continue::
     end

--- a/test/prioritize.lua
+++ b/test/prioritize.lua
@@ -5,21 +5,23 @@ local p = prioritize.unit_test_hooks
 -- mock out state and external dependencies
 local mock_eventful_onUnload, mock_eventful_onJobInitiated = {}, {}
 local mock_print = mock.func()
-local mock_watched_job_types = {}
-local function get_mock_watched_job_types() return mock_watched_job_types end
+local mock_watched_job_matchers = {}
+local function get_mock_watched_job_matchers()
+    return mock_watched_job_matchers
+end
 local mock_postings = {}
 local function get_mock_postings() return mock_postings end
 local function test_wrapper(test_fn)
     mock.patch({{eventful, 'onUnload', mock_eventful_onUnload},
                 {eventful, 'onJobInitiated', mock_eventful_onJobInitiated},
                 {prioritize, 'print', mock_print},
-                {prioritize, 'get_watched_job_types',
-                 get_mock_watched_job_types},
+                {prioritize, 'get_watched_job_matchers',
+                 get_mock_watched_job_matchers},
                 {prioritize, 'get_postings', get_mock_postings}},
                test_fn)
     mock_eventful_onUnload, mock_eventful_onJobInitiated = {}, {}
     mock_print = mock.func()
-    mock_watched_job_types, mock_postings = {}, {}
+    mock_watched_job_matchers, mock_postings = {}, {}
 end
 config.wrapper = test_wrapper
 
@@ -31,7 +33,7 @@ function test.status()
     expect.eq('Not automatically prioritizing any jobs.',
               mock_print.call_args[1][1])
 
-    mock_watched_job_types[REST] = 5
+    mock_watched_job_matchers[REST] = {num_prioritized=5}
     p.status()
     expect.eq(3, mock_print.call_count)
     expect.eq('Automatically prioritized jobs:', mock_print.call_args[2][1])
@@ -50,7 +52,7 @@ function test.boost()
              {job={job_type=EAT, flags={}}, flags={dead=true}},
              {job={job_type=EAT, flags={do_now=true}}, flags={}},
              {job={job_type=REST, flags={}}, flags={dead=true}}}
-    p.boost({[EAT]=true})
+    p.boost({[EAT]={num_prioritized=0}}, {})
     expect.eq(1, mock_print.call_count)
     expect.eq('Prioritized 1 job.', mock_print.call_args[1][1])
     expect.table_eq(expected_postings, mock_postings)
@@ -68,70 +70,70 @@ function test.boost_quiet()
              {job={job_type=EAT, flags={}}, flags={dead=true}},
              {job={job_type=EAT, flags={do_now=true}}, flags={}},
              {job={job_type=REST, flags={}}, flags={dead=true}}}
-    p.boost({[EAT]=true}, true)
+    p.boost({[EAT]={num_prioritized=0}}, {quiet=true})
     expect.eq(0, mock_print.call_count)
     expect.table_eq(expected_postings, mock_postings)
 end
 
 function test.boost_and_watch()
-    p.boost_and_watch({[DIG]=true})
+    p.boost_and_watch({[DIG]={num_prioritized=0}}, {})
     expect.eq(2, mock_print.call_count)
     expect.true_(mock_print.call_args[1][1]:find('^Prioritized'))
     expect.true_(mock_print.call_args[2][1]:find('^Automatically'))
-    expect.table_eq({[DIG]=0}, mock_watched_job_types)
+    expect.table_eq({[DIG]={num_prioritized=0}}, mock_watched_job_matchers)
 
-    p.boost_and_watch({[DIG]=true})
+    p.boost_and_watch({[DIG]={num_prioritized=0}}, {})
     expect.eq(4, mock_print.call_count)
     expect.true_(mock_print.call_args[3][1]:find('^Prioritized'))
     expect.true_(mock_print.call_args[4][1]:find('^Skipping'))
-    expect.table_eq({[DIG]=0}, mock_watched_job_types)
+    expect.table_eq({[DIG]={num_prioritized=0}}, mock_watched_job_matchers)
 end
 
 function test.boost_and_watch_quiet()
-    p.boost_and_watch({[DIG]=true}, true)
+    p.boost_and_watch({[DIG]={num_prioritized=0}}, {quiet=true})
     expect.eq(0, mock_print.call_count)
-    expect.table_eq({[DIG]=0}, mock_watched_job_types)
+    expect.table_eq({[DIG]={num_prioritized=0}}, mock_watched_job_matchers)
 
-    p.boost_and_watch({[DIG]=true}, true)
+    p.boost_and_watch({[DIG]={num_prioritized=0}}, {quiet=true})
     expect.eq(0, mock_print.call_count)
-    expect.table_eq({[DIG]=0}, mock_watched_job_types)
+    expect.table_eq({[DIG]={num_prioritized=0}}, mock_watched_job_matchers)
 end
 
 function test.remove_watch()
-    p.remove_watch({[DIG]=true})
+    p.remove_watch({[DIG]={num_prioritized=0}}, {})
     expect.eq(1, mock_print.call_count)
     expect.true_(mock_print.call_args[1][1]:find('Skipping unwatched'))
-    expect.table_eq({}, mock_watched_job_types)
+    expect.table_eq({}, mock_watched_job_matchers)
 
-    mock_watched_job_types[DIG] = 0
-    p.remove_watch({[DIG]=true})
+    mock_watched_job_matchers[DIG] = {num_prioritized=0}
+    p.remove_watch({[DIG]={num_prioritized=0}}, {})
     expect.eq(2, mock_print.call_count)
     expect.true_(mock_print.call_args[2][1]:find('No longer'))
 end
 
 function test.remove_watch_quiet()
-    p.remove_watch({[DIG]=true}, true)
+    p.remove_watch({[DIG]={num_prioritized=0}}, {quiet=true})
     expect.eq(0, mock_print.call_count)
-    expect.table_eq({}, mock_watched_job_types)
+    expect.table_eq({}, mock_watched_job_matchers)
 
-    mock_watched_job_types[DIG] = 0
-    p.remove_watch({[DIG]=true}, true)
+    mock_watched_job_matchers[DIG] = {num_prioritized=0}
+    p.remove_watch({[DIG]={num_prioritized=0}}, {quiet=true})
     expect.eq(0, mock_print.call_count)
-    expect.table_eq({}, mock_watched_job_types)
+    expect.table_eq({}, mock_watched_job_matchers)
 end
 
 function test.eventful_hook_lifecycle()
     expect.nil_(mock_eventful_onUnload.prioritize)
     expect.nil_(mock_eventful_onJobInitiated.prioritize)
 
-    p.boost_and_watch({[DIG]=true}, true)
-    expect.table_eq({[DIG]=0}, mock_watched_job_types)
+    p.boost_and_watch({[DIG]={num_prioritized=0}}, {quiet=true})
+    expect.table_eq({[DIG]={num_prioritized=0}}, mock_watched_job_matchers)
 
-    expect.eq(p.clear_watched_job_types, mock_eventful_onUnload.prioritize)
+    expect.eq(p.clear_watched_job_matchers, mock_eventful_onUnload.prioritize)
     expect.eq(p.on_new_job, mock_eventful_onJobInitiated.prioritize)
 
-    p.remove_watch({[DIG]=true}, true)
-    expect.table_eq({}, mock_watched_job_types)
+    p.remove_watch({[DIG]={num_prioritized=0}}, {quiet=true})
+    expect.table_eq({}, mock_watched_job_matchers)
 
     expect.nil_(mock_eventful_onUnload.prioritize)
     expect.nil_(mock_eventful_onJobInitiated.prioritize)
@@ -146,13 +148,13 @@ function test.eventful_callbacks()
 
     -- watched job
     local expected = {job_type=DIG, flags={do_now=true}}
-    p.boost_and_watch({[DIG]=true}, true)
+    p.boost_and_watch({[DIG]={num_prioritized=0}}, {quiet=true})
     p.on_new_job(job)
     expect.table_eq(expected, job)
 
     -- map unload
-    p.clear_watched_job_types()
-    expect.table_eq({}, mock_watched_job_types)
+    p.clear_watched_job_matchers()
+    expect.table_eq({}, mock_watched_job_matchers)
     expect.nil_(mock_eventful_onUnload.prioritize)
     expect.nil_(mock_eventful_onJobInitiated.prioritize)
 end
@@ -221,56 +223,58 @@ function test.print_registry()
     end
 end
 
+local SUTURE = df.job_type['Suture']
 function test.parse_commandline()
     expect.table_eq({help=true}, p.parse_commandline{'help'})
     expect.table_eq({help=true}, p.parse_commandline{'-h'})
     expect.table_eq({help=true}, p.parse_commandline{'--help'})
 
-    expect.table_eq({action=p.status, job_types={}}, p.parse_commandline{})
-    expect.table_eq({action=p.boost, job_types={[df.job_type['Suture']]=true}},
+    expect.table_eq({action=p.status, job_matchers={}}, p.parse_commandline{})
+    expect.table_eq({action=p.boost,
+                     job_matchers={[SUTURE]={num_prioritized=0}}},
                     p.parse_commandline{'Suture'})
     expect.printerr_match('Ignoring unknown job type',
         function()
-            expect.table_eq({action=p.status, job_types={}},
+            expect.table_eq({action=p.status, job_matchers={}},
                             p.parse_commandline{'XSutureX'})
         end)
     expect.printerr_match('Ignoring unknown job type',
         function()
             expect.table_eq({action=p.boost,
-                             job_types={[df.job_type['Suture']]=true}},
+                             job_matchers={[SUTURE]={num_prioritized=0}}},
                             p.parse_commandline{'XSutureX', 'Suture'})
         end)
 
-    expect.table_eq({action=p.status, job_types={}, quiet=true},
+    expect.table_eq({action=p.status, job_matchers={}, quiet=true},
                     p.parse_commandline{'-q'})
-    expect.table_eq({action=p.status, job_types={}, quiet=true},
+    expect.table_eq({action=p.status, job_matchers={}, quiet=true},
                     p.parse_commandline{'--quiet'})
 
     expect.table_eq({action=p.boost_and_watch,
-                     job_types={[df.job_type['Suture']]=true}},
+                     job_matchers={[SUTURE]={num_prioritized=0}}},
                     p.parse_commandline{'-a', 'Suture'})
     expect.table_eq({action=p.boost_and_watch,
-                     job_types={[df.job_type['Suture']]=true}},
+                     job_matchers={[SUTURE]={num_prioritized=0}}},
                     p.parse_commandline{'--add', 'Suture'})
 
     expect.table_eq({action=p.remove_watch,
-                     job_types={[df.job_type['Suture']]=true}},
+                     job_matchers={[SUTURE]={num_prioritized=0}}},
                     p.parse_commandline{'-d', 'Suture'})
     expect.table_eq({action=p.remove_watch,
-                     job_types={[df.job_type['Suture']]=true}},
+                     job_matchers={[SUTURE]={num_prioritized=0}}},
                     p.parse_commandline{'--delete', 'Suture'})
 
-    expect.table_eq({action=p.print_current_jobs, job_types={}},
+    expect.table_eq({action=p.print_current_jobs, job_matchers={}},
                     p.parse_commandline{'-j'})
     expect.table_eq({action=p.print_current_jobs,
-                     job_types={[df.job_type['Suture']]=true}},
+                     job_matchers={[SUTURE]={num_prioritized=0}}},
                     p.parse_commandline{'-j', 'Suture'})
     expect.table_eq({action=p.print_current_jobs,
-                     job_types={[df.job_type['Suture']]=true}},
+                     job_matchers={[SUTURE]={num_prioritized=0}}},
                     p.parse_commandline{'--jobs', 'Suture'})
 
-    expect.table_eq({action=p.print_registry, job_types={}},
+    expect.table_eq({action=p.print_registry, job_matchers={}},
                     p.parse_commandline{'-r'})
-    expect.table_eq({action=p.print_registry, job_types={}},
+    expect.table_eq({action=p.print_registry, job_matchers={}},
                     p.parse_commandline{'--registry'})
 end

--- a/test/prioritize.lua
+++ b/test/prioritize.lua
@@ -12,13 +12,16 @@ local function get_mock_watched_job_matchers()
 end
 local mock_postings = {}
 local function get_mock_postings() return mock_postings end
+local mock_reactions = {}
+local function get_mock_reactions() return mock_reactions end
 local function test_wrapper(test_fn)
     mock.patch({{eventful, 'onUnload', mock_eventful_onUnload},
                 {eventful, 'onJobInitiated', mock_eventful_onJobInitiated},
                 {prioritize, 'print', mock_print},
                 {prioritize, 'get_watched_job_matchers',
                  get_mock_watched_job_matchers},
-                {prioritize, 'get_postings', get_mock_postings}},
+                {prioritize, 'get_postings', get_mock_postings},
+                {prioritize, 'get_reactions', get_mock_reactions}},
                test_fn)
     mock_eventful_onUnload, mock_eventful_onJobInitiated = {}, {}
     mock_print = mock.func()
@@ -376,7 +379,7 @@ function test.print_registry()
     for i,v in ipairs(mock_print.call_args) do
         local out = v[1]:trim()
         if i == 1 then
-            expect.eq('Valid job types:', out)
+            expect.eq('Job types:', out)
             goto continue
         end
         expect.ne('nil', tostring(out))


### PR DESCRIPTION
Add the `--haul-labor` param to identify types of StoreItemInStockpile jobs and the `--reaction-name` param to identify types of CustomReaction jobs.

all dependencies of this script have been merged; this PR is ready for merge.