### PR TITLE
[build-now] cycle buildingplan before scanning buildings

### DIFF
--- a/build-now.lua
+++ b/build-now.lua
@@ -40,6 +40,7 @@ Options:
 ]====]
 
 local argparse = require('argparse')
+local buildingplan = require('plugins.buildingplan')
 local dig_now = require('plugins.dig-now')
 local gui = require('gui')
 local utils = require('utils')
@@ -360,7 +361,8 @@ local function pos_cmp(a, b)
 end
 
 local function get_original_tiletype(pos)
-    -- TODO
+    -- TODO: this is not always exactly the existing tile type. for example,
+    -- tracks are ignored
     return dfhack.maps.getTileType(pos)
 end
 
@@ -518,6 +520,10 @@ end
 -- main script
 local opts = parse_commandline({...})
 if opts.help then print(dfhack.script_help()) return end
+
+-- ensure buildingplan is up to date so we don't skip buildings just because
+-- buildingplan hasn't scanned them yet
+buildingplan.doCycle()
 
 local num_jobs = 0
 for _,job in ipairs(get_jobs(opts)) do

--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ that repo.
 - `build-now`: walls built above other walls can now be deconstructed as normal
 
 ## Misc Improvements
+- `build-now`: buildings that were just designated with `buildingplan` are now handled properly instead of being skipped (as long as there are items available to build the buildings with)
 - `deteriorate`: new ``now`` command immediately deteriorates all items of the specified types.
 - `list-agreements`: now displays translated Guild Names, worshiped Deity, age of petition, and "man" to race-specific professions (e.g. "Craftsman" -> "Craftsdwarf")
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ that repo.
 - `modtools/fire-rate`: allows modders to adjust the rate of fire for ranged attacks
 
 ## Fixes
+- `build-now`: walls built above other walls can now be deconstructed as normal
 
 ## Misc Improvements
 - `deteriorate`: new ``now`` command immediately deteriorates all items of the specified types.


### PR DESCRIPTION
Fixes DFHack/dfhack#2180

This allows `build-now` to complete buildings that were just designated with `buildingplan`