### PR TITLE
Add warn-stealers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ that repo.
 
 ## New Scripts
 
+- `warn-stealers`: warn when creatures that may steal your food, drinks, or items enter the map
 - `assign-minecarts`: assign minecarts to hauling routes that don't have one
 - `deteriorate`: combines, replaces, and extends previous `deteriorateclothes`, `deterioratecorpses`, and `deterioratefood` scripts.
 - `gui/petitions`: shows list of fort's petitions

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,7 +16,6 @@ that repo.
 ## New Scripts
 
 - `warn-stealers`: warn when creatures that may steal your food, drinks, or items become visible
-- `assign-minecarts`: assign minecarts to hauling routes that don't have one
 ## Fixes
 
 ## Misc Improvements

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ that repo.
 ## New Scripts
 
 - `warn-stealers`: warn when creatures that may steal your food, drinks, or items become visible
+
 ## Fixes
 
 ## Misc Improvements

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,7 +15,7 @@ that repo.
 
 ## New Scripts
 
-- `warn-stealers`: warn when creatures that may steal your food, drinks, or items enter the map
+- `warn-stealers`: warn when creatures that may steal your food, drinks, or items become visible
 - `assign-minecarts`: assign minecarts to hauling routes that don't have one
 - `deteriorate`: combines, replaces, and extends previous `deteriorateclothes`, `deterioratecorpses`, and `deterioratefood` scripts.
 - `gui/petitions`: shows list of fort's petitions

--- a/warn-stealers.lua
+++ b/warn-stealers.lua
@@ -14,13 +14,13 @@ local eventfulKey = "warn-stealers"
 local numTicksBetweenChecks = 100
 
 function gamemodeCheck()
-    if df.global.gamemode ~= df.game_mode.DWARF then
-        cache = nil
-        print("warn-stealers must be run in fort mode")
-        disable()
-        return false
+    if df.global.gamemode == df.game_mode.DWARF then
+        return true
     end
-    return true
+    cache = nil
+    print("warn-stealers must be run in fort mode")
+    disable()
+    return false
 end
 
 cache = cache or {}

--- a/warn-stealers.lua
+++ b/warn-stealers.lua
@@ -4,7 +4,9 @@
 warn-stealers
 =============
 Will make a zoomable announcement whenever a creature that can eat food, guzzle drinks, or steal items enters the map and moves into a revealed location.
-Takes ``start`` or ``stop`` as parameters.
+Usage::
+
+    warn-stealers [start|stop]
 ]====]
 
 local eventful = require("plugins.eventful")

--- a/warn-stealers.lua
+++ b/warn-stealers.lua
@@ -1,4 +1,5 @@
 -- Script to warn when creatures that may steal food become visible
+--@ enable = true
 --[====[
 warn-stealers
 =============
@@ -16,14 +17,11 @@ local numTicksBetweenChecks = 100
 function gamemodeCheck()
     if df.global.gamemode ~= df.game_mode.DWARF then
         cache = nil
-        stop()
+        print("warn-stealers must be run in fort mode")
+        disable()
         return false
     end
     return true
-end
-
-if not gamemodeCheck() then
-    return
 end
 
 cache = {}
@@ -79,7 +77,7 @@ function help()
     print(dfhack.script_help())
 end
 
-function start()
+function enable()
     if not gamemodeCheck() then
         return
     end
@@ -93,14 +91,17 @@ function start()
     print("warn-stealers running")
 end
 
-function stop()
+function disable()
     eventful.onUnitNewActive[eventfulKey] = nil
     repeatUtil.cancel(eventfulKey)
     print("warn-stealers stopped")
 end
 
-local action_switch = {start = start, stop = stop}
+local action_switch = {enable = enable, disable = disable}
 setmetatable(action_switch, {__index = function() return help end})
 
-local args = {...}
+args = {...}
+if dfhack_flags and dfhack_flags.enable then
+    args = {dfhack_flags.enable_state and "enable" or "disable"}
+end
 action_switch[args[1] or "help"]()

--- a/warn-stealers.lua
+++ b/warn-stealers.lua
@@ -24,7 +24,7 @@ function gamemodeCheck()
     return true
 end
 
-cache = {}
+cache = cache or {}
 
 local races = df.global.world.raws.creatures.all
 

--- a/warn-stealers.lua
+++ b/warn-stealers.lua
@@ -2,38 +2,75 @@
 --[====[
 warn-stealers
 ============
-Will make a zoomable announcement whenever a creature that can eat food, guzzle drinks, or steal items enters the map in a revealed location.
-Takes ``start`` and ``stop`` as parameters.
+Will make a zoomable announcement whenever a creature that can eat food, guzzle drinks, or steal items enters the map and moves into a revealed location.
+Takes ``start`` or ``stop`` as parameters.
 ]====]
 
+local persistTable = require("persist-table")
 local eventful = require("plugins.eventful")
+local repeatUtil = require("repeat-util")
 local eventfulKey = "warn-stealers"
 
+if df.global.gamemode ~= df.game_mode.DWARF then
+    if df.global.gamemode ~= df.game_mode.NONE then
+        -- errors when gamemode is NONE
+        persistTable.GlobalTable.warnStealersCache = nil
+    end
+    return
+end
+
+if not persistTable.GlobalTable.warnStealersCache then
+    persistTable.GlobalTable.warnStealersCache = {}
+end
+local cache = persistTable.GlobalTable.warnStealersCache
+
 local function isUnitHidden(unit)
-    return dfhack.maps.getTileBlock(unit.pos).designation[unit.pos.x%16][unit.pos.y%16].hidden
+    local block = dfhack.maps.getTileBlock(unit.pos)
+    if not block then
+        return false
+    end
+    return block.designation[unit.pos.x%16][unit.pos.y%16].hidden
 end
 
 local races = df.global.world.raws.creatures.all
-local function checkStealer(unitId)
+
+local function addToCacheIfStealer(unitId)
     local unit = df.unit.find(unitId)
-    if isUnitHidden(unit) then
-        return
+    local casteFlags = races[unit.race].caste[unit.caste].flags
+    if casteFlags.CURIOUS_BEAST_EATER or casteFlags.CURIOUS_BEAST_GUZZLER or casteFlags.CURIOUS_BEAST_ITEM then
+        cache[tostring(unitId)] = true
     end
+end
+
+local function announceAndRemoveFromCache(unit)
     local caste = races[unit.race].caste[unit.caste]
     local casteFlags = caste.flags
-    if casteFlags.CURIOUS_BEAST_EATER or casteFlags.CURIOUS_BEAST_GUZZLER or casteFlags.CURIOUS_BEAST_ITEM then
-        local str = ""
-        if casteFlags.CURIOUS_BEAST_EATER then
-            str = str .. "eat food + "
+    local str = ""
+    if casteFlags.CURIOUS_BEAST_EATER then
+        str = str .. "eat food + "
+    end
+    if casteFlags.CURIOUS_BEAST_GUZZLER then
+        str = str .. "guzzle drinks + "
+    end
+    if casteFlags.CURIOUS_BEAST_ITEM then
+        str = str .. "steal items + "
+    end
+    str = str:sub(1, -4)
+    dfhack.gui.showZoomAnnouncement(-1, unit.pos, "A " .. caste.caste_name[0] .. " has appeared, it may " .. str .. ".", COLOR_RED, true)
+    cache[tostring(unit.id)] = nil
+end
+
+local function onTick()
+    for unitIdStr in pairs(cache) do
+        local unitId = tonumber(unitIdStr)
+        if unitId then -- sometimes perisst-table special fields
+            local unit = df.unit.find(unitId)
+            if not unit or unit.flags1.inactive then
+                cache[unitId] = nil
+            elseif not isUnitHidden(unit) then
+                announceAndRemoveFromCache(unit)
+            end
         end
-        if casteFlags.CURIOUS_BEAST_GUZZLER then
-            str = str .. "guzzle drinks + "
-        end
-        if casteFlags.CURIOUS_BEAST_ITEM then
-            str = str .. "steal items + "
-        end
-        str = str:sub(1, -4)
-        dfhack.gui.showZoomAnnouncement(-1, unit.pos, "A " .. caste.caste_name[0] .. " has appeared, it may " .. str .. ".", COLOR_RED, true)
     end
 end
 
@@ -41,15 +78,21 @@ local function help()
     print("syntax: warn-stealers [start|stop]")
 end
 
-local function stop()
-    eventful.onUnitNewActive[eventfulKey] = nil
-    print("warn-stealers stopped")
-end
-
 local function start()
     eventful.enableEvent(eventful.eventType.NEW_UNIT_ACTIVE, 1)
-    eventful.onUnitNewActive[eventfulKey] = checkStealer
+    eventful.onUnitNewActive[eventfulKey] = addToCacheIfStealer
+    repeatUtil.scheduleEvery(eventfulKey, 1, "ticks", onTick)
+    -- in case any units were missed
+    for _, unit in ipairs(df.global.world.units.active) do
+        addToCacheIfStealer(unit.id)
+    end
     print("warn-stealers running")
+end
+
+local function stop()
+    eventful.onUnitNewActive[eventfulKey] = nil
+    repeatUtil.cancel(eventfulKey)
+    print("warn-stealers stopped")
 end
 
 local action_switch = {start = start, stop = stop}

--- a/warn-stealers.lua
+++ b/warn-stealers.lua
@@ -50,17 +50,17 @@ end
 local function announce(unit)
     local caste = races[unit.race].caste[unit.caste]
     local casteFlags = caste.flags
-    local str = ""
+    local desires = {}
     if casteFlags.CURIOUS_BEAST_EATER then
-        str = str .. "eat food + "
+        table.insert(desires, "eat food")
     end
     if casteFlags.CURIOUS_BEAST_GUZZLER then
-        str = str .. "guzzle drinks + "
+        table.insert(desires, "guzzle drinks")
     end
     if casteFlags.CURIOUS_BEAST_ITEM then
-        str = str .. "steal items + "
+        table.insert(desires, "steal items")
     end
-    str = str:sub(1, -4)
+    local str = table.concat(str, " + ")
     dfhack.gui.showZoomAnnouncement(-1, unit.pos, "A " .. caste.caste_name[0] .. " has appeared, it may " .. str .. ".", COLOR_RED, true)
 end
 

--- a/warn-stealers.lua
+++ b/warn-stealers.lua
@@ -80,7 +80,7 @@ local function onTick()
 end
 
 local function help()
-    print("syntax: warn-stealers [start|stop]")
+    print(dfhack.script_help())
 end
 
 local function start()

--- a/warn-stealers.lua
+++ b/warn-stealers.lua
@@ -54,7 +54,7 @@ function announce(unit)
     if casteFlags.CURIOUS_BEAST_ITEM then
         table.insert(desires, "steal items")
     end
-    local str = table.concat(desires, " + ")
+    local str = table.concat(desires, " and ")
     dfhack.gui.showZoomAnnouncement(-1, unit.pos, "A " .. caste.caste_name[0] .. " has appeared, it may " .. str .. ".", COLOR_RED, true)
 end
 

--- a/warn-stealers.lua
+++ b/warn-stealers.lua
@@ -66,7 +66,7 @@ end
 
 local function onTick()
     for _, unitIdStr in ipairs(cache._children) do
-        if not cache[unitIdStr] then -- For a bug in persist-table
+        if cache[unitIdStr] then -- For a bug in persist-table
             local unitId = tonumber(unitIdStr)
             local unit = df.unit.find(unitId)
             if not unit or unit.flags1.inactive then

--- a/warn-stealers.lua
+++ b/warn-stealers.lua
@@ -66,18 +66,15 @@ end
 
 local function onTick()
     for _, unitIdStr in ipairs(cache._children) do
-        -- For a bug in persist-table
-        if not cache[unitIdStr] then
-            return
-        end
-        -- end bug workaround
-        local unitId = tonumber(unitIdStr)
-        local unit = df.unit.find(unitId)
-        if not unit or unit.flags1.inactive then
-            cache[unitIdStr] = nil
-        elseif not isUnitHidden(unit) then
-            announce(unit)
-            cache[unitIdStr] = nil -- this isn't stopping it from being iterated over.
+        if not cache[unitIdStr] then -- For a bug in persist-table
+            local unitId = tonumber(unitIdStr)
+            local unit = df.unit.find(unitId)
+            if not unit or unit.flags1.inactive then
+                cache[unitIdStr] = nil
+            elseif not isUnitHidden(unit) then
+                announce(unit)
+                cache[unitIdStr] = nil -- this isn't stopping it from being iterated over.
+            end
         end
     end
 end

--- a/warn-stealers.lua
+++ b/warn-stealers.lua
@@ -1,7 +1,7 @@
 -- Script to warn when creatures that may steal food become visible
 --[====[
 warn-stealers
-============
+=============
 Will make a zoomable announcement whenever a creature that can eat food, guzzle drinks, or steal items enters the map and moves into a revealed location.
 Takes ``start`` or ``stop`` as parameters.
 ]====]

--- a/warn-stealers.lua
+++ b/warn-stealers.lua
@@ -7,7 +7,6 @@ Will make a zoomable announcement whenever a creature that can eat food, guzzle 
 Takes ``start`` or ``stop`` as parameters.
 ]====]
 
-local persistTable = require("persist-table")
 local eventful = require("plugins.eventful")
 local repeatUtil = require("repeat-util")
 

--- a/warn-stealers.lua
+++ b/warn-stealers.lua
@@ -31,6 +31,9 @@ cache = {}
 local races = df.global.world.raws.creatures.all
 
 function addToCacheIfStealerAndHidden(unitId)
+    if not gamemodeCheck() then
+        return
+    end
     local unit = df.unit.find(unitId)
     if not dfhack.units.isHidden(unit) then
         return


### PR DESCRIPTION
Requires the onUnitNewActive fix being worked on.
`warn-stealers start` in onMapLoad.init will warn when creatures that can steal food, drinks, or items become visible.