### PR TITLE
[assign-*] Add recalculation of needs after a personality change.

### DIFF
--- a/assign-beliefs.lua
+++ b/assign-beliefs.lua
@@ -70,6 +70,7 @@ triggered a report.
 ]====]
 
 local utils = require("utils")
+local setneed = reqscript("modtools/set-need")
 
 local valid_args = utils.invert({
                                     'help',
@@ -150,6 +151,7 @@ function assign(beliefs, unit, reset)
             print_yellow("WARNING: '" .. belief .. "' is not a valid belief token. Skipping...")
         end
     end
+    setneed.rebuildNeeds(unit)
 end
 
 -- ------------------------------------------------------ MAIN ------------------------------------------------------ --

--- a/assign-facets.lua
+++ b/assign-facets.lua
@@ -67,6 +67,7 @@ will be reported.
 ]====]
 
 local utils = require("utils")
+local setneed = reqscript("modtools/set-need")
 
 local valid_args = utils.invert({
                                     'help',
@@ -148,6 +149,7 @@ function assign(facets, unit, reset)
             print_yellow("WARNING: '" .. facet .. "' is not a valid facet token. Skipping...")
         end
     end
+    setneed.rebuildNeeds(unit)
 end
 
 -- ------------------------------------------------------ MAIN ------------------------------------------------------ --


### PR DESCRIPTION
I noticed that when other scripts changed a trait (facet) or a belief, they then called the function `rebuildNeeds()` of `set-need` to recalculate the needs focus level. So, I added this call to my scripts as well.