### PR TITLE
[gui/confirm-opts] allow unpausing from the settings menu

### DIFF
--- a/gui/confirm-opts.lua
+++ b/gui/confirm-opts.lua
@@ -17,7 +17,7 @@ Opts.ATTRS = {
     frame_style = gui.GREY_LINE_FRAME,
     frame_title = 'Confirmation dialogs',
     frame_width = 32,
-    frame_height = 10,
+    frame_height = 12,
     frame_inset = 1,
     focus_path = 'confirm/opts',
 }
@@ -33,6 +33,12 @@ function Opts:init()
             on_submit = self:callback('toggle'),
             on_submit2 = self:callback('toggle_all'),
         },
+        widgets.HotkeyLabel{
+            frame = {b=2, l=0},
+            label='Resume paused confirmations',
+            key='CUSTOM_P',
+            on_activate=function() confirm.unpause() self:refresh() end,
+            enabled=function() return self.paused end},
         widgets.Label{
             view_id = 'controls',
             frame = {b = 0, l = 0},
@@ -62,7 +68,7 @@ function Opts:init()
     self:refresh()
 
     -- restrict the list to above the controls
-    self.subviews.list.frame.h = self.frame_height - self.subviews.controls.frame.h - 1
+    self.subviews.list.frame.h = self.frame_height - self.subviews.controls.frame.h - 2
     -- move the down arrow next to the bottom of the list
     self.subviews.scroll_down.frame.t = self.subviews.list.frame.h - 1
 
@@ -77,6 +83,7 @@ end
 
 function Opts:refresh()
     self.data = confirm.get_conf_data()
+    self.paused = confirm.get_paused()
     local choices = {}
     for i, c in ipairs(self.data) do
         table.insert(choices, {


### PR DESCRIPTION
DFHack/dfhack#2164
DFHack/dfhack#2155

New hotkey on the settings menu that allows unpausing if the confirm plugin is currently paused.
text is disabled (grayed out) if confirm is already unpaused.

I also made the dialog a little taller to accommodate the extra line.

When not paused:
![image](https://user-images.githubusercontent.com/977482/170794305-1db83d7b-4cf7-40a7-8d99-f371ce218ac8.png)

When paused:
![image](https://user-images.githubusercontent.com/977482/170794340-950874ab-339a-40d2-b56a-3318da633014.png)

No changelog entry since this is part of the confirm plugin change in the dfhack repo (where the changelog entry is)