### PR TITLE
[quickfort] remove useless calls to checkBuildingsNow()

### DIFF
--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -795,8 +795,9 @@ function do_run(zlevel, grid, ctx)
             stats.build_designated.value = stats.build_designated.value + 1
         end
     end
-    buildingplan.scheduleCycle()
-    dfhack.job.checkBuildingsNow()
+    if not ctx.dry_run then
+        buildingplan.scheduleCycle()
+    end
 end
 
 function do_orders(zlevel, grid, ctx)

--- a/internal/quickfort/dig.lua
+++ b/internal/quickfort/dig.lua
@@ -722,7 +722,9 @@ function do_run(zlevel, grid, ctx)
     values = values_run
     ensure_ctx_stats(ctx, '')
     do_run_impl(zlevel, grid, ctx)
-    if not ctx.dry_run then dfhack.job.checkDesignationsNow() end
+    if not ctx.dry_run then
+        dfhack.job.checkDesignationsNow()
+    end
 end
 
 function do_orders()

--- a/internal/quickfort/zone.lua
+++ b/internal/quickfort/zone.lua
@@ -238,7 +238,6 @@ function do_run(zlevel, grid, ctx)
             stats.zone_designated.value = stats.zone_designated.value + 1
         end
     end
-    if not dry_run then dfhack.job.checkBuildingsNow() end
 end
 
 function do_orders()


### PR DESCRIPTION
There are no building jobs to check, so it's a noop in this situation. I originally added this call because I mistook "jobs belonging to buildings" for "jobs for building buildings"