### PR TITLE
[quickfort] gracefully handle error state for bad query blueprint key sequences that leave the game without a cursor

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ that repo.
 ## New Scripts
 
 ## Fixes
+- `quickfort`: produce a useful error message instead of a code error when a bad query blueprint key sequence leaves the game in a mode that does not have an active cursor
 
 ## Misc Improvements
 - `gui/blueprint`: support the new ``--splitby`` and ``--format`` options for `blueprint`

--- a/internal/quickfort/query.lua
+++ b/internal/quickfort/query.lua
@@ -114,7 +114,15 @@ function do_run(zlevel, grid, ctx)
             if not dry_run
                     and not quickfort_set.get_setting('query_unsafe') then
                 local cursor = guidm.getCursorPos()
-                if not same_xyz(pos, cursor) then
+                if not cursor then
+                    qerror(string.format(
+                        'expected to be at cursor position (%d, %d, %d) on ' ..
+                        'screen "%s" but there is no active cursor; there ' ..
+                        'is likely a problem with the blueprint text in ' ..
+                        'cell %s: "%s" (do you need a "q" at the end to get ' ..
+                        'back into query mode?)',
+                        pos.x, pos.y, pos.z, focus_string, cell, text))
+                elseif not same_xyz(pos, cursor) then
                     qerror(string.format(
                         'expected to be at cursor position (%d, %d, %d) on ' ..
                         'screen "%s" but cursor is at (%d, %d, %d); there ' ..


### PR DESCRIPTION
Produce a useful error message instead of a code error when a bad query blueprint key sequence leaves the game in a mode that does not have an active cursor