### PR TITLE
[quickfort] implement API for applying blueprint data passed in Lua tables

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,9 +17,11 @@ that repo.
 
 ## Fixes
 - `quickfort`: produce a useful error message instead of a code error when a bad query blueprint key sequence leaves the game in a mode that does not have an active cursor
+- `quickfort`: restore functionality to the ``--verbose`` commandline flag
 
 ## Misc Improvements
 - `gui/blueprint`: support the new ``--splitby`` and ``--format`` options for `blueprint`
+- `quickfort`: add ``quickfort.apply_blueprint()`` API function that can be called directly by other scripts
 
 # 0.47.05-r3
 

--- a/internal/quickfort/api.lua
+++ b/internal/quickfort/api.lua
@@ -1,0 +1,45 @@
+-- helper functions for the quickfort API
+--@ module = true
+
+if not dfhack_flags.module then
+    qerror('this script cannot be called directly')
+end
+
+require('dfhack.buildings') -- loads additional functions into dfhack.buildings
+local utils = require('utils')
+local quickfort_common = reqscript('internal/quickfort/common')
+local quickfort_building = reqscript('internal/quickfort/building')
+local quickfort_map = reqscript('internal/quickfort/map')
+local quickfort_parse = reqscript('internal/quickfort/parse')
+
+function normalize_data(data, pos)
+    pos = pos or {}
+    pos.x, pos.y, pos.z = pos.x or 0, pos.y or 0, pos.z or 0
+
+    local shifted, min = {}, {x=30000, y=30000, z=30000}
+    for z,grid in pairs(data) do
+        local shiftedz, shiftedgrid = z+pos.z, {}
+        if shiftedz < min.z then min.z = shiftedz end
+        for y,row in pairs(grid) do
+            local shiftedy, shiftedrow = y+pos.y, {}
+            if shiftedy < min.y then min.y = shiftedy end
+            for x,text in pairs(row) do
+                local shiftedx = x + pos.x
+                if shiftedx < min.x then min.x = shiftedx end
+                shiftedrow[shiftedx] = {cell=('%d,%d,%d'):format(x,y,z),
+                                        text=text}
+            end
+            shiftedgrid[shiftedy] = shiftedrow
+        end
+        shifted[shiftedz] = shiftedgrid
+    end
+    return shifted, min
+end
+
+function clean_stats(stats)
+    for _,stat in pairs(stats) do
+        -- remove internal markers
+        stat.always = nil
+    end
+    return stats
+end

--- a/internal/quickfort/command.lua
+++ b/internal/quickfort/command.lua
@@ -61,9 +61,8 @@ function do_command_section(ctx, section_name)
     local first_modeline = nil
     for _, section_data in ipairs(section_data_list) do
         if not first_modeline then first_modeline = section_data.modeline end
-        ctx.cursor.z = section_data.zlevel
-        mode_modules[section_data.modeline.mode][command_switch[ctx.command]](
-            section_data.zlevel, section_data.grid, ctx)
+        do_command_raw(section_data.modeline.mode, section_data.zlevel,
+                       section_data.grid, ctx)
     end
     if first_modeline and first_modeline.message then
         table.insert(ctx.messages, first_modeline.message)

--- a/internal/quickfort/dialog.lua
+++ b/internal/quickfort/dialog.lua
@@ -189,7 +189,7 @@ local function dialog_command(command, text)
     local aliases = quickfort_list.get_aliases(blueprint_name)
     local ctx = quickfort_command.init_ctx(command, blueprint_name, cursor,
                                            aliases, false)
-    quickfort_command.do_command_internal(ctx, section_name)
+    quickfort_command.do_command_section(ctx, section_name)
     quickfort_command.finish_command(ctx, section_name, true)
     if command == 'run' and #ctx.messages > 0 then
         dialogs.showMessage('Attention',

--- a/internal/quickfort/meta.lua
+++ b/internal/quickfort/meta.lua
@@ -47,7 +47,7 @@ local function do_meta(zlevel, grid, ctx)
         local section_name =
                 get_section_name(cell.cell, cell.text, ctx.sheet_name)
         print(string.format('applying blueprint: "%s"', section_name))
-        quickfort_command.do_command_internal(ctx, section_name)
+        quickfort_command.do_command_section(ctx, section_name)
         ctx.cursor.z = saved_zlevel
         stats.meta_blueprints.value = stats.meta_blueprints.value + 1
     end

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -259,7 +259,7 @@ function apply_blueprint(params)
     local data, cursor = quickfort_api.normalize_data(params.data, params.pos)
     local ctx = quickfort_command.init_ctx(params.command or 'run', 'API',
                                 cursor, params.aliases or {}, params.dry_run)
-    quickfort_common.verbose = params.verbose
+    quickfort_common.verbose = not not params.verbose
     dfhack.with_finalize(
         function() quickfort_common.verbose = false end,
         function()

--- a/test/quickfort/api_unit.lua
+++ b/test/quickfort/api_unit.lua
@@ -1,0 +1,45 @@
+local a = reqscript('internal/quickfort/api')
+
+function test.module()
+    expect.error_match(
+        'this script cannot be called directly',
+        function() dfhack.run_script('internal/quickfort/api') end)
+end
+
+function test.normalize_data()
+    local data = {[0]={[0]={[0]='d(10x10)'}}}
+    local expected_data = {[0]={[0]={[0]={cell='0,0,0', text='d(10x10)'}}}}
+    local expected_min = {x=0, y=0, z=0}
+    expect.table_eq({expected_data, expected_min}, {a.normalize_data(data)})
+
+    expected_data = {[10]={[11]={[12]={cell='0,0,0', text='d(10x10)'}}}}
+    expected_min = {x=12, y=11, z=10}
+    expect.table_eq({expected_data, expected_min},
+                    {a.normalize_data(data, {x=12, y=11, z=10})})
+
+    data = {[-1]={[-2]={[-3]='d(10x10)'}}}
+    expected_data = {[1]={[1]={[1]={cell='-3,-2,-1', text='d(10x10)'}}}}
+    expected_min = {x=1, y=1, z=1}
+    expect.table_eq({expected_data, expected_min},
+                    {a.normalize_data(data, {x=4, y=3, z=2})})
+
+    data = {[0]={[0]={[0]='d1',
+                      [5]='d2'},
+                 [3]={[4]='d3'}},
+            [10]={[1]={[2]='d4'}}}
+    expected_data = {[0]={[10]={[5]={cell='0,0,0', text='d1'},
+                                [10]={cell='5,0,0', text='d2'}},
+                          [13]={[9]={cell='4,3,0', text='d3'}}},
+                     [10]={[11]={[7]={cell='2,1,10', text='d4'}}}}
+    expected_min = {x=5, y=10, z=0}
+    expect.table_eq({expected_data, expected_min},
+                    {a.normalize_data(data, {x=5, y=10})})
+end
+
+function test.clean_stats()
+    local stats = {name1={label='label1', value=5},
+                   name2={label='label2', value=50, always=true}}
+    local expected_stats = {name1={label='label1', value=5},
+                            name2={label='label2', value=50}}
+    expect.table_eq(expected_stats, a.clean_stats(stats))
+end

--- a/test/quickfort/command_unit.lua
+++ b/test/quickfort/command_unit.lua
@@ -160,3 +160,10 @@ function test.do_command_stats()
                       mock_print.call_args[2][1])
         end)
 end
+
+function test.do_command_raw_errors()
+    expect.error_match('invalid mode',
+        function() c.do_command_raw('badmode', 0, {}, {}) end)
+    expect.error_match('invalid command',
+        function() c.do_command_raw('dig', 0, {}, {command='badcomm'}) end)
+end

--- a/test/quickfort/quickfort_unit.lua
+++ b/test/quickfort/quickfort_unit.lua
@@ -1,0 +1,64 @@
+local q = reqscript('quickfort')
+local quickfort_command = reqscript('internal/quickfort/command')
+local quickfort_common = reqscript('internal/quickfort/common')
+
+local mock_do_command_raw
+local verbose_snapshot
+
+local function verbose_snapshotter(...)
+    verbose_snapshot = quickfort_common.verbose
+    return mock_do_command_raw(...)
+end
+
+local function test_wrapper(test_fn)
+    mock_do_command_raw = mock.func()
+    verbose_snapshot = nil
+    mock.patch(quickfort_command, 'do_command_raw', verbose_snapshotter,
+               test_fn)
+end
+config.wrapper = test_wrapper
+
+function test.apply_blueprint_minimal()
+    local data = {[0]={[0]={[0]='d'}}}
+    local expected_ctx = quickfort_command.init_ctx('run', 'API',
+                                                    {x=0, y=0, z=0}, {}, nil)
+    q.apply_blueprint{mode='dig', data=data}
+
+    expect.eq(1, mock_do_command_raw.call_count)
+    local args = mock_do_command_raw.call_args[1]
+    expect.eq(args[1], 'dig')
+    expect.eq(args[2], 0)
+    expect.table_eq(args[3], {[0]={[0]={cell='0,0,0', text='d'}}})
+    expect.table_eq(args[4], expected_ctx)
+
+    expect.false_(verbose_snapshot)
+    expect.false_(quickfort_common.verbose)
+end
+
+function test.apply_blueprint_all_ctx_params()
+    local data = {[2]={[20]={[8]='somekeys'}},
+                  [3]={[9]={[20]='somealias'}}}
+    local expected_ctx = quickfort_command.init_ctx('undo', 'API',
+                                                    {x=10, y=10, z=1},
+                                                    {somealias='ab{analias}'},
+                                                    true)
+    q.apply_blueprint{mode='query', data=data, command='undo',
+                      pos={x=2, y=1, z=-1}, aliases={somealias='ab{analias}'},
+                      dry_run=true, verbose=true}
+
+    expect.eq(2, mock_do_command_raw.call_count)
+    local args = mock_do_command_raw.call_args[1]
+    expect.eq(args[1], 'query')
+    expect.eq(args[2], 1)
+    expect.table_eq(args[3], {[21]={[10]={cell='8,20,2', text='somekeys'}}})
+    expect.table_eq(args[4], expected_ctx)
+
+    args = mock_do_command_raw.call_args[2]
+    expect.eq(args[1], 'query')
+    expect.eq(args[2], 2)
+    expect.table_eq(args[3], {[10]={[22]={cell='20,9,3', text='somealias'}}})
+    expect.table_eq(args[4], expected_ctx)
+
+    expect.true_(verbose_snapshot)
+    expect.false_(quickfort_common.verbose)
+end


### PR DESCRIPTION
single API that exposes all of quickfort's blueprint actions ("run", "orders", "undo")

Question: should the API docs be just in the `quickfort.lua` file or should it be added to the online docs? Right now I just provide a link in the online docs to the source tree where the API is documented.

also fixes a bug that crept into the last release that broke the `--verbose` flag.
