### PR TITLE
[gui/blueprint] hide help text when the screen is too short to display it

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ that repo.
 
 ## Misc Improvements
 - `gui/blueprint`: support the new ``--splitby`` and ``--format`` options for `blueprint`
+- `gui/blueprint`: hide help text when the screen is too short to display it
 - `quickfort`: add ``quickfort.apply_blueprint()`` API function that can be called directly by other scripts
 
 # 0.47.05-r3


### PR DESCRIPTION
no unit tests for this since we can't control the display height from the test harness, but I did confirm that the existing tests now pass for both large and small screens.