### PR TITLE
Makes setfps also update fps_per_gfps

### DIFF
--- a/setfps.lua
+++ b/setfps.lua
@@ -25,3 +25,4 @@ if not capnum or capnum < 1 then
 end
 
 df.global.enabler.fps = capnum
+df.global.enabler.fps_per_gfps = df.global.enabler.fps / df.global.enabler.gfps


### PR DESCRIPTION
I realized that this doesn't update on its own while looking at timing stuff in-game. No idea if it's used anywhere, but it seems prudent to keep it accurate.