### PR TITLE
migrate to non-deprecated URL formats in git clone

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v1
     - name: Set up DFHack
       run: |
-        git clone git://github.com/dfhack/dfhack $HOME/dfhack --depth 1 --branch develop
+        git clone https://github.com/DFHack/dfhack.git $HOME/dfhack --depth 1 --branch develop
         git -C $HOME/dfhack submodule update --init --depth 1 --remote plugins/stonesense library/xml
         rmdir $HOME/dfhack/scripts
         ln -sv $(pwd) $HOME/dfhack/scripts
@@ -52,7 +52,7 @@ jobs:
       uses: actions/checkout@v1
     - name: Set up DFHack
       run: |
-        git clone git://github.com/dfhack/dfhack $HOME/dfhack --depth 1 --branch develop
+        git clone https://github.com/DFHack/dfhack.git $HOME/dfhack --depth 1 --branch develop
         rmdir $HOME/dfhack/scripts
         ln -sv $(pwd) $HOME/dfhack/scripts
     - name: Check whitespace


### PR DESCRIPTION
for build actions.  GitHub deprecated the git:// protocol, and our actions were failing with:
```
Run git clone git://github.com/dfhack/dfhack $HOME/dfhack --depth 1 --branch develop
Cloning into '/home/runner/dfhack'...
fatal: remote error: 
  The unauthenticated git protocol on port [9](https://github.com/DFHack/scripts/runs/5667904791?check_suite_focus=true#step:6:9)418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
Error: Process completed with exit code [12](https://github.com/DFHack/scripts/runs/5667904791?check_suite_focus=true#step:6:12)8.
```

e.g. https://github.com/DFHack/scripts/runs/5667904791?check_suite_focus=true