### PR TITLE
[deteriorate] hide items while waiting for garbage collection

### DIFF
--- a/deteriorate.lua
+++ b/deteriorate.lua
@@ -150,6 +150,7 @@ local function deteriorate(get_item_vectors_fn, is_valid_fn, increment_wear_fn)
             if is_valid_fn(item) and increment_wear_fn(item)
                     and not item.flags.garbage_collect then
                 item.flags.garbage_collect = true
+                item.flags.hidden = true
                 count = count + 1
             end
         end


### PR DESCRIPTION
although items aren't garbage collected for a few ticks, we can at least hide them from the player immediately so they can see that the script did something.