### PR TITLE
Adding Guild Names to output of list-agreements

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,7 +23,7 @@ that repo.
 
 ## Misc Improvements
 - `deteriorate`: new ``now`` command immediately deteriorates all items of the specified types.
-- `list-agreements`: now displays translated Guild Name 
+- `list-agreements`: now displays translated Guild Name
 
 ## Removed
 - `devel/unforbidall`: please use `unforbid` instead. You can silence the output with ``unforbid all --quiet``

--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ that repo.
 
 ## Misc Improvements
 - `deteriorate`: new ``now`` command immediately deteriorates all items of the specified types.
+- `list-agreements`: now displays translated Guild Name 
 
 ## Removed
 - `devel/unforbidall`: please use `unforbid` instead. You can silence the output with ``unforbid all --quiet``

--- a/list-agreements.lua
+++ b/list-agreements.lua
@@ -51,9 +51,9 @@ function get_guildhall_profession(agr)
 end
 
 function get_guildhall_name(agr)
-	guild_id = agr.parties[0].entity_ids[0]
-	guild_name = dfhack.TranslateName(df.global.world.entities.all[guild_id].name,true)
-	return guild_name
+    guild_id = agr.parties[0].entity_ids[0]
+    guild_name = dfhack.TranslateName(df.global.world.entities.all[guild_id].name,true)
+    return guild_name
 end
 
 function get_religion_name(agr)

--- a/list-agreements.lua
+++ b/list-agreements.lua
@@ -50,6 +50,12 @@ function get_guildhall_profession(agr)
     return profname:gsub("_", " ")
 end
 
+function get_guildhall_name(agr)
+	guild_id = agr.parties[0].entity_ids[0]
+	guild_name = dfhack.TranslateName(df.global.world.entities.all[guild_id].name,true)
+	return guild_name
+end
+
 function get_religion_name(agr)
     religion_id = agr.details[0].data.Location.deity_data.Religion
     religion_name = dfhack.TranslateName(df.global.world.entities.all[religion_id].name, true)
@@ -66,13 +72,14 @@ function is_denied(agr)
     return denied
 end
 
+--May need a/an handling for armorers (although DF doesn't do this itself)
 function generate_output_guild(agr)
     if is_satisfied(agr) == true then
-        print("Establish a "..get_location_name(agr).." for the "..get_guildhall_profession(agr).." guild, as agreed on "..get_petition_date(agr).." (satisfied)")
+        print("Establish a "..get_location_name(agr).." for \""..get_guildhall_name(agr)..",\" a "..get_guildhall_profession(agr).." guild, as agreed on "..get_petition_date(agr).." (satisfied)")
     elseif is_denied(agr) == true then
-        print("Establish a "..get_location_name(agr).." for the "..get_guildhall_profession(agr).." guild, as agreed on "..get_petition_date(agr).." (denied)")
+        print("Establish a "..get_location_name(agr).." for \""..get_guildhall_name(agr)..",\" a "..get_guildhall_profession(agr).." guild, as agreed on "..get_petition_date(agr).." (denied)")
     else
-        print("Establish a "..get_location_name(agr).." for the "..get_guildhall_profession(agr).." guild, as agreed on "..get_petition_date(agr))
+        print("Establish a "..get_location_name(agr).." for \""..get_guildhall_name(agr)..",\" a "..get_guildhall_profession(agr).." guild, as agreed on "..get_petition_date(agr))
     end
 end
 


### PR DESCRIPTION
To assist in selecting the correct guild in game, where many- or alike- guilds exist for certain professions/names.

Todo: The same for Deity Names (so as to properly detail Temple Decorations!) but i can't figure out how to parse historical_entity vectors which might yield the info (such as  `df.global.world.entities.all[religion_id].relations.deities[0]` )