### PR TITLE
[gui/quickfort] implement interactive controls for repetitions and transformations

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ that repo.
 - `deteriorate`: combines, replaces, and extends previous `deteriorateclothes`, `deterioratecorpses`, and `deterioratefood` scripts.
 - `gui/petitions`: shows list of fort's petitions
 - `gui/quantum`: interactive tool for creating quantum stockpiles
+- `gui/quickfort`: interactive previews and transformations of quickfort blueprints
 - `modtools/fire-rate`: allows modders to adjust the rate of fire for ranged attacks
 
 ## Fixes

--- a/gui/quickfort.lua
+++ b/gui/quickfort.lua
@@ -24,8 +24,21 @@ will be filtered as you type. You can search for directory names, file names,
 blueprint labels, modes, or comments. Note that, depending on the active list
 filters, the id numbers in the list may not be contiguous.
 
-Any settings you set in the UI, such as search terms for the blueprint list, are
-saved between invocations.
+To rotate or flip the blueprint around, enable transformations with :kbd:`t` and
+use :kbd:`Ctrl` with the arrow keys to add a transformation step:
+
+:kbd:`Ctrl`:kbd:`Left`:  Rotate counterclockwise (ccw)
+:kbd:`Ctrl`:kbd:`Right`: Rotate clockwise (cw)
+:kbd:`Ctrl`:kbd:`Up`:    Flip vertically (vflip)
+:kbd:`Ctrl`:kbd:`Down`:  Flip horizontally (hflip)
+
+If a shorter transformation sequence can be used to get the blueprint into the
+configuration you want, it will automatically be used. For example, if you
+rotate clockwise three times, gui/quickfort will shorten the sequence to a
+single counterclockwise rotation for you.
+
+Any settings you set in the UI, such as search terms for the blueprint list or
+transformation options, are saved for the next time you run the script.
 
 Examples:
 

--- a/gui/quickfort.lua
+++ b/gui/quickfort.lua
@@ -343,7 +343,10 @@ function QuickfortUI:init()
             widgets.ResizingPanel{view_id='transform_panel',
                     visible=transform,
                     subviews={
-                widgets.Label{text={{text='Ctrl+Arrow', pen=COLOR_LIGHTGREEN},
+                widgets.Label{text={{text='Ctrl+'..string.char(24)..
+                                          string.char(25)..string.char(26)..
+                                          string.char(27),
+                                     pen=COLOR_LIGHTGREEN},
                                     {text=':'}},
                     frame={l=2}},
                 widgets.WrappedLabel{

--- a/gui/quickfort.lua
+++ b/gui/quickfort.lua
@@ -5,8 +5,9 @@ gui/quickfort
 =============
 Graphical interface for the `quickfort` script. Once you load a blueprint, you
 will see a blinking "shadow" over the tiles that will be modified. You can use
-the cursor to reposition the blueprint. Once you are satisfied, hit :kbd:`ENTER`
-to apply the blueprint to the map.
+the cursor to reposition the blueprint or the hotkeys to rotate and repeat the
+blueprint. Once you are satisfied, hit :kbd:`ENTER` to apply the blueprint to
+the map.
 
 Usage::
 

--- a/gui/quickfort.lua
+++ b/gui/quickfort.lua
@@ -61,7 +61,7 @@ show_library = show_library == nil and true or show_library
 show_hidden = show_hidden or false
 filter_text = filter_text or ''
 selected_id = selected_id or 1
-repeat_dir = repeat_dir or 'No'
+repeat_dir = repeat_dir or false
 repetitions = repetitions or 1
 transform = transform or false
 transformations = transformations or {}
@@ -294,11 +294,13 @@ function QuickfortUI:init()
             widgets.CycleHotkeyLabel{key='CUSTOM_R',
                 view_id='repeat_cycle',
                 label='Repeat',
-                options={'No', 'Up', 'Down'},
+                options={{label='No', value=false},
+                         {label='Down z-levels', value='>'},
+                         {label='Up z-levels', value='<'}},
                 initial_option=repeat_dir,
                 on_change=self:callback('on_repeat_change')},
             widgets.ResizingPanel{view_id='repeat_times_panel',
-                    visible=repeat_dir ~= 'No',
+                    visible=repeat_dir,
                     subviews={
                 widgets.HotkeyLabel{key='SECONDSCROLL_UP',
                     frame={l=2}, key_sep='',
@@ -396,7 +398,7 @@ end
 
 function QuickfortUI:on_repeat_change(val)
     repeat_dir = val
-    self.subviews.repeat_times_panel.visible = val ~= 'No'
+    self.subviews.repeat_times_panel.visible = val
     self:updateLayout()
     self.dirty = true
 end
@@ -526,7 +528,7 @@ function QuickfortUI:refresh_preview()
     local section_name = self.section_name
     local modifiers = quickfort_parse.get_modifiers_defaults()
 
-    if repeat_dir ~= 'No' and repetitions > 1 then
+    if repeat_dir and repetitions > 1 then
         local repeat_str = repeat_dir .. tostring(repetitions)
         quickfort_parse.parse_repeat_params(repeat_str, modifiers)
     end

--- a/gui/quickfort.lua
+++ b/gui/quickfort.lua
@@ -314,7 +314,7 @@ function QuickfortUI:init()
                     on_activate=self:callback('on_adjust_repetitions', 10)},
                 widgets.EditField{key='CUSTOM_SHIFT_R',
                     view_id='repeat_times',
-                    frame={l=6, h=1},
+                    frame={l=7, h=1},
                     label_text='x ',
                     text=tostring(repetitions),
                     on_char=function(ch) return ch:match('%d') end,

--- a/internal/quickfort/command.lua
+++ b/internal/quickfort/command.lua
@@ -76,7 +76,8 @@ function init_ctx(params)
         params.aliases or {},
         params.quiet,
         params.dry_run,
-        params.preview and {tiles={}, bounds={}, invalid_tiles=0} or nil,
+        params.preview and
+                {tiles={}, bounds={}, invalid_tiles=0, total_tiles=0} or nil,
         params.preserve_engravings or df.item_quality.Masterful)
 end
 
@@ -93,7 +94,8 @@ function do_command_raw(mode, zlevel, grid, ctx)
 end
 
 local function make_transform_fn(prev_transform_fn, modifiers, cursor)
-    if modifiers.transform_fn_stack == 0 and modifiers.shift_fn_stack == 0 then
+    if #modifiers.transform_fn_stack == 0 and
+            #modifiers.shift_fn_stack == 0 then
         return prev_transform_fn
     end
     -- when no_shift is true, we transform around the origin instead of the

--- a/internal/quickfort/preview.lua
+++ b/internal/quickfort/preview.lua
@@ -12,6 +12,9 @@ function set_preview_tile(ctx, pos, is_valid_tile, override)
     local preview = ctx.preview
     if not preview then return false end
     local preview_row = ensure_key(ensure_key(ctx.preview.tiles, pos.z), pos.y)
+    if preview_row[pos.x] == nil then
+        preview.total_tiles = preview.total_tiles + 1
+    end
     if not override and preview_row[pos.x] ~= nil then
         return false
     end

--- a/internal/quickfort/transform.lua
+++ b/internal/quickfort/transform.lua
@@ -20,6 +20,12 @@ unit_vectors_revmap = {
     west='x=-1, y=0'
 }
 
+function resolve_vector(transformed_vector, revmap)
+    local serialized = ('x=%d, y=%d')
+            :format(transformed_vector.x, transformed_vector.y)
+    return revmap[serialized]
+end
+
 -- the revmap maps serialized vector strings to a string. for example:
 -- local bridge_revmap = {
 --     [unit_vectors_revmap.north]='gw',
@@ -28,10 +34,7 @@ unit_vectors_revmap = {
 --     [unit_vectors_revmap.west]='ga'
 -- }
 function resolve_transformed_vector(ctx, vector, revmap)
-    local transformed_vector = ctx.transform_fn(vector, true)
-    local serialized = ('x=%d, y=%d')
-            :format(transformed_vector.x, transformed_vector.y)
-    return revmap[serialized]
+    return resolve_vector(ctx.transform_fn(vector, true), revmap)
 end
 
 local function make_transform_fn(tfn)


### PR DESCRIPTION
Fixes DFHack/dfhack#2018

Depends on DFHack/dfhack#2147

UI for controlling repetitions and transformations in quickfort blueprints.

There is some UI behavior that is unique to this script that could use some feedback about whether it works. The repetitions counter can be modified by multiple hotkeys or edited directly. Is that obvious from the presentation?

Separate hotkey labels for each transformation type crowded the UI a little too much, so I collapsed them into just a generic "Ctrl+Arrow" label. Does that work?

The transformations get "auto-reduced" so the transformation list doesn't get too long. Longer transformation sequences will get automatically replaced with shorter equivalent sequences. Is that confusing?

Finally, the repetition and transformation settings get saved between script invocations. Should it be? The thinking here is that if you are applying a sequence of blueprints, they are likely to all need to be transformed the same way.

Screenshot:
![image](https://user-images.githubusercontent.com/977482/170895808-a2e0d0e4-cfc6-40bf-81ba-8c455a30da95.png)