### PR TITLE
[quickfort] make aliases module reentrant

### DIFF
--- a/internal/quickfort/aliases.lua
+++ b/internal/quickfort/aliases.lua
@@ -28,27 +28,21 @@ local special_aliases = {
     ['r+']={'r','+','Enter'},
 }
 
-local alias_stack = {}
-
-local function reset_aliases()
-    alias_stack = {}
-end
-
 -- pushes a collection of aliases on the stack. aliases are resolved with the
 -- definition nearest the top of the stack.
 -- note: this function overwrites the metatable of the passed-in aliases map
-local function push_aliases(aliases)
-    local prev = alias_stack
+local function push_aliases(alias_ctx, aliases)
+    local prev = alias_ctx.stack
     setmetatable(aliases, {prev=prev,
                            __index=function(_, key) return prev[key] end})
-    alias_stack = aliases
+    alias_ctx.stack = aliases
 end
 
-local function pop_aliases()
-    alias_stack = getmetatable(alias_stack).prev
+local function pop_aliases(alias_ctx)
+    alias_ctx.stack = getmetatable(alias_ctx.stack).prev
 end
 
-local function push_aliases_reader(reader)
+local function push_aliases_reader(alias_ctx, reader)
     local aliases, num_aliases = {}, 0
     local line = reader:get_next_row()
     while line do
@@ -57,37 +51,43 @@ local function push_aliases_reader(reader)
         end
         line = reader:get_next_row()
     end
-    push_aliases(aliases)
+    push_aliases(alias_ctx, aliases)
     return num_aliases
 end
 
-local function push_aliases_file(filepath)
-    local num_aliases = push_aliases_reader(
+local function push_aliases_file(alias_ctx, filepath)
+    local num_aliases = push_aliases_reader(alias_ctx,
             quickfort_reader.TextReader{filepath=filepath})
     log('read in %d aliases from "%s"', num_aliases, filepath)
 end
 
--- clears the alias stack and reloads all relevant aliases
-function reload_aliases(ctx)
-    reset_aliases()
-    push_aliases_file(common_aliases_filename)
-    push_aliases_file(user_aliases_filename)
+local function init_alias_ctx_base()
+    return {stack={}}
+end
+
+-- initializes a new alias_ctx with all aliases within scope
+function init_alias_ctx(ctx)
+    local alias_ctx = init_alias_ctx_base()
+    push_aliases_file(alias_ctx, common_aliases_filename)
+    push_aliases_file(alias_ctx, user_aliases_filename)
     if not ctx or not ctx.aliases then return end
     local num_file_aliases = 0
     for _ in pairs(ctx.aliases) do num_file_aliases = num_file_aliases + 1 end
     if num_file_aliases > 0 then
-        push_aliases(ctx.aliases)
+        push_aliases(alias_ctx, ctx.aliases)
         log('read in %d aliases from "%s"',
             num_file_aliases, ctx.blueprint_name)
     end
+    return alias_ctx
 end
 
-local function process_text(text, tokens, depth)
+local function process_text(alias_ctx, text, tokens, depth)
     depth = depth or 1
     if depth > 50 then
         qerror(string.format('alias maximum recursion depth exceeded (%d)',
                              depth))
     end
+    local alias_stack = alias_ctx.stack
     local i = 1
     while i <= #text do
         local next_char = text:sub(i, i)
@@ -99,9 +99,9 @@ local function process_text(text, tokens, depth)
             local etoken, params, reps, next_pos =
                 quickfort_parse.parse_extended_token(text, i)
             if not special_aliases[etoken] and alias_stack[etoken] then
-                push_aliases(params)
-                process_text(alias_stack[etoken], expansion, depth+1)
-                pop_aliases()
+                push_aliases(alias_ctx, params)
+                process_text(alias_ctx, alias_stack[etoken], expansion, depth+1)
+                pop_aliases(alias_ctx)
             else
                 expansion[1] = special_aliases[etoken] or etoken
             end
@@ -134,14 +134,14 @@ end
 -- doesn't get expanded to 'Numpad' 8 times, but rather 'Numpad 8' once. You can
 -- repeat Numpad keys like this: '{Numpad 8 5}'.
 -- returns an array of character key tokens
-function expand_aliases(text)
-    local tokens = {}
+function expand_aliases(alias_ctx, text)
+    local tokens, alias_stack = {}, alias_ctx.stack
     if special_aliases[text] then
         tokens = special_aliases[text]
     elseif alias_stack[text] then
-        process_text(alias_stack[text], tokens)
+        process_text(alias_ctx, alias_stack[text], tokens)
     else
-        process_text(text, tokens)
+        process_text(alias_ctx, text, tokens)
     end
     local expanded_text = table.concat(tokens, '')
     if text ~= expanded_text then
@@ -152,7 +152,7 @@ end
 
 if dfhack.internal.IN_TEST then
     unit_test_hooks = {
-        reset_aliases=reset_aliases,
+        init_alias_ctx_base=init_alias_ctx_base,
         push_aliases=push_aliases,
         pop_aliases=pop_aliases,
         push_aliases_reader=push_aliases_reader,

--- a/internal/quickfort/config.lua
+++ b/internal/quickfort/config.lua
@@ -72,7 +72,7 @@ function do_query_config_blueprint(zlevel, grid, ctx, sidebar_mode,
             {label='Keystrokes sent', value=0, always=true}
 
     quickfort_keycodes.init_keycodes()
-    quickfort_aliases.reload_aliases(ctx)
+    local alias_ctx = quickfort_aliases.init_alias_ctx(ctx)
 
     local dry_run = ctx.dry_run
     local saved_mode = df.global.ui.main.mode
@@ -98,7 +98,8 @@ function do_query_config_blueprint(zlevel, grid, ctx, sidebar_mode,
                 goto continue
             end
             local modifiers = {} -- tracks ctrl, shift, and alt modifiers
-            local tokens = quickfort_aliases.expand_aliases(tile_ctx.text)
+            local tokens = quickfort_aliases.expand_aliases(alias_ctx,
+                                                            tile_ctx.text)
             for _,token in ipairs(tokens) do
                 if handle_modifiers(token, modifiers) then goto continue2 end
                 token = transform_token(ctx, token, transformable_dirs)

--- a/test/quickfort/aliases_unit.lua
+++ b/test/quickfort/aliases_unit.lua
@@ -1,4 +1,4 @@
-local aliases = reqscript('internal/quickfort/aliases').unit_test_hooks
+local a = reqscript('internal/quickfort/aliases').unit_test_hooks
 local quickfort_reader = reqscript('internal/quickfort/reader')
 
 function test.module()
@@ -7,28 +7,22 @@ function test.module()
         function() dfhack.run_script('internal/quickfort/aliases') end)
 end
 
-function test.push_pop_reset()
-    dfhack.with_finalize(
-        function() aliases.reset_aliases() end,
-        function()
-            expect.table_eq({'a','a'}, aliases.expand_aliases('aa'))
-            aliases.push_aliases({aa='zz'})
-            expect.table_eq({'z','z'}, aliases.expand_aliases('aa'))
-            expect.table_eq({'b','b'}, aliases.expand_aliases('bb'))
-            aliases.push_aliases({aa='yy', bb='ww'})
-            expect.table_eq({'y','y'}, aliases.expand_aliases('aa'))
-            expect.table_eq({'w','w'}, aliases.expand_aliases('bb'))
-            expect.table_eq({'c','c'}, aliases.expand_aliases('cc'))
-            aliases.pop_aliases()
-            expect.table_eq({'z','z'}, aliases.expand_aliases('aa'))
-            expect.table_eq({'b','b'}, aliases.expand_aliases('bb'))
-            aliases.push_aliases({cc='xx'})
-            expect.table_eq({'x','x'}, aliases.expand_aliases('cc'))
-            aliases.reset_aliases()
-            expect.table_eq({'a','a'}, aliases.expand_aliases('aa'))
-            expect.table_eq({'b','b'}, aliases.expand_aliases('bb'))
-            expect.table_eq({'c','c'}, aliases.expand_aliases('cc'))
-        end)
+function test.push_pop()
+    local alias_ctx = a.init_alias_ctx_base()
+
+    expect.table_eq({'a','a'}, a.expand_aliases(alias_ctx, 'aa'))
+    a.push_aliases(alias_ctx, {aa='zz'})
+    expect.table_eq({'z','z'}, a.expand_aliases(alias_ctx, 'aa'))
+    expect.table_eq({'b','b'}, a.expand_aliases(alias_ctx, 'bb'))
+    a.push_aliases(alias_ctx, {aa='yy', bb='ww'})
+    expect.table_eq({'y','y'}, a.expand_aliases(alias_ctx, 'aa'))
+    expect.table_eq({'w','w'}, a.expand_aliases(alias_ctx, 'bb'))
+    expect.table_eq({'c','c'}, a.expand_aliases(alias_ctx, 'cc'))
+    a.pop_aliases(alias_ctx)
+    expect.table_eq({'z','z'}, a.expand_aliases(alias_ctx, 'aa'))
+    expect.table_eq({'b','b'}, a.expand_aliases(alias_ctx, 'bb'))
+    a.push_aliases(alias_ctx, {cc='xx'})
+    expect.table_eq({'x','x'}, a.expand_aliases(alias_ctx, 'cc'))
 end
 
 MockFile = defclass(MockFile, nil)
@@ -48,80 +42,74 @@ function test.push_aliases_reader()
     local mock_reader =
             quickfort_reader.TextReader{filepath='f', open_fn=mock_open}
     local mock_file = mock_reader.source
-    dfhack.with_finalize(
-        function() aliases.reset_aliases() end,
-        function()
-            expect.eq(0, aliases.push_aliases_reader(mock_reader))
+    local alias_ctx = a.init_alias_ctx_base()
 
-            mock_file:reset({'# comment', '#comment: withcolon', 'aa: zz'})
-            expect.eq(1, aliases.push_aliases_reader(mock_reader))
-            expect.table_eq({'z','z'}, aliases.expand_aliases('aa'))
-        end)
+    expect.eq(0, a.push_aliases_reader(alias_ctx, mock_reader))
+
+    mock_file:reset({'# comment', '#comment: withcolon', 'aa: zz'})
+    expect.eq(1, a.push_aliases_reader(alias_ctx, mock_reader))
+    expect.table_eq({'z','z'}, a.expand_aliases(alias_ctx, 'aa'))
 end
 
 function test.process_text()
-    dfhack.with_finalize(
-        function() aliases.reset_aliases() end,
-        function()
-            expect.error(function() aliases.process_text('text', {}, 51) end)
+    local alias_ctx = a.init_alias_ctx_base()
 
-            aliases.push_aliases({aa='{bb}',bb='{aa}'})
-            expect.error_match(
-                    'recursion',
-                    function() aliases.process_text('{aa}', {}) end)
+    expect.error(function() a.process_text(alias_ctx, 'text', {}, 51) end)
 
-            aliases.reset_aliases()
-            aliases.push_aliases({aa='{bb}', bb='x{cc}x', cc='o'})
+    a.push_aliases(alias_ctx, {aa='{bb}',bb='{aa}'})
+    expect.error_match(
+            'recursion',
+            function() a.process_text(alias_ctx, '{aa}', {}) end)
 
-            local tokens = {}
-            aliases.process_text('send!&', tokens)
-            expect.table_eq({'s','e','n','d','Ctrl','Enter'}, tokens)
+    alias_ctx = a.init_alias_ctx_base()
+    a.push_aliases(alias_ctx, {aa='{bb}', bb='x{cc}x', cc='o'})
 
-            tokens = {}
-            aliases.process_text('!n@', tokens)
-            expect.table_eq({'Ctrl','n','Shift','Enter'}, tokens)
+    local tokens = {}
+    a.process_text(alias_ctx, 'send!&', tokens)
+    expect.table_eq({'s','e','n','d','Ctrl','Enter'}, tokens)
 
-            tokens = {}
-            aliases.process_text('{Enter 3}{ExitMenu}', tokens)
-            expect.table_eq({'Enter','Enter','Enter','ESC'}, tokens)
+    tokens = {}
+    a.process_text(alias_ctx, '!n@', tokens)
+    expect.table_eq({'Ctrl','n','Shift','Enter'}, tokens)
 
-            tokens = {}
-            aliases.process_text('{q 3}{cc 2}{za 2}', tokens)
-            expect.table_eq({'q','q','q','o','o','za','za'}, tokens)
+    tokens = {}
+    a.process_text(alias_ctx, '{Enter 3}{ExitMenu}', tokens)
+    expect.table_eq({'Enter','Enter','Enter','ESC'}, tokens)
 
-            tokens = {}
-            aliases.process_text('i{aa 3}', tokens)
-            expect.table_eq({'i','x','o','x','x','o','x','x','o','x'}, tokens)
+    tokens = {}
+    a.process_text(alias_ctx, '{q 3}{cc 2}{za 2}', tokens)
+    expect.table_eq({'q','q','q','o','o','za','za'}, tokens)
 
-            tokens = {}
-            aliases.process_text('{aa bb=q 3}', tokens)
-            expect.table_eq({'q','q','q'}, tokens)
+    tokens = {}
+    a.process_text(alias_ctx, 'i{aa 3}', tokens)
+    expect.table_eq({'i','x','o','x','x','o','x','x','o','x'}, tokens)
 
-            tokens = {}
-            aliases.process_text('{aa cc=q 3}', tokens)
-            expect.table_eq({'x','q','x','x','q','x','x','q','x'}, tokens)
+    tokens = {}
+    a.process_text(alias_ctx, '{aa bb=q 3}', tokens)
+    expect.table_eq({'q','q','q'}, tokens)
 
-            tokens = {}
-            aliases.process_text('{aa bb=q}{aa cc=u}', tokens)
-            expect.table_eq({'q','x','u','x'}, tokens)
+    tokens = {}
+    a.process_text(alias_ctx, '{aa cc=q 3}', tokens)
+    expect.table_eq({'x','q','x','x','q','x','x','q','x'}, tokens)
 
-            tokens = {}
-            aliases.process_text('{aa cc={dd} dd=v}', tokens)
-            expect.table_eq({'x','v','x'}, tokens)
-        end)
+    tokens = {}
+    a.process_text(alias_ctx, '{aa bb=q}{aa cc=u}', tokens)
+    expect.table_eq({'q','x','u','x'}, tokens)
+
+    tokens = {}
+    a.process_text(alias_ctx, '{aa cc={dd} dd=v}', tokens)
+    expect.table_eq({'x','v','x'}, tokens)
 end
 
 function test.expand_aliases()
-    dfhack.with_finalize(
-        function() aliases.reset_aliases() end,
-        function()
-            expect.table_eq({'r','+','Enter'}, aliases.expand_aliases('r+'))
-            expect.table_eq({'r','+','Enter'}, aliases.expand_aliases('{r+}'))
+    local alias_ctx = a.init_alias_ctx_base()
 
-            aliases.push_aliases({aa='{bb}', bb='x{cc}x', cc='o'})
-            expect.table_eq({'o'}, aliases.expand_aliases('cc'))
-            expect.table_eq({'x','o','x'}, aliases.expand_aliases('aa'))
+    expect.table_eq({'r','+','Enter'}, a.expand_aliases(alias_ctx, 'r+'))
+    expect.table_eq({'r','+','Enter'}, a.expand_aliases(alias_ctx, '{r+}'))
 
-            expect.table_eq({'l','i','t'}, aliases.expand_aliases('lit'))
-       end)
+    a.push_aliases(alias_ctx, {aa='{bb}', bb='x{cc}x', cc='o'})
+    expect.table_eq({'o'}, a.expand_aliases(alias_ctx, 'cc'))
+    expect.table_eq({'x','o','x'}, a.expand_aliases(alias_ctx, 'aa'))
+
+    expect.table_eq({'l','i','t'}, a.expand_aliases(alias_ctx, 'lit'))
 end


### PR DESCRIPTION
before, the aliases module kept state for which aliases were on the stack. This PR moves state into a context table that is owned by the calling code.

The global state became an issue when I started considering simultaneous blueprint calculations and early cancellation of blueprint processing for asynchronous UI preview refreshes. The alias stack changes dynamically during processing according to which parameters are defined for sub-aliases (see [docs](https://docs.dfhack.org/en/stable/docs/guides/quickfort-alias-guide.html#sub-aliases)).

Note there is no changelog entry for this since there is no user-visible change in behavior.