### PR TITLE
remove `has_manager` requirement from workorder.lua

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ that repo.
 - `build-now`: buildings that were just designated with `buildingplan` are now handled properly instead of being skipped (as long as there are items available to build the buildings with)
 - `deteriorate`: new ``now`` command immediately deteriorates all items of the specified types.
 - `list-agreements`: now displays translated Guild Names, worshiped Deity, age of petition, and "man" to race-specific professions (e.g. "Craftsman" -> "Craftsdwarf")
+- `workorder`: doesn't check for an assigned manager anymore.
 
 ## Removed
 - `devel/unforbidall`: please use `unforbid` instead. You can silence the output with ``unforbid all --quiet``

--- a/workorder.lua
+++ b/workorder.lua
@@ -140,14 +140,6 @@ end
 
 -- [[ from stockflow.lua:
 
--- is a manager assigned in the fortress?
-local function has_manager()
-    return #df.historical_entity
-        .find(df.global.ui.group_id)
-        .assignments_by_type
-        .MANAGE_PRODUCTION > 0
-end
-
 -- Compare the job specification of two orders.
 local function orders_match(a, b)
     local fields = {
@@ -599,11 +591,6 @@ default_action = function (...)
         for k,v in pairs({...}) do
             print(k,v)
         end
-    end
-
-    if not has_manager() then
-        printerr "You should assign a manager first."
-        return
     end
 
     local v, n = ...


### PR DESCRIPTION
The game actually allows creating work orders without a manager, the text "A manager is required to coordinate work orders" is meant as a warning. It only makes sense to allow it in this script too.