### PR TITLE
Myk blueprint phases

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ that repo.
 - `quickfort`: new blueprint mode: ``#config``; for playing back key sequences that don't involve the map cursor (like configuring hotkeys, changing standing orders, or modifying military uniforms)
 - `autonick`: now requires ``all`` command
 - `autonick`: added ``--quiet`` and ``--help`` options; also displays help on incorrect use
+- `gui/blueprint`: support new `blueprint` options and phases
 
 # 0.47.05-r4
 

--- a/gui/blueprint.lua
+++ b/gui/blueprint.lua
@@ -34,7 +34,7 @@ function ResizingPanel:postUpdateLayout()
     local h = 0
     for _,subview in ipairs(self.subviews) do
         if subview.visible then
-            h = h + subview.frame.h
+            h = math.max(h, subview.frame.t + subview.frame.h)
         end
     end
     self.frame.h = h
@@ -236,17 +236,41 @@ function PhasesPanel:init()
         -- from the subviews
         widgets.Panel{frame={t=3,h=1}},
         ToggleHotkeyLabel{frame={t=4}, key='CUSTOM_D', label='dig',
-                          option_idx=self:get_default('dig'), label_width=5},
-        ToggleHotkeyLabel{frame={t=5}, key='CUSTOM_B', label='build',
+                          option_idx=self:get_default('dig'), label_width=6},
+        ToggleHotkeyLabel{frame={t=4, l=15}, key='CUSTOM_SHIFT_D',
+                          label='track', option_idx=self:get_default('track')},
+        ToggleHotkeyLabel{frame={t=5}, key='CUSTOM_SHIFT_B', label='const',
+                          option_idx=self:get_default('construct'),
+                          label_width=6},
+        ToggleHotkeyLabel{frame={t=5, l=15}, key='CUSTOM_B', label='build',
                           option_idx=self:get_default('build')},
         ToggleHotkeyLabel{frame={t=6}, key='CUSTOM_P', label='place',
-                          option_idx=self:get_default('place')},
-        ToggleHotkeyLabel{frame={t=7}, key='CUSTOM_Q', label='query',
-                          option_idx=self:get_default('query')},
+                          option_idx=self:get_default('place'), label_width=6},
+        ToggleHotkeyLabel{frame={t=6, l=15}, key='CUSTOM_Z', label='zone',
+                          option_idx=self:get_default('zone'), label_width=5},
+        ToggleHotkeyLabel{frame={t=7}, key='CUSTOM_SHIFT_Q', label='config',
+                          option_idx=self:get_default('config')},
+        ToggleHotkeyLabel{frame={t=7, l=15}, key='CUSTOM_Q', label='rooms',
+                          option_idx=self:get_default('rooms')},
+        CycleHotkeyLabel{
+            frame={t=8},
+            key='CUSTOM_SHIFT_A',
+            label='toggle all',
+            options={'', ''},
+            on_change=self:callback('toggle_all'),
+        },
     }
 end
 function PhasesPanel:get_default(label)
     return (self.phases.auto_phase or self.phases[label]) and 1 or 2
+end
+function PhasesPanel:toggle_all()
+    local target_state = self.subviews[#self.subviews].option_idx
+    for _,subview in ipairs(self.subviews) do
+        if subview.options and not subview.view_id then
+            subview.option_idx = target_state
+        end
+    end
 end
 function PhasesPanel:preUpdateLayout()
     local is_custom = self.subviews.phases.option_idx > 1

--- a/test/gui/blueprint.lua
+++ b/test/gui/blueprint.lua
@@ -460,7 +460,7 @@ function test.phase_preset()
     expect.eq('Custom', phases_view:get_current_option_value())
 
     for _,sv in ipairs(view.subviews.phases_panel.subviews) do
-        if sv.label and sv.label ~= 'phases' then
+        if sv.label and sv.label ~= 'phases' and sv.label ~= 'toggle all' then
             expect.true_(sv.visible)
             -- only build should be on; everything else should be off
             expect.eq(sv.label == 'build' and 'On' or 'Off',


### PR DESCRIPTION
DFHack/dfhack#1842

GUI support for new features in DFHack/dfhack#2072 and UI unit tests.

We were also missing the toggle for the `zone` phase, which I had in an old branch but never committed. That is included here.

The list of phases is starting to get long, and it will get even longer soon, so the UI was reorganized so the phase toggles don't take up so much room.