### PR TITLE
[quickfort] extended syntax for z-level changes in quickfort blueprints

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@ that repo.
 - `quickfort`: add ``quickfort.apply_blueprint()`` API function that can be called directly by other scripts
 - `quickfort`: by default, don't designate tiles for digging that have masterwork engravings on them. quality level to preserve is configurable with the new ``--preserve-engravings`` param
 - `quickfort`: implement single-tile track aliases so engraved tracks can be specified tile-by-tile just like constructed tracks
+- `quickfort`: allow blueprints to jump up or down multiple z-levels with a single command (e.g. ``#>5`` goes down 5 levels)
 
 # 0.47.05-r3
 

--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -311,11 +311,11 @@ local function process_level(reader, start_line_num, start_coord)
         for i, v in ipairs(row_tokens) do
             v = trim_token(v)
             if i == 1 then
-                local _, _, zchar, zcount = v:find('^#([<>])%s*(%d*)?$')
+                local _, _, zchar, zcount = v:find('^#([<>])%s*(%d*)')
                 if zchar then
-                    if not zcount then zcount = 1 end
+                    zcount = tonumber(zcount) or 1
                     local zdir = (zchar == '<') and 1 or -1
-                    return grid, y-start_coord.y, zcount * zdir
+                    return grid, y-start_coord.y, zcount*zdir
                 end
                 if parse_modeline(v, reader.filepath) then
                     return grid, y-start_coord.y

--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -311,15 +311,19 @@ local function process_level(reader, start_line_num, start_coord)
         for i, v in ipairs(row_tokens) do
             v = trim_token(v)
             if i == 1 then
-                if v == '#<' then return grid, y-start_coord.y, 1 end
-                if v == '#>' then return grid, y-start_coord.y, -1 end
+                local _, _, zchar, zcount = v:find('^#([<>])%s*(%d*)?$')
+                if zchar then
+                    if not zcount then zcount = 1 end
+                    local zdir = (zchar == '<') and 1 or -1
+                    return grid, y-start_coord.y, zcount * zdir
+                end
                 if parse_modeline(v, reader.filepath) then
                     return grid, y-start_coord.y
                 end
             end
             if v:match('^#$') then break end
             if not v:match('^[`~ ]*$') and not v:match('^%s*#') then
-                -- cell has actual content, not just comments or chalk line chars
+                -- cell has actual content, not just comments or chalkline chars
                 if not grid[y] then grid[y] = {} end
                 local x = start_coord.x + i - 1
                 local line_num = start_line_num + y - start_coord.y

--- a/test/quickfort/parse_unit.lua
+++ b/test/quickfort/parse_unit.lua
@@ -460,6 +460,14 @@ function test.process_level()
     expect.table_eq({{[20]={[10]={cell='A1', text='d'}}}, 1, -1},
                     {parse.process_level(reader, 1, start)})
 
+    reader:reset({{'d'},{'#<1'}})
+    expect.table_eq({{[20]={[10]={cell='A1', text='d'}}}, 1, 1},
+                    {parse.process_level(reader, 1, start)})
+
+    reader:reset({{'d'},{'#> 8'}})
+    expect.table_eq({{[20]={[10]={cell='A1', text='d'}}}, 1, -8},
+                    {parse.process_level(reader, 1, start)})
+
     reader:reset({{'d'},{'#dig'}})
     expect.table_eq({{[20]={[10]={cell='A1', text='d'}}}, 1},
                     {parse.process_level(reader, 1, start)})


### PR DESCRIPTION
Implement feature discussed in passing in DFHack/dfhack#1998

This will allow `#>` and `#<` to take a number indicating how many levels to move up or down. This is especially useful in meta blueprints that work with multi-level sub-blueprints and the meta blueprint has to adjust its own z-level counter to compensate for what the sub-blueprints do.