### PR TITLE
[quickfort] accept string data params for one-cell blueprints

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@ that repo.
 - `quickfort`: adjust direction affinity when transforming buildings (e.g.  bridges that open to the north now open to the south when rotated 180 degrees)
 - `quickfort`: automatically adjust cursor movements on the map screen in ``#query`` and ``#config`` modes when the blueprint is transformed. e.g.  ``{Up}`` will be played back as ``{Right}`` when the blueprint is rotated clockwise and the direction key would move the map cursor
 - `quickfort`: new blueprint mode: ``#config``; for playing back key sequences that don't involve the map cursor (like configuring hotkeys, changing standing orders, or modifying military uniforms)
+- `quickfort`: API function ``apply_blueprint`` can now take ``data`` parameters that are simple strings instead of coordinate maps. This allows easier application of blueprints that are just one cell.
 - `autonick`: now requires ``all`` command
 - `autonick`: added ``--quiet`` and ``--help`` options; also displays help on incorrect use
 - `gui/blueprint`: support new `blueprint` options and phases

--- a/internal/quickfort/api.lua
+++ b/internal/quickfort/api.lua
@@ -17,6 +17,10 @@ function normalize_data(data, pos)
     pos = pos or {}
     pos.x, pos.y, pos.z = pos.x or 0, pos.y or 0, pos.z or 0
 
+    if type(data) == 'string' then
+        data = {[0]={[0]={[0]=data}}}
+    end
+
     local shifted, min = {}, {x=30000, y=30000, z=30000}
     for z,grid in pairs(data) do
         local shiftedz, shiftedgrid = z+pos.z, {}

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -184,7 +184,8 @@ statistics structure is a map of stat ids to ``{label=string, value=number}``.
 :``mode``: (required) The name of the blueprint mode, e.g. 'dig', 'build', etc.
 :``data``: (required) A sparse map populated such that ``data[z][y][x]`` yields
     the blueprint text that should be applied to the tile at map coordinate
-    ``(x, y, z)``.
+    ``(x, y, z)``. You can also just pass a string and it will be interpreted
+    as the value of ``data[0][0][0]``.
 :``command``: The quickfort command to execute, e.g. 'run', 'orders', etc.
     Defaults to 'run'.
 :``pos``: A coordinate that serves as the reference point for the coordinates in

--- a/test/quickfort/api_unit.lua
+++ b/test/quickfort/api_unit.lua
@@ -12,11 +12,19 @@ function test.normalize_data()
     local expected_min = {x=0, y=0, z=0}
     expect.table_eq({expected_data, expected_min}, {a.normalize_data(data)})
 
+    -- test a string instead of a coordinate map
+    data = 'd(10x10)'
+    expected_data = {[0]={[0]={[0]={cell='0,0,0', text='d(10x10)'}}}}
+    expected_min = {x=0, y=0, z=0}
+    expect.table_eq({expected_data, expected_min}, {a.normalize_data(data)})
+
+    -- offset with a pos param
     expected_data = {[10]={[11]={[12]={cell='0,0,0', text='d(10x10)'}}}}
     expected_min = {x=12, y=11, z=10}
     expect.table_eq({expected_data, expected_min},
                     {a.normalize_data(data, {x=12, y=11, z=10})})
 
+    -- test negative starting coords
     data = {[-1]={[-2]={[-3]='d(10x10)'}}}
     expected_data = {[1]={[1]={[1]={cell='-3,-2,-1', text='d(10x10)'}}}}
     expected_min = {x=1, y=1, z=1}


### PR DESCRIPTION
before, the `data` param passed to the quickfort API had to contain a coordinate map. a common case for using the API, though, is to apply a one-cell blueprint. we can simplify the syntax for such usage by allowing data to be just a simple string, and interpreting it as `{[0]={[0]={[0]=string}}}`