### PR TITLE
Configure `merge=union` for `changelog.txt` to reduce merge conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+changelog.txt merge=union


### PR DESCRIPTION
from the [gitattributes](http://kernel.org/pub/software/scm/git/docs/gitattributes.html) man page

> union
> Run 3-way file level merge for text files, but take lines from both versions, instead of leaving conflict markers. This tends to leave the added lines in the resulting file in random order and the user should verify the result. Do not use this if you do not understand the implications.