### PR TITLE
add options to autonick

### DIFF
--- a/autonick.lua
+++ b/autonick.lua
@@ -44,57 +44,58 @@ if #commands ~= 0 then options.help = true end
 
 if options.help == true then
     print(dfhack.script_help())
-else
-    result = options.force;
-    if options.force ~= true then
-        local utils = require("utils")
-        result = utils.prompt_yes_no("nickname unnicked dwarves? (use -f to disable this check)", true)
+    return
+end
+
+result = options.force;
+if options.force ~= true then
+    local utils = require("utils")
+    result = utils.prompt_yes_no("nickname unnicked dwarves? (use -f to disable this check)", true)
+end
+
+if result == true then
+    local seen = {}
+    --check current nicknames
+    for _,unit in ipairs(df.global.world.units.active) do
+        if dfhack.units.isCitizen(unit) and
+        unit.name.nickname ~= "" then
+            seen[unit.name.nickname] = true
+        end
     end
 
-    if result == true then
-        local seen = {}
-        --check current nicknames
-        for _,unit in ipairs(df.global.world.units.active) do
-            if dfhack.units.isCitizen(unit) and
-            unit.name.nickname ~= "" then
-                seen[unit.name.nickname] = true
-            end
+    local names = {}
+    -- grab list, put in array
+    local path = dfhack.getDFPath () .. "/dfhack-config/autonick.txt";
+    for line in io.lines(path) do
+        line = line:trim()
+        if (line ~= "")
+        and (not line:startswith('#'))
+        and (not seen[line]) then
+            table.insert(names, line)
+            seen[line] = true
         end
+    end
 
-        local names = {}
-        -- grab list, put in array
-        local path = dfhack.getDFPath () .. "/dfhack-config/autonick.txt";
-        for line in io.lines(path) do
-            line = line:trim()
-            if (line ~= "")
-            and (not line:startswith('#'))
-            and (not seen[line]) then
-                table.insert(names, line)
-                seen[line] = true
-            end
+    --assign names
+    count = 0
+    for _,unit in ipairs(df.global.world.units.active) do
+        if (#names == 0) then
+                if options.quiet ~= true then
+                    print("no free names left in autonick.txt.")
+                end
+            break
         end
+        --if there are any names left
+        if dfhack.units.isCitizen(unit) and
+        unit.name.nickname == "" then
+            newnameIndex = math.random (#names)
+            dfhack.units.setNickname(unit, names[newnameIndex])
+            table.remove(names, newnameIndex)
+            count = count + 1
+        end
+    end
 
-        --assign names
-        count = 0
-        for _,unit in ipairs(df.global.world.units.active) do
-            if (#names == 0) then
-                    if options.quiet ~= true then
-                        print("no free names left in autonick.txt.")
-                    end
-                break
-            end
-            --if there are any names left
-            if dfhack.units.isCitizen(unit) and
-            unit.name.nickname == "" then
-                newnameIndex = math.random (#names)
-                dfhack.units.setNickname(unit, names[newnameIndex])
-                table.remove(names, newnameIndex)
-                count = count + 1
-            end
-        end
-
-        if options.quiet ~= true then
-            print(("gave nicknames to %s dwarves."):format(count))
-        end
+    if options.quiet ~= true then
+        print(("gave nicknames to %s dwarves."):format(count))
     end
 end

--- a/autonick.lua
+++ b/autonick.lua
@@ -14,41 +14,87 @@ If there are fewer available nicknames than dwarves, the remaining
 dwarves will go un-nicknamed.
 
 You may wish to use this script with the "repeat" command, e.g:
-``repeat -name autonick -time 3 -timeUnits months -command [ autonick ]``
+``repeat -name autonick -time 3 -timeUnits months -command [ autonick -f ]``
 
+Usage:
+
+    autonick [<options>]
+
+Options:
+
+:``-f``, ``--force``:
+    skip confirmation. useful for scripting.
+:``-h``, ``--help``:
+    Show this text.
+:``-q``, ``--quiet``:
+    Do not report how many dwarves were given nicknames.
 ]====]
 
-local seen = {}
---check current nicknames
-for _,unit in ipairs(df.global.world.units.active) do
-    if dfhack.units.isCitizen(unit) and
-    unit.name.nickname ~= "" then
-        seen[unit.name.nickname] = true
+local options = {}
+
+local argparse = require('argparse')
+local commands = argparse.processArgsGetopt({...}, {
+    {'h', 'help', handler=function() options.help = true end},
+    {'f', 'force', handler=function() options.force = true end},
+    {'q', 'quiet', handler=function() options.quiet = true end},
+})
+
+-- autonick does not use commands, so if there are any, the script is being used wrong.
+if #commands ~= 0 then options.help = true end
+
+if options.help == true then
+    print(dfhack.script_help())
+else
+    result = options.force;
+    if options.force ~= true then
+        local utils = require("utils")
+        result = utils.prompt_yes_no("nickname unnicked dwarves? (use -f to disable this check)", true)
+    end
+
+    if result == true then
+        local seen = {}
+        --check current nicknames
+        for _,unit in ipairs(df.global.world.units.active) do
+            if dfhack.units.isCitizen(unit) and
+            unit.name.nickname ~= "" then
+                seen[unit.name.nickname] = true
+            end
+        end
+
+        local names = {}
+        -- grab list, put in array
+        local path = dfhack.getDFPath () .. "/dfhack-config/autonick.txt";
+        for line in io.lines(path) do
+            line = line:trim()
+            if (line ~= "")
+            and (not line:startswith('#'))
+            and (not seen[line]) then
+                table.insert(names, line)
+                seen[line] = true
+            end
+        end
+
+        --assign names
+        count = 0
+        for _,unit in ipairs(df.global.world.units.active) do
+            if (#names == 0) then
+                    if options.quiet ~= true then
+                        print("no free names left in autonick.txt.")
+                    end
+                break
+            end
+            --if there are any names left
+            if dfhack.units.isCitizen(unit) and
+            unit.name.nickname == "" then
+                newnameIndex = math.random (#names)
+                dfhack.units.setNickname(unit, names[newnameIndex])
+                table.remove(names, newnameIndex)
+                count = count + 1
+            end
+        end
+
+        if options.quiet ~= true then
+            print(("gave nicknames to %s dwarves."):format(count))
+        end
     end
 end
-
-local names = {}
--- grab list, put in array
-local path = dfhack.getDFPath () .. "/dfhack-config/autonick.txt";
-for line in io.lines(path) do
-    line = line:trim()
-    if (line ~= "")
-    and (not line:startswith('#'))
-    and (not seen[line]) then
-        table.insert(names, line)
-        seen[line] = true
-    end
-end
-
---assign names
-for _,unit in ipairs(df.global.world.units.active) do
-    if (#names == 0) then break end
-    --if there are any names left
-    if dfhack.units.isCitizen(unit) and
-    unit.name.nickname == "" then
-        newnameIndex = math.random (#names)
-        dfhack.units.setNickname(unit, names[newnameIndex])
-        table.remove(names, newnameIndex)
-    end
-end
-

--- a/autonick.lua
+++ b/autonick.lua
@@ -69,7 +69,7 @@ for line in io.lines(path) do
 end
 
 --assign names
-count = 0
+local count = 0
 for _,unit in ipairs(df.global.world.units.active) do
     if (#names == 0) then
             if options.quiet ~= true then

--- a/autonick.lua
+++ b/autonick.lua
@@ -14,16 +14,15 @@ If there are fewer available nicknames than dwarves, the remaining
 dwarves will go un-nicknamed.
 
 You may wish to use this script with the "repeat" command, e.g:
-``repeat -name autonick -time 3 -timeUnits months -command [ autonick -f ]``
+``repeat -name autonick -time 3 -timeUnits months -command [ autonick all ]``
 
 Usage:
 
-    autonick [<options>]
+    autonick all [<options>]
+    autonick help
 
 Options:
 
-:``-f``, ``--force``:
-    skip confirmation. useful for scripting.
 :``-h``, ``--help``:
     Show this text.
 :``-q``, ``--quiet``:
@@ -35,67 +34,59 @@ local options = {}
 local argparse = require('argparse')
 local commands = argparse.processArgsGetopt({...}, {
     {'h', 'help', handler=function() options.help = true end},
-    {'f', 'force', handler=function() options.force = true end},
     {'q', 'quiet', handler=function() options.quiet = true end},
 })
 
--- autonick does not use commands, so if there are any, the script is being used wrong.
-if #commands ~= 0 then options.help = true end
+if #commands ~= 1 or commands[1] ~= "all" then
+    options.help = true
+end
 
 if options.help == true then
     print(dfhack.script_help())
     return
 end
 
-result = options.force;
-if options.force ~= true then
-    local utils = require("utils")
-    result = utils.prompt_yes_no("nickname unnicked dwarves? (use -f to disable this check)", true)
+local seen = {}
+--check current nicknames
+for _,unit in ipairs(df.global.world.units.active) do
+    if dfhack.units.isCitizen(unit) and
+    unit.name.nickname ~= "" then
+        seen[unit.name.nickname] = true
+    end
 end
 
-if result == true then
-    local seen = {}
-    --check current nicknames
-    for _,unit in ipairs(df.global.world.units.active) do
-        if dfhack.units.isCitizen(unit) and
-        unit.name.nickname ~= "" then
-            seen[unit.name.nickname] = true
-        end
+local names = {}
+-- grab list, put in array
+local path = dfhack.getDFPath () .. "/dfhack-config/autonick.txt";
+for line in io.lines(path) do
+    line = line:trim()
+    if (line ~= "")
+    and (not line:startswith('#'))
+    and (not seen[line]) then
+        table.insert(names, line)
+        seen[line] = true
     end
+end
 
-    local names = {}
-    -- grab list, put in array
-    local path = dfhack.getDFPath () .. "/dfhack-config/autonick.txt";
-    for line in io.lines(path) do
-        line = line:trim()
-        if (line ~= "")
-        and (not line:startswith('#'))
-        and (not seen[line]) then
-            table.insert(names, line)
-            seen[line] = true
-        end
+--assign names
+count = 0
+for _,unit in ipairs(df.global.world.units.active) do
+    if (#names == 0) then
+            if options.quiet ~= true then
+                print("no free names left in autonick.txt.")
+            end
+        break
     end
+    --if there are any names left
+    if dfhack.units.isCitizen(unit) and
+    unit.name.nickname == "" then
+        newnameIndex = math.random (#names)
+        dfhack.units.setNickname(unit, names[newnameIndex])
+        table.remove(names, newnameIndex)
+        count = count + 1
+    end
+end
 
-    --assign names
-    count = 0
-    for _,unit in ipairs(df.global.world.units.active) do
-        if (#names == 0) then
-                if options.quiet ~= true then
-                    print("no free names left in autonick.txt.")
-                end
-            break
-        end
-        --if there are any names left
-        if dfhack.units.isCitizen(unit) and
-        unit.name.nickname == "" then
-            newnameIndex = math.random (#names)
-            dfhack.units.setNickname(unit, names[newnameIndex])
-            table.remove(names, newnameIndex)
-            count = count + 1
-        end
-    end
-
-    if options.quiet ~= true then
-        print(("gave nicknames to %s dwarves."):format(count))
-    end
+if options.quiet ~= true then
+    print(("gave nicknames to %s dwarves."):format(count))
 end

--- a/autonick.lua
+++ b/autonick.lua
@@ -73,7 +73,7 @@ local count = 0
 for _,unit in ipairs(df.global.world.units.active) do
     if (#names == 0) then
             if options.quiet ~= true then
-                print("no free names left in autonick.txt.")
+                print("no free names left in dfhack-config/autonick.txt")
             end
         break
     end

--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,8 @@ that repo.
 ## Misc Improvements
 - `quickfort`: support transformations for blueprints that use expansion syntax
 - `quickfort`: adjust direction affinity when transforming buildings (e.g.  bridges that open to the north now open to the south when rotated 180 degrees)
+- `autonick`: now requires `all` command
+- `autonick`: added `--quiet` and `--help` options; also displays help on incorrect use
 
 # 0.47.05-r4
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -26,8 +26,8 @@ that repo.
 ## Misc Improvements
 - `quickfort`: support transformations for blueprints that use expansion syntax
 - `quickfort`: adjust direction affinity when transforming buildings (e.g.  bridges that open to the north now open to the south when rotated 180 degrees)
-- `autonick`: now requires `all` command
-- `autonick`: added `--quiet` and `--help` options; also displays help on incorrect use
+- `autonick`: now requires ``all`` command
+- `autonick`: added ``--quiet`` and ``--help`` options; also displays help on incorrect use
 
 # 0.47.05-r4
 


### PR DESCRIPTION
three real changes, whoops.

- first, listens for -h and --help options. help is also displayed if commands are used, as autonick has none.
- second, ~~add a dialogue to confirm that the user actually wants to nickname, suppressable with -f / --force~~ require the use of the command `all` to proceed, eg `autonick all`. together with 1, this resolves https://github.com/DFHack/dfhack/issues/2050.
- third, report the number of dwarves given nicknames and if autonick.txt has ran out of names, suppressable with -q / --quiet.

something that might be nice (but that i haven't done yet) is to raise an error if the user is not in fort mode, since it doesn't really make sense to run it anywhere else. ~~another possible improvement would be to assume -f if no console exists, so existing configs don't break.~~