### PR TITLE
[quickfort, gui/quickfort] improve orders dialog presentation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ that repo.
 ## Fixes
 
 ## Misc Improvements
+- `gui/quickfort`: better formatting for generated manager orders report
 
 ## Removed
 

--- a/gui/quickfort.lua
+++ b/gui/quickfort.lua
@@ -642,11 +642,10 @@ function QuickfortUI:do_command(command, dry_run, post_fn)
     elseif command == 'orders' then
         local count = 0
         for _,_ in pairs(ctx.order_specs or {}) do count = count + 1 end
-        local messages = {string.format(
-            '%d order(s) %senqueued for %s.', count,
-            dry_run and 'would be ' or '',
-            quickfort_parse.format_command(nil, self.blueprint_name,
-                                           self.section_name))}
+        local messages = {('%d order(s) %senqueued for\n%s.'):format(count,
+                dry_run and 'would be ' or '',
+                quickfort_parse.format_command(nil, self.blueprint_name,
+                                               self.section_name))}
         if count > 0 then
             table.insert(messages, '')
         end

--- a/gui/quickfort.lua
+++ b/gui/quickfort.lua
@@ -624,9 +624,9 @@ function QuickfortUI:commit()
 end
 
 function QuickfortUI:do_command(command, dry_run, post_fn)
-    print(string.format('executing via gui/quickfort: quickfort %s',
-                        quickfort_parse.format_command(
-                            command, self.blueprint_name, self.section_name)))
+    print(('executing via gui/quickfort: quickfort %s'):format(
+                quickfort_parse.format_command(
+                    command, self.blueprint_name, self.section_name, dry_run)))
     local ctx = self:run_quickfort_command(command, dry_run, false)
     quickfort_command.finish_command(ctx, self.section_name)
     if command == 'run' then

--- a/internal/quickfort/command.lua
+++ b/internal/quickfort/command.lua
@@ -167,12 +167,12 @@ end
 function finish_command(ctx, section_name)
     if ctx.command == 'orders' then quickfort_orders.create_orders(ctx) end
     if not ctx.quiet then
-        print(string.format('%s successfully completed',
-                            quickfort_parse.format_command(
-                                ctx.command, ctx.blueprint_name, section_name)))
+        print(('%s successfully completed'):format(
+                quickfort_parse.format_command(ctx.command, ctx.blueprint_name,
+                                               section_name, ctx.dry_run)))
         for _,stat in pairs(ctx.stats) do
             if stat.always or stat.value > 0 then
-                print(string.format('  %s: %d', stat.label, stat.value))
+                print(('  %s: %d'):format(stat.label, stat.value))
             end
         end
     end

--- a/internal/quickfort/orders.lua
+++ b/internal/quickfort/orders.lua
@@ -81,6 +81,7 @@ local function process_filter(order_specs, filter, reactions)
         label = 'ballista parts'
     elseif filter.item_type == df.item_type.BAR then label = 'magnetite ore'
     elseif filter.item_type == df.item_type.BOX then label = 'coffer'
+    elseif filter.item_type == df.item_type.CAGE then label = 'wooden cage'
     elseif filter.item_type == df.item_type.CATAPULTPARTS then
         label = 'catapult parts'
     elseif filter.item_type == df.item_type.CHAIN then label = 'cloth rope'

--- a/internal/quickfort/parse.lua
+++ b/internal/quickfort/parse.lua
@@ -109,18 +109,21 @@ end
 -- returns a string like:
 --   orders library/dreamfort.csv -n /apartments2
 --   run "some file.csv"
-function format_command(command, blueprint_name, section_name)
+function format_command(command, blueprint_name, section_name, dry_run)
     local command_str = ''
     if command then
-        command_str = string.format('%s ', command)
+        command_str = ('%s '):format(command)
     end
     local section_name_str = ''
     if section_name then
-        section_name_str = string.format(' -n %s',
-                                         quote_if_has_spaces(section_name))
+        section_name_str = (' -n %s'):format(quote_if_has_spaces(section_name))
     end
-    return string.format('%s%s%s', command_str,
-                         quote_if_has_spaces(blueprint_name), section_name_str)
+    local dry_run_str = ''
+    if dry_run then
+        dry_run_str = ' --dry-run'
+    end
+    return ('%s%s%s%s'):format(command_str, quote_if_has_spaces(blueprint_name),
+                               section_name_str, dry_run_str)
 end
 
 -- returns the next token, the current (possibly reassembed multiline) line, and

--- a/test/quickfort/parse_unit.lua
+++ b/test/quickfort/parse_unit.lua
@@ -117,6 +117,8 @@ function test.format_command()
     expect.eq('run file.csv -n /somelabel',
               parse.format_command('run', 'file.csv', '/somelabel'))
     expect.eq('"f name.xlsx"', parse.format_command(nil, 'f name.xlsx', nil))
+    expect.eq('run file.csv --dry-run',
+              parse.format_command('run', 'file.csv', nil, true))
     expect.error(function() parse.format_command(nil, nil, nil) end)
 end
 


### PR DESCRIPTION
- format text better in the gui/quickfort orders dialog so it's not so wide
- ensure built cage orders get combined with the rest of the wooden cages
- report that we're running quickfort in --dry-run mode when previewing orders