### PR TITLE
[quickfort] adjust direction affinity when transforming buildings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ that repo.
 
 ## Misc Improvements
 - `quickfort`: support transformations for blueprints that use expansion syntax
+- `quickfort`: adjust direction affinity when transforming buildings (e.g.  bridges that open to the north now open to the south when rotated 180 degrees)
 
 # 0.47.05-r4
 

--- a/internal/quickfort/command.lua
+++ b/internal/quickfort/command.lua
@@ -64,6 +64,12 @@ local function make_transform_fn(prev_transform_fn, modifiers, cursor)
     if modifiers.transform_fn_stack == 0 and modifiers.shift_fn_stack == 0 then
         return prev_transform_fn
     end
+    -- when no_shift is true, we transform around the origin instead of the
+    -- cursor. this is a convenient way to transform expansion syntax elements
+    -- so they are still valid after the cell itself is transformed around the
+    -- cursor. e.g. T(5x2) becomes T(-2,5) after a clockwise rotation.
+    -- no_shift is also useful for transforming unit vectors around the origin
+    -- so we can figure out where the cardinal directions got transformed to.
     local origin = xy2pos(0, 0)
     return function(pos, no_shift)
         for _,tfn in ipairs(modifiers.transform_fn_stack) do


### PR DESCRIPTION
for example, bridges that open to the north now open to the south when rotated 180 degrees. before this change, the bridge position would be transformed, but the bridge would continue to open in the original, untransformed direction.

full coverage functional tests are coming in a dfhack repo PR.