### PR TITLE
[quickfort] migrate command.init_ctx to take named params

### DIFF
--- a/internal/quickfort/api.lua
+++ b/internal/quickfort/api.lua
@@ -7,6 +7,7 @@ end
 
 require('dfhack.buildings') -- loads additional functions into dfhack.buildings
 local utils = require('utils')
+local quickfort_command = reqscript('internal/quickfort/command')
 local quickfort_common = reqscript('internal/quickfort/common')
 local quickfort_building = reqscript('internal/quickfort/building')
 local quickfort_map = reqscript('internal/quickfort/map')
@@ -36,6 +37,21 @@ function normalize_data(data, pos)
     return shifted, min
 end
 
+-- wraps quickfort_command.init_ctx() and sets API-specific settings
+function init_api_ctx(params, cursor)
+    local p = copyall(params)
+
+    -- fix up API params so they can be used to initialize a quickfort ctx
+    if not p.command then p.command = 'run' end
+    p.blueprint_name = 'API'
+    p.cursor = cursor
+    if p.preserve_engravings then
+        p.preserve_engravings = quickfort_parse.parse_preserve_engravings(
+                params.preserve_engravings, true)
+    end
+
+    return quickfort_command.init_ctx(p)
+end
 function clean_stats(stats)
     for _,stat in pairs(stats) do
         -- remove internal markers

--- a/internal/quickfort/command.lua
+++ b/internal/quickfort/command.lua
@@ -28,16 +28,11 @@ local command_switch = {
 
 local default_transform_fn = function(pos) return pos end
 
-function init_ctx(command, blueprint_name, cursor, aliases, dry_run,
-                  preserve_engravings)
+-- returns map of values that start the same for all contexts
+local function make_ctx_base()
     return {
-        command=command,
-        blueprint_name=blueprint_name,
-        cursor=cursor,
-        aliases=aliases,
-        dry_run=dry_run,
-        preserve_engravings=preserve_engravings,
-        zmin=30000, zmax=0,
+        zmin=30000,
+        zmax=0,
         transform_fn=default_transform_fn,
         stats={out_of_bounds={label='Tiles outside map boundary', value=0},
                invalid_keys={label='Invalid key sequences', value=0}},
@@ -45,14 +40,47 @@ function init_ctx(command, blueprint_name, cursor, aliases, dry_run,
     }
 end
 
+local function make_ctx(command, blueprint_name, cursor, aliases, dry_run,
+                        preserve_engravings)
+    local ctx = make_ctx_base()
+    local params = {
+        command=command,
+        blueprint_name=blueprint_name,
+        cursor=cursor,
+        aliases=aliases,
+        dry_run=dry_run,
+        preserve_engravings=preserve_engravings,
+    }
+
+    return utils.assign(ctx, params)
+end
+
+-- see make_ctx() above for which params can be specified
+function init_ctx(params)
+    if not params.command or not command_switch[params.command] then
+        error(('invalid command: "%s"'):format(params.command))
+    end
+    if not params.blueprint_name or params.blueprint_name == '' then
+        error('must specify blueprint_name')
+    end
+    if not params.cursor then
+        error('must specify cursor')
+    end
+
+    return make_ctx(
+        params.command,
+        params.blueprint_name,
+        params.cursor,
+        params.aliases or {},
+        params.dry_run,
+        params.preserve_engravings or df.item_quality.Masterful)
+end
+
 function do_command_raw(mode, zlevel, grid, ctx)
     -- this error checking is done here again because this function can be
     -- called directly by the quickfort API
     if not mode or not mode_modules[mode] then
         error(string.format('invalid mode: "%s"', mode))
-    end
-    if not ctx.command or not command_switch[ctx.command] then
-        error(string.format('invalid command: "%s"', ctx.command))
     end
 
     ctx.cursor.z = zlevel
@@ -156,9 +184,14 @@ local function do_one_command(command, cursor, blueprint_name, section_name,
         end
     end
 
-    local aliases = quickfort_list.get_aliases(blueprint_name)
-    local ctx = init_ctx(command, blueprint_name, cursor, aliases, dry_run,
-                         preserve_engravings)
+    local ctx = init_ctx{
+        command=command,
+        blueprint_name=blueprint_name,
+        cursor=cursor,
+        aliases=quickfort_list.get_aliases(blueprint_name),
+        dry_run=dry_run,
+        preserve_engravings=preserve_engravings}
+
     do_command_section(ctx, section_name, modifiers)
     finish_command(ctx, section_name, quiet)
     if command == 'run' then
@@ -173,8 +206,8 @@ local function do_bp_name(commands, cursor, bp_name, sec_names, quiet, dry_run,
     for _,sec_name in ipairs(sec_names) do
         local mode = quickfort_list.get_blueprint_mode(bp_name, sec_name)
         for _,command in ipairs(commands) do
-            do_one_command(command, cursor, bp_name, sec_name, mode,
-                           quiet, dry_run, preserve_engravings, modifiers)
+            do_one_command(command, cursor, bp_name, sec_name, mode, quiet,
+                           dry_run, preserve_engravings, modifiers)
         end
     end
 end
@@ -185,8 +218,8 @@ local function do_list_num(commands, cursor, list_nums, quiet, dry_run,
         local bp_name, sec_name, mode =
                 quickfort_list.get_blueprint_by_number(list_num)
         for _,command in ipairs(commands) do
-            do_one_command(command, cursor, bp_name, sec_name, mode,
-                           quiet, dry_run, preserve_engravings, modifiers)
+            do_one_command(command, cursor, bp_name, sec_name, mode, quiet,
+                           dry_run, preserve_engravings, modifiers)
         end
     end
 end
@@ -241,10 +274,20 @@ function do_command(args)
             local ok, list_nums = pcall(argparse.numberList, blueprint_name)
             if not ok then
                 do_bp_name(args.commands, cursor, blueprint_name, section_names,
-                           quiet, dry_run, preserve_engravings, modifiers)
+                           quiet, dry_run, preserve_engravings,
+                           modifiers)
             else
                 do_list_num(args.commands, cursor, list_nums, quiet, dry_run,
                             preserve_engravings, modifiers)
             end
         end)
+end
+
+if dfhack.internal.IN_TEST then
+    unit_test_hooks = {
+        make_ctx_base=make_ctx_base,
+        init_ctx=init_ctx,
+        do_command_raw=do_command_raw,
+        do_command=do_command,
+    }
 end

--- a/internal/quickfort/command.lua
+++ b/internal/quickfort/command.lua
@@ -206,8 +206,8 @@ local function do_bp_name(commands, cursor, bp_name, sec_names, quiet, dry_run,
     for _,sec_name in ipairs(sec_names) do
         local mode = quickfort_list.get_blueprint_mode(bp_name, sec_name)
         for _,command in ipairs(commands) do
-            do_one_command(command, cursor, bp_name, sec_name, mode, quiet,
-                           dry_run, preserve_engravings, modifiers)
+            do_one_command(command, cursor, bp_name, sec_name, mode,
+                           quiet, dry_run, preserve_engravings, modifiers)
         end
     end
 end
@@ -218,8 +218,8 @@ local function do_list_num(commands, cursor, list_nums, quiet, dry_run,
         local bp_name, sec_name, mode =
                 quickfort_list.get_blueprint_by_number(list_num)
         for _,command in ipairs(commands) do
-            do_one_command(command, cursor, bp_name, sec_name, mode, quiet,
-                           dry_run, preserve_engravings, modifiers)
+            do_one_command(command, cursor, bp_name, sec_name, mode,
+                           quiet, dry_run, preserve_engravings, modifiers)
         end
     end
 end
@@ -274,8 +274,7 @@ function do_command(args)
             local ok, list_nums = pcall(argparse.numberList, blueprint_name)
             if not ok then
                 do_bp_name(args.commands, cursor, blueprint_name, section_names,
-                           quiet, dry_run, preserve_engravings,
-                           modifiers)
+                           quiet, dry_run, preserve_engravings, modifiers)
             else
                 do_list_num(args.commands, cursor, list_nums, quiet, dry_run,
                             preserve_engravings, modifiers)

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -357,10 +357,4 @@ local args = {...}
 local action = table.remove(args, 1) or 'help'
 args.commands = argparse.stringList(action)
 
-local action_fn = action_switch[args.commands[1]]
-
-if action_fn ~= print_short_help and not dfhack.isMapLoaded() then
-    qerror('quickfort needs a fortress map to be loaded.')
-end
-
-action_fn(args)
+action_switch[args.commands[1]](args)

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -190,7 +190,8 @@ statistics structure is a map of stat ids to ``{label=string, value=number}``.
 :``pos``: A coordinate that serves as the reference point for the coordinates in
     the data map. That is, the text at ``data[z][y][x]`` will be shifted to be
     applied to coordinate ``(pos.x + x, pos.y + y, pos.z + z)``. If not
-    specified, defaults to ``{x=0, y=0, z=0}``.
+    specified, defaults to ``{x=0, y=0, z=0}``, which means that the coordinates
+    in the ``data`` map are used directly.
 :``aliases``: a map of query blueprint aliases names to their expansions. If not
     specified, defaults to ``{}``.
 :``preserve_engravings``: Don't designate tiles for digging if they have an
@@ -323,11 +324,8 @@ end
 -- public API
 function apply_blueprint(params)
     local data, cursor = quickfort_api.normalize_data(params.data, params.pos)
-    local preserve_engravings = quickfort_parse.parse_preserve_engravings(
-                params.preserve_engravings or df.item_quality.Masterful, true)
-    local ctx = quickfort_command.init_ctx(params.command or 'run', 'API',
-                                cursor, params.aliases or {}, params.dry_run,
-                                preserve_engravings)
+    local ctx = quickfort_api.init_api_ctx(params, cursor)
+
     quickfort_common.verbose = not not params.verbose
     dfhack.with_finalize(
         function() quickfort_common.verbose = false end,
@@ -359,4 +357,10 @@ local args = {...}
 local action = table.remove(args, 1) or 'help'
 args.commands = argparse.stringList(action)
 
-action_switch[args.commands[1]](args)
+local action_fn = action_switch[args.commands[1]]
+
+if action_fn ~= print_short_help and not dfhack.isMapLoaded() then
+    qerror('quickfort needs a fortress map to be loaded.')
+end
+
+action_fn(args)

--- a/test/quickfort/quickfort_unit.lua
+++ b/test/quickfort/quickfort_unit.lua
@@ -1,6 +1,10 @@
 local q = reqscript('quickfort')
+local quickfort_api = reqscript('internal/quickfort/api')
 local quickfort_command = reqscript('internal/quickfort/command')
+local c = quickfort_command.unit_test_hooks
 local quickfort_common = reqscript('internal/quickfort/common')
+
+local utils = require('utils')
 
 local mock_do_command_raw
 local verbose_snapshot
@@ -20,8 +24,7 @@ config.wrapper = test_wrapper
 
 function test.apply_blueprint_minimal()
     local data = {[0]={[0]={[0]='d'}}}
-    local expected_ctx = quickfort_command.init_ctx('run', 'API',
-                            {x=0, y=0, z=0}, {}, nil, df.item_quality.Masterful)
+    local expected_ctx = quickfort_api.init_api_ctx({}, {x=0, y=0, z=0})
     q.apply_blueprint{mode='dig', data=data}
 
     expect.eq(1, mock_do_command_raw.call_count)
@@ -38,9 +41,12 @@ end
 function test.apply_blueprint_all_ctx_params()
     local data = {[2]={[20]={[8]='somekeys'}},
                   [3]={[9]={[20]='somealias'}}}
-    local expected_ctx = quickfort_command.init_ctx('undo', 'API',
-                                {x=10, y=10, z=1}, {somealias='ab{analias}'},
-                                true, df.item_quality.Masterful)
+    local expected_ctx = utils.assign(
+            c.make_ctx_base(),
+            {command='undo', blueprint_name='API', cursor={x=10, y=10, z=1},
+             aliases={somealias='ab{analias}'}, dry_run=true,
+             preserve_engravings=df.item_quality.Masterful})
+
     q.apply_blueprint{mode='query', data=data, command='undo',
                       pos={x=2, y=1, z=-1}, aliases={somealias='ab{analias}'},
                       dry_run=true, verbose=true}


### PR DESCRIPTION
the quickfort execution context is getting just too big and complicated. When I add blueprint shadows in the UI, it will gain more variables. Already I've run into maintenance issues when I add a new context element but forget to update all the calls to `init_ctx()`.

This change moves `init_ctx()` to take named params in a map instead of a long long parameter list.

No user-visible changes.