### PR TITLE
Use new library code in gui scripts

### DIFF
--- a/devel/unit-path.lua
+++ b/devel/unit-path.lua
@@ -24,24 +24,18 @@ UnitPathUI.ATTRS {
     unit = default_nil_unit,
     has_path = false,
     has_goal = false,
+    sidebar_mode=df.ui_sidebar_mode.LookAround,
 }
 
 function UnitPathUI:init()
-    self.saved_mode = df.global.ui.main.mode
     if self.unit then
         self.has_path = #self.unit.path.path.x > 0
         self.has_goal = self.unit.path.dest.x >= 0
     end
 end
 
-function UnitPathUI:onShow()
-    -- with cursor, but without those ugly lines from native hauling mode
-    df.global.ui.main.mode = df.ui_sidebar_mode.Stockpiles
-end
-
 function UnitPathUI:onDestroy()
     self:moveCursorTo(copyall(self.unit.pos))
-    df.global.ui.main.mode = self.saved_mode
 end
 
 local function getTileType(cursor)
@@ -221,7 +215,7 @@ end
 local unit = dfhack.gui.getSelectedUnit(true)
 
 if not unit or not string.match(dfhack.gui.getCurFocus(), '^dwarfmode/ViewUnits/Some/') then
-    qerror("This script requires the main dwarfmode view in 'v' mode with a unit selected")
+    qerror("This script requires 'v' mode with a unit selected")
 end
 
 UnitPathUI{ unit = unit }:show()

--- a/gui/guide-path.lua
+++ b/gui/guide-path.lua
@@ -27,11 +27,11 @@ GuidePathUI.ATTRS {
     route = DEFAULT_NIL,
     stop = DEFAULT_NIL,
     order = DEFAULT_NIL,
+    -- with cursor, but without those ugly lines from native hauling mode
+    sidebar_mode=df.ui_sidebar_mode.LookAround,
 }
 
 function GuidePathUI:init()
-    self.saved_mode = df.global.ui.main.mode
-
     for i=0,#self.route.stops-1 do
         if self.route.stops[i] == self.stop then
             self.stop_idx = i
@@ -44,15 +44,6 @@ function GuidePathUI:init()
     end
 
     self.next_stop = self.route.stops[(self.stop_idx+1)%#self.route.stops]
-end
-
-function GuidePathUI:onShow()
-    -- with cursor, but without those ugly lines from native hauling mode
-    df.global.ui.main.mode = df.ui_sidebar_mode.Stockpiles
-end
-
-function GuidePathUI:onDestroy()
-    df.global.ui.main.mode = self.saved_mode
 end
 
 local function getTileType(cursor)
@@ -193,7 +184,7 @@ function GuidePathUI:onInput(keys)
 end
 
 if not string.match(dfhack.gui.getCurFocus(), '^dwarfmode/Hauling/DefineStop/Cond/Guide') then
-    qerror("This script requires the main dwarfmode view in 'h' mode over a Guide order")
+    qerror("This script requires 'h' mode over a Guide order")
 end
 
 local hauling = df.global.ui.hauling

--- a/gui/liquids.lua
+++ b/gui/liquids.lua
@@ -109,6 +109,10 @@ end
 
 LiquidsUI = defclass(LiquidsUI, guidm.MenuOverlay)
 
+LiquidsUI.ATTRS = {
+    sidebar_mode=df.ui_sidebar_mode.LookAround,
+}
+
 LiquidsUI.focus_path = 'liquids'
 
 function LiquidsUI:init()
@@ -325,9 +329,8 @@ function LiquidsUI:onInput(keys)
     end
 end
 
-if not string.match(dfhack.gui.getCurFocus(), '^dwarfmode/LookAround') then
-    qerror("This script requires the main dwarfmode view in 'k' mode")
+if not dfhack.isMapLoaded() then
+    qerror("This script requires a fortress map to be loaded")
 end
 
-local list = LiquidsUI()
-list:show()
+LiquidsUI{}:show()

--- a/gui/mechanisms.lua
+++ b/gui/mechanisms.lua
@@ -136,7 +136,7 @@ function MechanismList:onInput(keys)
 end
 
 if not string.match(dfhack.gui.getCurFocus(), '^dwarfmode/QueryBuilding/Some') then
-    qerror("This script requires the main dwarfmode view in 'q' mode")
+    qerror("This script requires a mechanism-linked building to be selected in 'q' mode")
 end
 
 local list = MechanismList{ building = df.global.world.selected_building }

--- a/gui/pathable.lua
+++ b/gui/pathable.lua
@@ -40,16 +40,9 @@ end
 
 Pathable = defclass(Pathable, guidm.MenuOverlay)
 
-function Pathable:onAboutToShow(parent)
-    if df.global.cursor.x == -30000 then
-        if df.global.ui.main.mode == df.ui_sidebar_mode.Default then
-            parent:feed_key(df.interface_key.D_LOOK)
-        else
-            qerror("Unsupported UI mode - needs a cursor")
-        end
-    end
-    Pathable.super.onAboutToShow(self, parent)
-end
+Pathable.ATTRS = {
+    sidebar_mode=df.ui_sidebar_mode.LookAround,
+}
 
 function Pathable:onRenderBody(p)
     local cursor = df.global.cursor
@@ -83,7 +76,6 @@ function Pathable:onInput(keys)
         dfhack.gui.refreshSidebar()
     elseif keys.LEAVESCREEN_ALL then
         self:dismiss()
-        df.global.ui.main.mode = df.ui_sidebar_mode.Default
     elseif keys.CUSTOM_L then
         opts.lock_cursor = not opts.lock_cursor
     elseif keys.CUSTOM_D then
@@ -98,6 +90,10 @@ function Pathable:onInput(keys)
             self:propagateMoveKeys(keys)
         end
     end
+end
+
+if not dfhack.isMapLoaded() then
+    qerror('This script requires a fortress map to be loaded')
 end
 
 Pathable():show()

--- a/gui/power-meter.lua
+++ b/gui/power-meter.lua
@@ -124,10 +124,9 @@ function PowerMeter:onInput(keys)
 end
 
 if dfhack.gui.getCurFocus() ~= 'dwarfmode/Build/Position/Trap'
-or bselector.building_subtype ~= df.trap_type.PressurePlate
+        or bselector.building_subtype ~= df.trap_type.PressurePlate
 then
-    qerror("This script requires the main dwarfmode view in build pressure plate mode")
+    qerror("This script requires the build pressure plate sidebar")
 end
 
-local list = PowerMeter()
-list:show()
+PowerMeter():show()

--- a/gui/room-list.lua
+++ b/gui/room-list.lua
@@ -242,5 +242,5 @@ elseif string.match(dfhack.gui.getCurFocus(), '^dwarfmode/QueryBuilding/Some') t
     local base = df.global.world.selected_building
     RoomList{ unit = base.owner }:show()
 else
-    qerror("This script requires the main dwarfmode view in 'q' mode")
+    qerror("This script requires 'q' mode")
 end

--- a/gui/siege-engine.lua
+++ b/gui/siege-engine.lua
@@ -512,9 +512,6 @@ function SiegeEngine:onInput(keys)
     elseif keys.LEAVESCREEN_ALL then
         self:dismiss()
         self.no_select_building = true
-        guidm.clearCursorPos()
-        df.global.ui.main.mode = df.ui_sidebar_mode.Default
-        df.global.world.selected_building = nil
     end
 end
 
@@ -531,5 +528,4 @@ if building:getBuildStage() < building:getMaxBuildStage() then
     qerror("This engine is not completely built yet")
 end
 
-local list = SiegeEngine{ building = building }
-list:show()
+SiegeEngine{building=building}:show()

--- a/gui/stamper.lua
+++ b/gui/stamper.lua
@@ -22,19 +22,11 @@ StamperUI.ATTRS {
     offsetDirection=0,
     cull=true,
     blink=false,
-    option="normal"
+    option="normal",
+    sidebar_mode=df.ui_sidebar_mode.LookAround,
 }
 
 local digSymbols={" ", "X", "_", 30, ">", "<"}
-
-function StamperUI:init()
-    self.saved_mode = df.global.ui.main.mode
-    df.global.ui.main.mode=df.ui_sidebar_mode.LookAround
-end
-
-function StamperUI:onDestroy()
-    df.global.ui.main.mode = self.saved_mode
-end
 
 local function paintMapTile(dc, vp, cursor, pos, ...)
     if not same_xyz(cursor, pos) then
@@ -378,9 +370,8 @@ function StamperUI:onInput(keys)
     end
 end
 
-if not (dfhack.gui.getCurFocus():match("^dwarfmode/Default") or dfhack.gui.getCurFocus():match("^dwarfmode/Designate") or dfhack.gui.getCurFocus():match("^dwarfmode/LookAround"))then
-    qerror("This screen requires the main dwarfmode view or the designation screen")
+if not dfhack.isMapLoaded() then
+    qerror('This script requires a fortress map to be loaded')
 end
 
-local list = StamperUI{state="mark", blink=false,cull=true}
-list:show()
+StamperUI{state="mark", blink=false,cull=true}:show()

--- a/gui/teleport.lua
+++ b/gui/teleport.lua
@@ -19,6 +19,10 @@ end
 
 TeleportSidebar = defclass(TeleportSidebar, guidm.MenuOverlay)
 
+TeleportSidebar.ATTRS = {
+    sidebar_mode=df.ui_sidebar_mode.ViewUnits,
+}
+
 function TeleportSidebar:init()
     self:addviews{
         widgets.Label{
@@ -43,28 +47,9 @@ function TeleportSidebar:init()
     self.in_pick_pos = false
 end
 
-function TeleportSidebar:onAboutToShow(parent)
-    if not df.viewscreen_dwarfmodest:is_instance(parent) then
-        qerror("This screen requires the main dwarfmode view")
-    end
-
-    self.old_mode = df.global.ui.main.mode
-    if df.global.ui.main.mode == df.ui_sidebar_mode.Default then
-        parent:feed_key(df.interface_key.D_VIEWUNIT)
-    end
-
-    local mode = df.global.ui.main.mode
-    if mode ~= df.ui_sidebar_mode.ViewUnits then
-        qerror(("Use '%s' to select a unit"):format(
-            dfhack.screen.getKeyDisplay(df.interface_key.D_VIEWUNIT)
-        ))
-    end
-end
-
 function TeleportSidebar:choose()
     if not self.in_pick_pos then
         self.in_pick_pos = true
-        df.global.ui.main.mode = df.ui_sidebar_mode.LookAround
     else
         dfhack.units.teleport(self.unit, xyz2pos(pos2xyz(df.global.cursor)))
         self:dismiss()
@@ -74,7 +59,6 @@ end
 function TeleportSidebar:back()
     if self.in_pick_pos then
         self.in_pick_pos = false
-        df.global.ui.main.mode = self.old_mode
     else
         self:dismiss()
     end
@@ -121,12 +105,12 @@ function TeleportSidebar:onInput(keys)
     TeleportSidebar.super.propagateMoveKeys(self, keys)
 end
 
-function TeleportSidebar:onDismiss()
-    df.global.ui.main.mode = self.old_mode
-end
-
 function TeleportSidebar:onGetSelectedUnit()
     return self.unit
+end
+
+if not dfhack.isMapLoaded() then
+    qerror('This script requires a fortress map to be loaded')
 end
 
 TeleportSidebar():show()


### PR DESCRIPTION
Use new sidebar-setting code in `guidm.MenuOverlay`, use the new `guidm.MenuOverlay:renderMapOverlay()` function where convenient, and standardize error message phrasing when the user is on the wrong viewscreen (for those scripts that care).

Updates to:
- devel/block-borders.lua
- devel/unit-path.lua
- gui/blueprint.lua
- gui/guide-path.lua
- gui/liquids.lua
- gui/mass-remove.lua
- gui/mechanisms.lua
- gui/pathable.lua
- gui/power-meter.lua
- gui/room-list.lua
- gui/siege-engine.lua
- gui/stamper.lua
- gui/teleport.lua