### PR TITLE
[quickfort] protect masterwork engravings from being designated for digging

### DIFF
--- a/internal/quickfort/command.lua
+++ b/internal/quickfort/command.lua
@@ -25,13 +25,15 @@ local command_switch = {
     undo='do_undo',
 }
 
-function init_ctx(command, blueprint_name, cursor, aliases, dry_run)
+function init_ctx(command, blueprint_name, cursor, aliases, dry_run,
+                  clobber_masterwork_engravings)
     return {
         command=command,
         blueprint_name=blueprint_name,
         cursor=cursor,
         aliases=aliases,
         dry_run=dry_run,
+        clobber_masterwork_engravings=clobber_masterwork_engravings,
         stats={out_of_bounds={label='Tiles outside map boundary', value=0},
                invalid_keys={label='Invalid key sequences', value=0}},
         messages={},
@@ -84,7 +86,8 @@ function finish_command(ctx, section_name, quiet)
 end
 
 local function do_one_command(command, cursor, blueprint_name, section_name,
-                              mode, quiet, dry_run)
+                              mode, quiet, dry_run,
+                              clobber_masterwork_engravings)
     if not cursor then
         if command == 'orders' or mode == 'notes' then
             cursor = {x=0, y=0, z=0}
@@ -95,8 +98,8 @@ local function do_one_command(command, cursor, blueprint_name, section_name,
     end
 
     local aliases = quickfort_list.get_aliases(blueprint_name)
-    local ctx = init_ctx(command, blueprint_name, cursor, aliases,
-                            dry_run)
+    local ctx = init_ctx(command, blueprint_name, cursor, aliases, dry_run,
+                         clobber_masterwork_engravings)
     do_command_section(ctx, section_name)
     finish_command(ctx, section_name, quiet)
     if command == 'run' then
@@ -106,23 +109,25 @@ local function do_one_command(command, cursor, blueprint_name, section_name,
     end
 end
 
-local function do_bp_name(commands, cursor, bp_name, sec_names, quiet, dry_run)
+local function do_bp_name(commands, cursor, bp_name, sec_names, quiet, dry_run,
+                          clobber_masterwork_engravings)
     for _,sec_name in ipairs(sec_names) do
         local mode = quickfort_list.get_blueprint_mode(bp_name, sec_name)
         for _,command in ipairs(commands) do
             do_one_command(command, cursor, bp_name, sec_name, mode,
-                           quiet, dry_run)
+                           quiet, dry_run, clobber_masterwork_engravings)
         end
     end
 end
 
-local function do_list_num(commands, cursor, list_nums, quiet, dry_run)
+local function do_list_num(commands, cursor, list_nums, quiet, dry_run,
+                           clobber_masterwork_engravings)
     for _,list_num in ipairs(list_nums) do
         local bp_name, sec_name, mode =
                 quickfort_list.get_blueprint_by_number(list_num)
         for _,command in ipairs(commands) do
             do_one_command(command, cursor, bp_name, sec_name, mode,
-                           quiet, dry_run)
+                           quiet, dry_run, clobber_masterwork_engravings)
         end
     end
 end
@@ -135,9 +140,12 @@ function do_command(args)
     end
     local cursor = guidm.getCursorPos()
     local quiet, verbose, dry_run, section_names = false, false, false, {''}
+    local clobber_masterwork_engravings = false
     local other_args = argparse.processArgsGetopt(args, {
             {'c', 'cursor', hasArg=true,
              handler=function(optarg) cursor = argparse.coords(optarg) end},
+            {nil, 'clobber-masterwork-engravings',
+             handler=function() clobber_masterwork_engravings = true end},
             {'d', 'dry-run', handler=function() dry_run = true end},
             {'n', 'name', hasArg=true,
              handler=function(optarg)
@@ -162,9 +170,10 @@ function do_command(args)
             local ok, list_nums = pcall(argparse.numberList, blueprint_name)
             if not ok then
                 do_bp_name(args.commands, cursor, blueprint_name, section_names,
-                        quiet, dry_run)
+                           quiet, dry_run, clobber_masterwork_engravings)
             else
-                do_list_num(args.commands, cursor, list_nums, quiet, dry_run)
+                do_list_num(args.commands, cursor, list_nums, quiet, dry_run,
+                            clobber_masterwork_engravings)
             end
         end)
 end

--- a/internal/quickfort/dialog.lua
+++ b/internal/quickfort/dialog.lua
@@ -188,7 +188,7 @@ local function dialog_command(command, text)
                             command, blueprint_name, section_name)))
     local aliases = quickfort_list.get_aliases(blueprint_name)
     local ctx = quickfort_command.init_ctx(command, blueprint_name, cursor,
-                                           aliases, false)
+                                           aliases, false, false)
     quickfort_command.do_command_section(ctx, section_name)
     quickfort_command.finish_command(ctx, section_name, true)
     if command == 'run' and #ctx.messages > 0 then

--- a/internal/quickfort/dig.lua
+++ b/internal/quickfort/dig.lua
@@ -643,7 +643,8 @@ local function do_run_impl(zlevel, grid, ctx)
                         if not ctx.clobber_masterwork_engravings
                                 and db_entry.can_clobber_engravings
                                 and digctx.engraving
-                                and digctx.engraving.quality >= 5 then
+                                and digctx.engraving.quality >=
+                                        df.item_quality.Masterful then
                             stats.dig_protected_masterwork.value =
                                     stats.dig_protected_masterwork.value + 1
                         else

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -73,6 +73,10 @@ Usage:
     Use the specified map coordinates instead of the current cursor position for
     the blueprint cursor start position. If this option is specified, then an
     active game map cursor is not necessary.
+``--clobber-masterwork-engravings``
+    Allow dig blueprints to designate tiles for digging even if they have
+    masterwork engravings on them. Note that once those tiles are dug out, the
+    dwarf who engraved the masterwork will get negative thoughts.
 ``-d``, ``--dry-run``
     Go through all the motions and print statistics on what would be done, but
     don't actually change any game state.
@@ -157,6 +161,8 @@ statistics structure is a map of stat ids to ``{label=string, value=number}``.
     specified, defaults to ``{x=0, y=0, z=0}``.
 :``aliases``: a map of query blueprint aliases names to their expansions. If not
     specified, defaults to ``{}``.
+:``clobber_masterwork_engravings``: Allow dig blueprints to designate tiles for
+    digging even if they have masterwork engravings on them. Defaults to false.
 :``dry_run``: Just calculate statistics, such as how many tiles are outside the
     boundaries of the map; don't actually apply the blueprint. Defaults to
     false.
@@ -242,6 +248,10 @@ undo    Applies the inverse of the specified blueprint. Dig tiles are
     Use the specified map coordinates instead of the current cursor position for
     the blueprint cursor start position. If this option is specified, then an
     active game map cursor is not necessary.
+--clobber-masterwork-engravings
+    Allow dig blueprints to designate tiles for digging even if they have
+    masterwork engravings on them. Note that once those tiles are dug out, the
+    dwarf who engraved the masterwork will get negative thoughts.
 -d, --dry-run
     Go through all the motions and print statistics on what would be done, but
     don't actually change any game state.
@@ -261,7 +271,8 @@ end
 function apply_blueprint(params)
     local data, cursor = quickfort_api.normalize_data(params.data, params.pos)
     local ctx = quickfort_command.init_ctx(params.command or 'run', 'API',
-                                cursor, params.aliases or {}, params.dry_run)
+                                cursor, params.aliases or {}, params.dry_run,
+                                params.clobber_masterwork_engravings)
     quickfort_common.verbose = not not params.verbose
     dfhack.with_finalize(
         function() quickfort_common.verbose = false end,


### PR DESCRIPTION
By default, `quickfort` will now refuse to designate tiles for digging if they have masterwork engravings on them. The new `--clobber-masterwork-engravings` param allows players to get the old behavior of digging them out anyway if that is actually desired.

Note that masterworks could still be destroyed in adjacent z-levels if `quickfort` designates a tile for channeling or ramp. I figure this is outside the scope of the expected masterwork protection.

I expect the `clobber-masterwork-engravings` param to be rarely used, so I didn't bother wiring it up to the gui interface. If we get more esoteric params in the future, I might add a popup to the gui where they can all be configured.

As a by-product of this PR, dig blueprints that interact with engravings (e.g. toggle show engraving) will now go a lot faster on maps that have a lot of engravings. Not that I expect there to be many of those types of blueprints, but hey, a side benefit is still a benefit : )

In testing this PR, I discovered a bug that I fixed in passing: `quickfort` would designate tiles for channeling even if they were underneath buildings. The UI doesn't allow this, so `quickfort` shouldn't allow this either.