### PR TITLE
[quickfort] adjust cursor movements when blueprint is rotated

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@ that repo.
 ## Misc Improvements
 - `quickfort`: support transformations for blueprints that use expansion syntax
 - `quickfort`: adjust direction affinity when transforming buildings (e.g.  bridges that open to the north now open to the south when rotated 180 degrees)
+- `quickfort`: automatically adjust cursor movements on the map screen in ``#query`` and ``#config`` modes when the blueprint is transformed. e.g.  ``{Up}`` will be played back as ``{Right}`` when the blueprint is rotated clockwise and the direction key would move the map cursor
 - `quickfort`: new blueprint mode: ``#config``; for playing back key sequences that don't involve the map cursor (like configuring hotkeys, changing standing orders, or modifying military uniforms)
 - `autonick`: now requires ``all`` command
 - `autonick`: added ``--quiet`` and ``--help`` options; also displays help on incorrect use

--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -21,6 +21,7 @@ local buildingplan = require('plugins.buildingplan')
 local quickfort_common = reqscript('internal/quickfort/common')
 local quickfort_building = reqscript('internal/quickfort/building')
 local quickfort_orders = reqscript('internal/quickfort/orders')
+local quickfort_transform = reqscript('internal/quickfort/transform')
 
 local log = quickfort_common.log
 
@@ -172,30 +173,13 @@ end
 -- ************ the database ************ --
 --
 
--- y coords are inverted since the map y axis is inverted
-local unit_vectors = {
-    north={x=0, y=-1},
-    east={x=1, y=0},
-    south={x=0, y=1},
-    west={x=-1, y=0}
-}
-local unit_vectors_revmap = {
-    north='x=0, y=-1',
-    east='x=1, y=0',
-    south='x=0, y=1',
-    west='x=-1, y=0'
-}
-
-local function resolve_transformed_vector(ctx, vector, revmap)
-    local transformed_vector = ctx.transform_fn(vector, true)
-    local serialized = ('x=%d, y=%d')
-            :format(transformed_vector.x, transformed_vector.y)
-    return revmap[serialized]
-end
+local unit_vectors = quickfort_transform.unit_vectors
+local unit_vectors_revmap = quickfort_transform.unit_vectors_revmap
 
 local function make_transform_building_fn(vector, revmap, post_fn)
     return function(ctx)
-        local keys = resolve_transformed_vector(ctx, vector, revmap)
+        local keys = quickfort_transform.resolve_transformed_vector(
+                                                        ctx, vector, revmap)
         if post_fn then keys = post_fn(keys) end
         return keys
     end

--- a/internal/quickfort/transform.lua
+++ b/internal/quickfort/transform.lua
@@ -1,0 +1,67 @@
+-- logic for euclidean transformations of blueprints for the quickfort script
+--@ module = true
+
+if not dfhack_flags.module then
+    qerror('this script cannot be called directly')
+end
+
+-- y coords are inverted since the DF map y axis is inverted
+unit_vectors = {
+    north={x=0, y=-1},
+    east={x=1, y=0},
+    south={x=0, y=1},
+    west={x=-1, y=0}
+}
+
+unit_vectors_revmap = {
+    north='x=0, y=-1',
+    east='x=1, y=0',
+    south='x=0, y=1',
+    west='x=-1, y=0'
+}
+
+-- the revmap maps serialized vector strings to a string. for example:
+-- local bridge_revmap = {
+--     [unit_vectors_revmap.north]='gw',
+--     [unit_vectors_revmap.east]='gd',
+--     [unit_vectors_revmap.south]='gx',
+--     [unit_vectors_revmap.west]='ga'
+-- }
+function resolve_transformed_vector(ctx, vector, revmap)
+    local transformed_vector = ctx.transform_fn(vector, true)
+    local serialized = ('x=%d, y=%d')
+            :format(transformed_vector.x, transformed_vector.y)
+    return revmap[serialized]
+end
+
+local function make_transform_fn(tfn)
+    return function(pos, origin_pos)
+        -- shift pos to treat origin_pos as the origin
+        local pos = xy2pos(pos.x-origin_pos.x, pos.y-origin_pos.y)
+        -- apply transformation
+        pos = tfn(pos)
+        -- undo origin shift
+        return xy2pos(pos.x+origin_pos.x, pos.y+origin_pos.y)
+    end
+end
+
+-- the y axis is reversed in DF so the normal logic for cw and ccw is reversed.
+local function transform_cw(tpos) return xy2pos(-tpos.y, tpos.x) end
+local function transform_ccw(tpos) return xy2pos(tpos.y, -tpos.x) end
+local function transform_fliph(tpos) return xy2pos(-tpos.x, tpos.y) end
+local function transform_flipv(tpos) return xy2pos(tpos.x, -tpos.y) end
+
+function make_transform_fn_from_name(name)
+    if name == 'rotcw' or name == 'cw' then
+        return make_transform_fn(transform_cw)
+    elseif name == 'rotccw' or name == 'ccw' then
+        return make_transform_fn(transform_ccw)
+    elseif name == 'fliph' then
+        return make_transform_fn(transform_fliph)
+    elseif name == 'flipv' then
+        return make_transform_fn(transform_flipv)
+    else
+        qerror('invalid transformation name: '..name)
+    end
+end
+

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -237,6 +237,7 @@ local quickfort_place = reqscript('internal/quickfort/place')
 local quickfort_query = reqscript('internal/quickfort/query')
 local quickfort_reader = reqscript('internal/quickfort/reader')
 local quickfort_set = reqscript('internal/quickfort/set')
+local quickfort_transform = reqscript('internal/quickfort/transform')
 local quickfort_zone = reqscript('internal/quickfort/zone')
 
 -- keep this in sync with the full help text above


### PR DESCRIPTION
automatically adjust cursor movements on the map screen in `#query` and `#config` modes when the blueprint is transformed. e.g.  `{Up}` will be played back as `{Right}` when the blueprint is rotated clockwise and the direction key would move the map cursor

refactors the transformation code so it can be reused by query and config modes.