### PR TITLE
Update assign-preferences.lua

### DIFF
--- a/assign-preferences.lua
+++ b/assign-preferences.lua
@@ -282,6 +282,7 @@ local preference_functions = {
     -- ---------------- LIKEFOOD ---------------- --
     LIKEFOOD = function(token)
         local mat_info = dfhack.matinfo.find(token)
+        local food_state = 1
         if not mat_info then
             goto error
         end
@@ -305,6 +306,7 @@ local preference_functions = {
                 item_type = df.item_type.POWDER_MISC
             elseif food_mat_index.CookableSeed > -1 then
                 item_type = df.item_type.SEEDS
+                food_state = 0
             elseif food_mat_index.CookableLeaf > -1 then
                 --[[
                 In case of plant growths, "mat_info" stores the item type as a specific subtype ("FLOWER", or "FRUIT",
@@ -312,6 +314,7 @@ local preference_functions = {
                 are sometimes stored in the plural form and sometimes in the singular form, so we need to know what to
                 look for when we try to associate the item_type to the growth_id.
                 --]]
+                food_state = 0
                 local growths = {
                     -- item_id = growth_id, as returned by dfhack.matinfo.find()
                     BULB = "BULBS",
@@ -347,7 +350,7 @@ local preference_functions = {
                     item_subtype = item_subtype,
                     mattype = mat_info.type,
                     matindex = mat_info.index,
-                    mat_state = 1,
+                    mat_state = food_state,
                     active = true,
                     prefstring_seed = rng:random()
                 }


### PR DESCRIPTION
For some food categories, this script saves the mat_state wrong. That is, differently from how the game does it. Dunno if it has any actual effect, apart from Dwarf Therapist showing it in detail. Might actually even be that mat_state should outright be 0, as even drinks don't seem to have 1 for them.

Just start a new embark and look at the preferences of your starting seven with gm-editor or something, I could post screenshots of examples but it should be easy to see for yourself.