### PR TITLE
Fix dfhack #1618 (advfort encrust/stud deletes items)

### DIFF
--- a/gui/advfort_items.lua
+++ b/gui/advfort_items.lua
@@ -185,11 +185,17 @@ function jobitemEditor:jobValid()
 end
 function jobitemEditor:commit()
     if self.job then
+        -- count slots
+        local numSlots = 0
+        for _ in pairs(self.slots) do
+            numSlots = numSlots + 1
+        end
+
         -- equivalent of insertion sorting the slots in their job_item_idx order
         -- fixes decoration jobs destroying both reagents
-        for slotID=0,#self.slots,1 do
+        for orderedSlotID=0,numSlots,1 do
             for _,slot in pairs(self.slots) do
-                if slot.id == slotID then
+                if slot.id == orderedSlotID then
                     for _1,cur_item in pairs(slot.items) do
                         self.job.items:insert("#",{new=true,item=cur_item,role=df.job_item_ref.T_role.Reagent,job_item_idx=slot.id})
                     end

--- a/gui/advfort_items.lua
+++ b/gui/advfort_items.lua
@@ -185,9 +185,15 @@ function jobitemEditor:jobValid()
 end
 function jobitemEditor:commit()
     if self.job then
-        for _,slot in pairs(self.slots) do
-            for _1,cur_item in pairs(slot.items) do
-                self.job.items:insert("#",{new=true,item=cur_item,role=df.job_item_ref.T_role.Reagent,job_item_idx=slot.id})
+        -- equivalent of insertion sorting the slots in their job_item_idx order
+        -- fixes decoration jobs destroying both reagents
+        for slotID=0,#self.slots,1 do
+            for _,slot in pairs(self.slots) do
+                if slot.id == slotID then
+                    for _1,cur_item in pairs(slot.items) do
+                        self.job.items:insert("#",{new=true,item=cur_item,role=df.job_item_ref.T_role.Reagent,job_item_idx=slot.id})
+                    end
+                end
             end
         end
     end


### PR DESCRIPTION
Fixes DFHack/dfhack#1618

This pull request adjusts `advfort_items.lua` to always append the available items for a job in their `job_item_idx` order. This fixes `Stud with <metal>` and `Encrust with Gems` jobs so that they won't delete both reagents.