### PR TITLE
[gui/launcher] first iteration of the in-game help browser and command launcher

### DIFF
--- a/docs/gui/launcher.rst
+++ b/docs/gui/launcher.rst
@@ -1,4 +1,63 @@
 gui/launcher
 ============
+Tags: fort, adventure, legends, system
+:dfhack-keybind:`gui/launcher`
 
-In-game DFHack command launcher and help browser, with command autocomplete.
+In-game DFHack command launcher with integrated help. It is the primary GUI
+interface for running DFHack commands.
+
+Usage::
+
+    gui/launcher [initial commandline]
+
+Examples:
+
+- ``gui/launcher``
+    Opens the launcher dialog with the default help message.
+- ``gui/launcher prospect --show ores,veins``
+    Opens the launcher dialog with the given command visible in the edit area,
+    ready for modification or running. Commands related to the ``prospect``
+    command will appear in the autocomplete list, and help text for the
+    ``prospect`` command will be displayed in the help area.
+
+**Editing and running commands**
+
+Enter the command you want to run by typing its name. If you want to start over,
+:kbd:`Ctrl`:kbd:`C` will clear the line. When you are happy with the command,
+hit :kbd:`Enter` to run it. Any output from the command will appear in the help
+area. If you want to run the command and close the dialog so you can get back to
+the game, use :kbd:`Shift`:kbd:`Enter` instead. The dialog also closes
+automatically if you run a command that brings up a new GUI screen. In the cases
+where the dialog does not reappear to show you the command output, the output
+(if any) will appear in the DFHack terminal console.
+
+**Autocomplete**
+
+As you type, autocomplete options for DFHack commands appear in the right
+column. If the first word of what you've typed matches a valid command, then the
+autocomplete options will also include commands that have similar functionality
+to the one that you've named. Hit :kbd:`Tab` or :kbd:`Shift`:kbd:`Tab` to cycle
+through the autocomplete options. Hit :kbd:`Alt`:kbd:`Left` if you want to undo
+the autocomplete and go back to the text you had before you hit :kbd:`Tab`.
+
+**Context-sensitive help**
+
+When you start ``gui/launcher`` without parameters, it shows some useful
+information in the help area about how to get started.
+
+Once you have typed (or autocompleted) a word that matches a valid command, the
+help area shows the help for that command, including usage instructions. You can
+scroll the help text page by page with :kbd:`PgUp` and :kbd:`PgDn` or line by
+line with :kbd:`Ctrl`:kbd:`Up` and :kbd:`Ctrl`:kbd:`Down`.
+
+**Command history**
+
+``gui/launcher`` keeps a history of commands you have run to let you quickly run
+those commands again. You can scroll through your command history with the
+:kbd:`Up` and :kbd:`Down` cursor keys, or you can search your history for
+something specific with the :kbd:`Alt`:kbd:`S` hotkey. After you hit
+:kbd:`Alt`:kbd:`S`, start typing to search your history for a match. To find the
+next match for what you've already typed, hit :kbd:`Alt`:kbd:`S` again. You can
+run the matched command immediately with :kbd:`Enter` (or
+:kbd:`Shift`:kbd:`Enter`), or hit :kbd:`Esc` to edit the command before running
+it.

--- a/docs/gui/launcher.rst
+++ b/docs/gui/launcher.rst
@@ -5,7 +5,7 @@ Tags: system
 
 In-game DFHack command launcher with integrated help. It is the primary GUI
 interface for running DFHack commands. You can open it from any screen with
-the ``\``` hotkey. If you opened it by mistake, tap ``\``` again to close.
+the \` hotkey. If you opened it by mistake, tap \` again to close.
 
 Usage::
 

--- a/docs/gui/launcher.rst
+++ b/docs/gui/launcher.rst
@@ -1,11 +1,13 @@
 gui/launcher
 ============
-Tags: system
-:dfhack-keybind:`gui/launcher`
 
-In-game DFHack command launcher with integrated help. It is the primary GUI
-interface for running DFHack commands. You can open it from any screen with
-the \` hotkey. If you opened it by mistake, tap \` again to close.
+.. dfhack-tool::
+    :summary: In-game DFHack command launcher with integrated help.
+    :tags: dfhack
+
+This tool is the primary GUI interface for running DFHack commands. You can open
+it from any screen with the \` hotkey. If you opened it by mistake, tap \` again
+to close.
 
 Usage::
 

--- a/docs/gui/launcher.rst
+++ b/docs/gui/launcher.rst
@@ -68,3 +68,10 @@ next match for what you've already typed, hit :kbd:`Alt`:kbd:`S` again. You can
 run the matched command immediately with :kbd:`Enter` (or
 :kbd:`Shift`:kbd:`Enter`), or hit :kbd:`Esc` to edit the command before running
 it.
+
+Dev mode
+--------
+
+By default, commands intended for developers and modders are filtered out of the
+autocomplete list. You can toggle this filtering by hitting :kbd:`Ctrl`:kbd:`D`
+at any time.

--- a/docs/gui/launcher.rst
+++ b/docs/gui/launcher.rst
@@ -4,13 +4,15 @@ Tags: system
 :dfhack-keybind:`gui/launcher`
 
 In-game DFHack command launcher with integrated help. It is the primary GUI
-interface for running DFHack commands.
+interface for running DFHack commands. You can open it from any screen with
+the ``\``` hotkey. If you opened it by mistake, tap ``\``` again to close.
 
 Usage::
 
     gui/launcher [initial commandline]
 
-Examples:
+Examples
+--------
 
 - ``gui/launcher``
     Opens the launcher dialog with the default help message.
@@ -20,18 +22,19 @@ Examples:
     command will appear in the autocomplete list, and help text for the
     ``prospect`` command will be displayed in the help area.
 
-**Editing and running commands**
+Editing and running commands
+----------------------------
 
 Enter the command you want to run by typing its name. If you want to start over,
 :kbd:`Ctrl`:kbd:`C` will clear the line. When you are happy with the command,
 hit :kbd:`Enter` to run it. Any output from the command will appear in the help
 area. If you want to run the command and close the dialog so you can get back to
 the game, use :kbd:`Shift`:kbd:`Enter` instead. The dialog also closes
-automatically if you run a command that brings up a new GUI screen. In the cases
-where the dialog does not reappear to show you the command output, the output
-(if any) will appear in the DFHack terminal console.
+automatically if you run a command that brings up a new GUI screen. In those
+cases, the command output (if any) will appear in the DFHack terminal console.
 
-**Autocomplete**
+Autocomplete
+------------
 
 As you type, autocomplete options for DFHack commands appear in the right
 column. If the first word of what you've typed matches a valid command, then the
@@ -41,7 +44,8 @@ cycle through them with :kbd:`Tab` or :kbd:`Shift`:kbd:`Tab`. Hit
 :kbd:`Alt`:kbd:`Left` if you want to undo the autocomplete and go back to the
 text you had before you autocompleted.
 
-**Context-sensitive help**
+Context-sensitive help
+----------------------
 
 When you start ``gui/launcher`` without parameters, it shows some useful
 information in the help area about how to get started.
@@ -52,7 +56,8 @@ scroll the help text page by page by left/right clicking or with :kbd:`PgUp` and
 :kbd:`PgDn`. You can also scroll line by line with :kbd:`Ctrl`:kbd:`Up` and
 :kbd:`Ctrl`:kbd:`Down`.
 
-**Command history**
+Command history
+---------------
 
 ``gui/launcher`` keeps a history of commands you have run to let you quickly run
 those commands again. You can scroll through your command history with the

--- a/docs/gui/launcher.rst
+++ b/docs/gui/launcher.rst
@@ -1,0 +1,4 @@
+gui/launcher
+============
+
+In-game DFHack command launcher and help browser, with command autocomplete.

--- a/docs/gui/launcher.rst
+++ b/docs/gui/launcher.rst
@@ -1,6 +1,6 @@
 gui/launcher
 ============
-Tags: fort, adventure, legends, system
+Tags: system
 :dfhack-keybind:`gui/launcher`
 
 In-game DFHack command launcher with integrated help. It is the primary GUI
@@ -36,9 +36,10 @@ where the dialog does not reappear to show you the command output, the output
 As you type, autocomplete options for DFHack commands appear in the right
 column. If the first word of what you've typed matches a valid command, then the
 autocomplete options will also include commands that have similar functionality
-to the one that you've named. Hit :kbd:`Tab` or :kbd:`Shift`:kbd:`Tab` to cycle
-through the autocomplete options. Hit :kbd:`Alt`:kbd:`Left` if you want to undo
-the autocomplete and go back to the text you had before you hit :kbd:`Tab`.
+to the one that you've named. Click on an autocomplete option to select it or
+cycle through them with :kbd:`Tab` or :kbd:`Shift`:kbd:`Tab`. Hit
+:kbd:`Alt`:kbd:`Left` if you want to undo the autocomplete and go back to the
+text you had before you autocompleted.
 
 **Context-sensitive help**
 
@@ -47,8 +48,9 @@ information in the help area about how to get started.
 
 Once you have typed (or autocompleted) a word that matches a valid command, the
 help area shows the help for that command, including usage instructions. You can
-scroll the help text page by page with :kbd:`PgUp` and :kbd:`PgDn` or line by
-line with :kbd:`Ctrl`:kbd:`Up` and :kbd:`Ctrl`:kbd:`Down`.
+scroll the help text page by page by left/right clicking or with :kbd:`PgUp` and
+:kbd:`PgDn`. You can also scroll line by line with :kbd:`Ctrl`:kbd:`Up` and
+:kbd:`Ctrl`:kbd:`Down`.
 
 **Command history**
 

--- a/docs/gui/launcher.rst
+++ b/docs/gui/launcher.rst
@@ -27,11 +27,14 @@ Editing and running commands
 
 Enter the command you want to run by typing its name. If you want to start over,
 :kbd:`Ctrl`:kbd:`C` will clear the line. When you are happy with the command,
-hit :kbd:`Enter` to run it. Any output from the command will appear in the help
-area. If you want to run the command and close the dialog so you can get back to
-the game, use :kbd:`Shift`:kbd:`Enter` instead. The dialog also closes
-automatically if you run a command that brings up a new GUI screen. In those
-cases, the command output (if any) will appear in the DFHack terminal console.
+hit :kbd:`Enter` or click on the ``run`` button to run it. Any output from the
+command will appear in the help area. If you want to run the command and close
+the dialog so you can get back to the game, use :kbd:`Shift`:kbd:`Enter` or hold
+down the :kbd:`Shift` key and click on the ``run`` button instead. The dialog
+also closes automatically if you run a command that brings up a new GUI screen.
+In either case, if the launcher window doesn't come back up to show the command
+output, then the command output (if any) will appear in the DFHack terminal
+console.
 
 Autocomplete
 ------------
@@ -51,10 +54,10 @@ When you start ``gui/launcher`` without parameters, it shows some useful
 information in the help area about how to get started.
 
 Once you have typed (or autocompleted) a word that matches a valid command, the
-help area shows the help for that command, including usage instructions. You can
-scroll the help text page by page by left/right clicking or with :kbd:`PgUp` and
-:kbd:`PgDn`. You can also scroll line by line with :kbd:`Ctrl`:kbd:`Up` and
-:kbd:`Ctrl`:kbd:`Down`.
+help area shows the help for that command, including usage instructions and
+examples. You can scroll the help text by half pages by left/right clicking or
+with :kbd:`PgUp` and :kbd:`PgDn`. You can also scroll line by line with
+:kbd:`Ctrl`:kbd:`Up` and :kbd:`Ctrl`:kbd:`Down`.
 
 Command history
 ---------------

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -133,7 +133,7 @@ function AutocompletePanel:advance(delta)
         self.first_advance = false
     end
     list.cursor_pen = COLOR_LIGHTCYAN -- enable highlight
-    list:moveCursor(delta)
+    list:moveCursor(delta, true)
 end
 
 function AutocompletePanel:onInput(keys)
@@ -508,7 +508,8 @@ if dfhack_flags.module then
 end
 
 if view then
-    -- hitting the launcher hotkey while it is open should close the dialog
+    -- running the launcher while it is open (e.g. from hitting the launcher
+    -- hotkey a second time) should close the dialog
     view:dismiss()
 else
     local args = {...}

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -431,7 +431,7 @@ local DEV_FILTER = {tag={'dev'}}
 -- aren't already in the entries list. affiliation is determined by how many
 -- tags the entries share.
 local function add_top_related_entries(entries, entry, n)
-    local dev_ok = dev_mode or helpdb.entry_has_tag(entry, 'dev')
+    local dev_ok = dev_mode or helpdb.get_entry_tags(entry).dev
     local tags = helpdb.get_entry_tags(entry)
     local affinities, buckets = {}, {}
     for i,tag in ipairs(tags) do
@@ -451,7 +451,7 @@ local function add_top_related_entries(entries, entry, n)
         for _,peer in ipairs(buckets[i]) do
             if not entry_set[peer] then
                 entry_set[peer] = true
-                if dev_ok or not helpdb.entry_has_tag(peer, 'dev') then
+                if dev_ok or not helpdb.get_entry_tags(peer).dev then
                     table.insert(entries, peer)
                     n = n - 1
                     if n < 1 then return end

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -149,19 +149,19 @@ function EditPanel:init()
     self:addviews{
         widgets.EditField{
             view_id='editfield',
-            frame={l=1, t=1},
+            frame={l=1, t=1, r=1},
             on_change=self.on_change,
             on_submit=self.on_submit,
             on_submit2=self.on_submit2},
         widgets.EditField{
             view_id='search',
-            frame={l=3, t=3},
+            frame={l=3, t=3, r=1},
             key='CUSTOM_ALT_S',
             label_text='history search: ',
             on_change=self:callback('on_search_text'),
             on_unfocus=function()
                 self:reset_history_idx()
-                self.subviews.search.text = ''
+                self.subviews.search:setText('')
                 self.subviews.editfield:setFocus(true) end,
             on_submit=function()
                 self.on_submit(self.subviews.editfield.text) end,
@@ -181,7 +181,7 @@ function EditPanel:set_text(text, push)
     if push and #editfield.text > 0 then
         table.insert(self.stack, editfield.text)
     end
-    editfield.text = text
+    editfield:setText(text)
     self:reset_history_idx()
 end
 
@@ -190,7 +190,7 @@ function EditPanel:pop_text()
     local text = self.stack[#self.stack]
     if text then
         self.stack[#self.stack] = nil
-        editfield.text = text
+        editfield:setText(text)
     end
     return text
 end
@@ -202,7 +202,7 @@ function EditPanel:move_history(delta)
     end
     self.history_idx = history_idx
     local text = history[history_idx]
-    self.subviews.editfield.text = text
+    self.subviews.editfield:setText(text)
     self.on_change(text)
 end
 
@@ -264,7 +264,7 @@ closes automatically if you run a command that shows
 a new GUI screen.
 
 Not sure what to do? Run the "help" command to get
-started.
+started!
 
 To see help for this command launcher, type
 "launcher" and autocomplete to "gui/launcher" with

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -45,16 +45,24 @@ local function add_history(hist, hist_set, line)
     trim_history(hist, hist_set)
 end
 
+local function file_exists(fname)
+    return dfhack.filesystem.mtime(fname) ~= -1
+end
+
 local function init_history()
     local hist, hist_set = {}, {}
     -- snarf the console history into our active history. it would be better if
     -- both the launcher and the console were using the same history object so
     -- the sharing would be "live", but we can address that later.
-    for line in io.lines(CONSOLE_HISTORY_FILE_OLD) do
-        add_history(hist, hist_set, line)
+    if file_exists(CONSOLE_HISTORY_FILE_OLD) then
+        for line in io.lines(CONSOLE_HISTORY_FILE_OLD) do
+            add_history(hist, hist_set, line)
+        end
     end
-    for line in io.lines(CONSOLE_HISTORY_FILE) do
-        add_history(hist, hist_set, line)
+    if file_exists(CONSOLE_HISTORY_FILE) then
+        for line in io.lines(CONSOLE_HISTORY_FILE) do
+            add_history(hist, hist_set, line)
+        end
     end
     for _,line in ipairs(dfhack.getCommandHistory(HISTORY_ID, HISTORY_FILE)) do
         add_history(hist, hist_set, line)

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -299,6 +299,20 @@ function HelpPanel:set_entry(entry_name)
     self:set_help(helpdb.get_entry_long_help(entry_name))
 end
 
+function HelpPanel:onInput(keys)
+    if HelpPanel.super.onInput(self, keys) then
+        return true
+    elseif keys._MOUSE_L and self:getMousePos() then
+        local label = self.subviews.help_label
+        label:scroll(label.frame_body.height)
+        return true
+    elseif keys._MOUSE_R and self:getMousePos() then
+        local label = self.subviews.help_label
+        label:scroll(-label.frame_body.height)
+        return true
+    end
+end
+
 ----------------------------------
 -- LauncherUI
 --

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -188,7 +188,12 @@ function EditPanel:init()
             key='SELECT',
             label='run',
             on_activate=function()
-                self.on_submit(self.subviews.editfield.text) end},
+                if dfhack.internal.getModifiers().shift then
+                    self.on_submit2(self.subviews.editfield.text)
+                else
+                    self.on_submit(self.subviews.editfield.text)
+                end
+                end},
         widgets.EditField{
             view_id='search',
             frame={l=13, t=3, r=1},

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -318,8 +318,8 @@ function HelpPanel:init()
             scroll_keys={
                 A_MOVE_N_DOWN=-1, -- Ctrl-Up
                 A_MOVE_S_DOWN=1,  -- Ctrl-Down
-                STANDARDSCROLL_PAGEUP='-page',
-                STANDARDSCROLL_PAGEDOWN='+page',
+                STANDARDSCROLL_PAGEUP='-halfpage',
+                STANDARDSCROLL_PAGEDOWN='+halfpage',
             },
             text_to_wrap=DEFAULT_HELP_TEXT}
     }
@@ -347,12 +347,10 @@ function HelpPanel:onInput(keys)
     if HelpPanel.super.onInput(self, keys) then
         return true
     elseif keys._MOUSE_L and self:getMousePos() then
-        local label = self.subviews.help_label
-        label:scroll(label.frame_body.height)
+        self.subviews.help_label:scroll('+halfpage')
         return true
     elseif keys._MOUSE_R and self:getMousePos() then
-        local label = self.subviews.help_label
-        label:scroll(-label.frame_body.height)
+        self.subviews.help_label:scroll('-halfpage')
         return true
     end
 end

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -260,7 +260,7 @@ HelpPanel = defclass(HelpPanel, widgets.Panel)
 
 local DEFAULT_HELP_TEXT = [[Welcome to DFHack!
 
-Type a command to see it's help text here. Hit ENTER
+Type a command to see its help text here. Hit ENTER
 to run the command, or Shift-ENTER to run the
 command and close this dialog. The dialog also
 closes automatically if you run a command that shows

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -1,0 +1,347 @@
+-- The DFHack in-game launcher
+--@module=true
+
+local gui = require('gui')
+local helpdb = require('helpdb')
+local widgets = require('gui.widgets')
+
+AUTOCOMPLETE_PANEL_WIDTH = 20
+EDIT_PANEL_HEIGHT = 4
+EDIT_PANEL_ON_TOP = true
+
+----------------------------------
+-- AutocompletePanel
+--
+AutocompletePanel = defclass(AutocompletePanel, widgets.Panel)
+
+function AutocompletePanel:init()
+    self:addviews{
+        widgets.List{
+            view_id='autocomplete_list',
+            frame={l=0, t=0}}
+    }
+end
+
+function AutocompletePanel:computeFrame(parent_rect)
+    local list = self.subviews.autocomplete_list
+    self.saved_selected = list.selected
+    self.saved_page_top = list.page_top
+    return gui.mkdims_wh(
+        parent_rect.width - AUTOCOMPLETE_PANEL_WIDTH,
+        1,
+        AUTOCOMPLETE_PANEL_WIDTH,
+        parent_rect.height - 2)
+end
+
+function AutocompletePanel:postUpdateLayout()
+    -- ensure the list display stays stable during resize events
+    local list = self.subviews.autocomplete_list
+    list.selected = self.saved_selected
+    list.page_top = self.saved_page_top
+end
+
+function AutocompletePanel:advance(delta)
+    local list = self.subviews.autocomplete_list
+    list:moveCursor(delta)
+    local idx, option = list:getSelected()
+    return option and option.text or nil
+end
+
+function AutocompletePanel:set_options(options, initially_selected)
+    local list = self.subviews.autocomplete_list
+    list:setChoices(options, 1)
+    if not initially_selected then
+        -- don't highlight any row, and select the first row on next advance
+        list.selected = 0
+    end
+end
+
+function AutocompletePanel:ensure_selection()
+    local list = self.subviews.autocomplete_list
+    if list.selected == 0 then
+        list:setSelected(1)
+    end
+end
+
+
+----------------------------------
+-- EditPanel
+--
+EditPanel = defclass(EditPanel, widgets.Panel)
+EditPanel.ATTRS{
+    on_change=DEFAULT_NIL,
+    on_tab=DEFAULT_NIL,
+    on_tab2=DEFAULT_NIL,
+    on_submit=DEFAULT_NIL,
+    on_submit2=DEFAULT_NIL
+}
+
+function EditPanel:init()
+    self.stack = {}
+
+    self:addviews{
+        widgets.EditField{
+            view_id='editfield',
+            frame={l=1, t=1},
+            on_change=self.on_change,
+            on_submit=self.on_submit},
+        widgets.HotkeyLabel{
+            frame={l=1, t=3},
+            key='CHANGETAB',
+            key_sep='/',
+            label='',
+            on_activate=self.on_tab},
+        widgets.HotkeyLabel{
+            frame={l=5, t=3},
+            key='SEC_CHANGETAB',
+            label='Autocomplete',
+            on_activate=self.on_tab2},
+        widgets.HotkeyLabel{
+            frame={l=30, t=3},
+            key='SELECT',
+            key_sep='/',
+            label=''},
+        widgets.HotkeyLabel{
+            frame={l=36, t=3},
+            key='SEC_SELECT',
+            label='Run',
+            on_activate=function()
+                self.on_submit2(self.subviews.editfield.text) end},
+    }
+end
+
+-- set the edit field text and save the current text in the stackin case the
+-- user wants it back
+function EditPanel:push_text(text)
+    local editfield = self.subviews.editfield
+    table.insert(self.stack, editfield.text)
+    editfield.text = text
+end
+
+function EditPanel:pop_text()
+    local editfield = self.subviews.editfield
+    local text = self.stack[#self.stack]
+    self.stack[#self.stack] = nil
+    editfield.text = text
+end
+
+function EditPanel:computeFrame(parent_rect)
+    local y1 = EDIT_PANEL_ON_TOP and 0 or (parent_rect.height - EDIT_PANEL_HEIGHT)
+    return gui.mkdims_wh(
+        0,
+        y1,
+        parent_rect.width - (AUTOCOMPLETE_PANEL_WIDTH + 2),
+        EDIT_PANEL_HEIGHT)
+end
+
+----------------------------------
+-- HelpPanel
+--
+HelpPanel = defclass(HelpPanel, widgets.Panel)
+
+function HelpPanel:init()
+    self.cur_entry = ""
+
+    self:addviews{
+        widgets.WrappedLabel{
+            view_id='help_label',
+            frame={l=0, t=0},
+            auto_height=false,
+            text_to_wrap='Welcome to DFHack!'}
+    }
+end
+
+function HelpPanel:set_help(help_text)
+    local label = self.subviews.help_label
+    label.text_to_wrap = help_text
+    label:postComputeFrame()
+    label:updateLayout() -- to update the scroll arrows after rewrapping text
+end
+
+function HelpPanel:set_entry(entry_name)
+    if not helpdb.is_entry(entry_name) then
+        entry_name = ""
+    end
+    if #entry_name == 0 or entry_name == self.cur_entry then
+        return
+    end
+    self.cur_entry = entry_name
+    self:set_help(helpdb.get_entry_long_help(entry_name))
+end
+
+function HelpPanel:computeFrame(parent_rect)
+    local y1 = not EDIT_PANEL_ON_TOP and 1 or (EDIT_PANEL_HEIGHT + 2)
+    return gui.mkdims_wh(
+        1,
+        y1,
+        parent_rect.width - (AUTOCOMPLETE_PANEL_WIDTH + 4),
+        parent_rect.height - (EDIT_PANEL_HEIGHT + 2))
+end
+
+----------------------------------
+-- LauncherUI
+--
+LauncherUI = defclass(LauncherUI, gui.FramedScreen)
+LauncherUI.ATTRS{
+    frame_title='DFHack Launcher',
+    frame_style = gui.GREY_LINE_FRAME,
+    focus_path='launcher',
+}
+
+function LauncherUI:init()
+    self.firstword = ""
+
+    self:addviews{
+        AutocompletePanel{
+            view_id='autocomplete',
+            active=false},
+        EditPanel{
+            view_id='edit',
+            on_change=self:callback('on_edit_input'),
+            on_tab=self:callback('next_autocomplete'),
+            on_tab2=self:callback('prev_autocomplete'),
+            on_submit=self:callback('run_command', true),
+            on_submit2=self:callback('run_command', false)},
+        HelpPanel{
+            view_id='help'},
+    }
+end
+
+local function get_first_word(text)
+    return text:trim():split(' +')[1]
+end
+
+function LauncherUI:update_help(text, firstword)
+    local firstword = firstword or get_first_word(text)
+    if firstword == self.firstword then
+        return
+    end
+    self.firstword = firstword
+    self.subviews.help:set_entry(firstword)
+end
+
+function LauncherUI:update_autocomplete(text, firstword)
+    local entries = helpdb.search_entries(
+        {str=firstword},
+        {str={'modtools/', 'devel/'}})
+    local found = false
+    for i,v in ipairs(entries) do
+        if v == firstword then
+            -- if firstword is in the list, move that item to the top
+            table.remove(entries, i)
+            table.insert(entries, 1, v)
+            found = true
+            break
+        end
+    end
+    self.subviews.autocomplete:set_options(entries, found)
+end
+
+function LauncherUI:on_edit_input(text)
+    local firstword = get_first_word(text)
+    self:update_help(text, firstword)
+    self:update_autocomplete(text, firstword)
+end
+
+function LauncherUI:next_autocomplete()
+    local text = self.subviews.autocomplete:advance(1)
+    if text then
+        self.subviews.edit:push_text(text)
+        self:update_help(text)
+    end
+end
+
+function LauncherUI:prev_autocomplete()
+    local autocomplete = self.subviews.autocomplete
+    autocomplete:ensure_selection()
+    local text = autocomplete:advance(-1)
+    if text then
+        self.subviews.edit:push_text(text)
+        self:update_help(text)
+    end
+end
+
+local function launch(initial_help)
+    view = LauncherUI{}
+    view:show()
+    view:on_edit_input('')
+    if initial_help then
+        view.subviews.help:set_help(initial_help)
+    end
+end
+
+function LauncherUI:onDismiss()
+    view = nil
+end
+
+function LauncherUI:run_command(reappear, text)
+    self:dismiss()
+    local output = dfhack.run_command_silent(text)
+    -- if we launched a new screen, don't come back up, even if reappear is true
+    if not reappear or dfhack.gui.getCurFocus(true):startswith('dfhack/') then
+        return
+    end
+    -- reappear and show the command output
+    local initial_help = ('> %s\n\n%s'):format(text, output)
+    launch(initial_help)
+end
+
+function LauncherUI:getWantedFrameSize()
+    local width, height = dfhack.screen.getWindowSize()
+    return math.max(76, width-10), math.max(24, height-10)
+end
+
+local H_SPLIT_PEN = dfhack.pen.parse{ch=205, fg=COLOR_GREY, bg=COLOR_BLACK}
+local V_SPLIT_PEN = dfhack.pen.parse{ch=186, fg=COLOR_GREY, bg=COLOR_BLACK}
+local TOP_SPLIT_PEN = dfhack.pen.parse{ch=203, fg=COLOR_GREY, bg=COLOR_BLACK}
+local BOTTOM_SPLIT_PEN = dfhack.pen.parse{ch=202, fg=COLOR_GREY, bg=COLOR_BLACK}
+local LEFT_SPLIT_PEN = dfhack.pen.parse{ch=204, fg=COLOR_GREY, bg=COLOR_BLACK}
+local RIGHT_SPLIT_PEN = dfhack.pen.parse{ch=185, fg=COLOR_GREY, bg=COLOR_BLACK}
+
+-- paint autocomplete panel border
+local function paint_vertical_border(rect)
+    local x = rect.x2 - (AUTOCOMPLETE_PANEL_WIDTH + 2)
+    local y1, y2 = rect.y1, rect.y2
+    dfhack.screen.paintTile(TOP_SPLIT_PEN, x, y1)
+    dfhack.screen.paintTile(BOTTOM_SPLIT_PEN, x, y2)
+    for y=y1+1,y2-1 do
+        dfhack.screen.paintTile(V_SPLIT_PEN, x, y)
+    end
+end
+
+-- paint border between edit area and help area
+local function paint_horizontal_border(rect)
+    local panel_height = EDIT_PANEL_HEIGHT + 1
+    local x1, x2 = rect.x1, rect.x2
+    local v_border_x = x2 - (AUTOCOMPLETE_PANEL_WIDTH + 2)
+    local y = EDIT_PANEL_ON_TOP and
+            (rect.y1 + panel_height) or (rect.y2 - panel_height)
+    dfhack.screen.paintTile(LEFT_SPLIT_PEN, x1, y)
+    dfhack.screen.paintTile(RIGHT_SPLIT_PEN, v_border_x, y)
+    for x=x1+1,v_border_x-1 do
+        dfhack.screen.paintTile(H_SPLIT_PEN, x, y)
+    end
+end
+
+function LauncherUI:onRenderFrame(dc, rect)
+    LauncherUI.super.onRenderFrame(self, dc, rect)
+    paint_vertical_border(rect)
+    paint_horizontal_border(rect)
+end
+
+function LauncherUI:onInput(keys)
+    if keys.LEAVESCREEN then
+        self:dismiss()
+        return true
+    end
+
+    return self:inputToSubviews(keys)
+end
+
+if dfhack_flags.module then
+    return
+end
+
+if not view then
+    launch()
+end

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -183,9 +183,15 @@ function EditPanel:init()
             on_change=self.on_change,
             on_submit=self.on_submit,
             on_submit2=self.on_submit2},
+        widgets.HotkeyLabel{
+            frame={l=1, t=3, w=10},
+            key='SELECT',
+            label='run',
+            on_activate=function()
+                self.on_submit(self.subviews.editfield.text) end},
         widgets.EditField{
             view_id='search',
-            frame={l=3, t=3, r=1},
+            frame={l=13, t=3, r=1},
             key='CUSTOM_ALT_S',
             label_text='history search: ',
             on_change=self:callback('on_search_text'),

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -427,7 +427,9 @@ local function add_top_related_entries(entries, entry, n)
         buckets[i] = {}
     end
     for peer,affinity in pairs(affinities) do
-        table.insert(buckets[affinity], peer)
+        if helpdb.get_entry_types(peer).command then
+            table.insert(buckets[affinity], peer)
+        end
     end
     local entry_set = utils.invert(entries)
     for i=#buckets,1,-1 do
@@ -445,7 +447,7 @@ end
 
 function LauncherUI:update_autocomplete(firstword)
     local entries = helpdb.search_entries(
-        {str=firstword},
+        {str=firstword, types='command'},
         {str={'modtools/', 'devel/'}})
     -- if firstword is in the list, extract it so we can add it to the top later
     -- even if it's not in the list, add it back anyway if it's a valid db entry

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -13,7 +13,8 @@ local EDIT_PANEL_HEIGHT = 4
 local HISTORY_SIZE = 5000
 local HISTORY_ID = 'gui/launcher'
 local HISTORY_FILE = 'dfhack-config/launcher.history'
-local CONSOLE_HISTORY_FILE = 'dfhack.history'
+local CONSOLE_HISTORY_FILE = 'dfhack-config/dfhack.history'
+local CONSOLE_HISTORY_FILE_OLD = 'dfhack.history'
 local BASE_FREQUENCY_FILE = 'hack/data/base_command_counts.json'
 local USER_FREQUENCY_FILE = 'dfhack-config/command_counts.json'
 
@@ -49,6 +50,9 @@ local function init_history()
     -- snarf the console history into our active history. it would be better if
     -- both the launcher and the console were using the same history object so
     -- the sharing would be "live", but we can address that later.
+    for line in io.lines(CONSOLE_HISTORY_FILE_OLD) do
+        add_history(hist, hist_set, line)
+    end
     for line in io.lines(CONSOLE_HISTORY_FILE) do
         add_history(hist, hist_set, line)
     end

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -445,10 +445,13 @@ local function add_top_related_entries(entries, entry, n)
     end
 end
 
+dev_mode = dev_mode or false
+local DEV_FILTER = {str={'modtools/', 'devel/'}}
+
 function LauncherUI:update_autocomplete(firstword)
     local entries = helpdb.search_entries(
         {str=firstword, types='command'},
-        {str={'modtools/', 'devel/'}})
+        dev_mode and DEV_FILTER or nil)
     -- if firstword is in the list, extract it so we can add it to the top later
     -- even if it's not in the list, add it back anyway if it's a valid db entry
     -- (e.g. if it's a devel/ script that we masked out) to show that it's a
@@ -568,6 +571,9 @@ function LauncherUI:onInput(keys)
     elseif keys.CUSTOM_CTRL_C then
         self.subviews.edit:set_text('', self.input_is_worth_saving)
         self:on_edit_input('')
+    elseif keys.CUSTOM_CTRL_D then
+        dev_mode = not dev_mode
+        self:update_autocomplete(get_first_word(self.subviews.editfield.text))
     end
 end
 


### PR DESCRIPTION
Fixes DFHack/dfhack#2224

Requires the [docs](https://github.com/DFHack/dfhack/tree/docs) branch of DFHack/dfhack.

Tab autocomplete is implemented, but the cross-indexing of commands via tags can't be (usefully) implemented until we go through and tag everything.

Enter to run the current command and show the output, shift-enter to run it and close the dialog. Dialog also auto-closes if the command brings up any screens of its own.

Screenshot:
![image](https://user-images.githubusercontent.com/977482/178380997-1b560826-1ad9-4d9f-ae10-ba7d8084f0db.png)
