### PR TITLE
Fix emigration logic

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ that repo.
 ## Fixes
 - `gui/unit-info-viewer`: fix logic for displaying undead creature names
 - `gui/workflow`: restore functionality to the add/remove/order hotkeys on the workflow status screen
+- `emigration`: fix emigrant logic so unhappy dorfs leave as designed
 
 ## Misc Improvements
 - `gui/quickfort`: better formatting for generated manager orders report

--- a/emigration.lua
+++ b/emigration.lua
@@ -87,7 +87,7 @@ function checkForDeserters(method,civ_id)
     local allUnits = df.global.world.units.active
     for i=#allUnits-1,0,-1 do   -- search list in reverse
         local u = allUnits[i]
-        if canLeave(u) and math.random(100) < desireToStay(u,method,civ_id) then
+        if canLeave(u) and math.random(100) > desireToStay(u,method,civ_id) then
             desert(u,method,civ_id)
         end
     end


### PR DESCRIPTION
The comparator in the master code is incorrect.

Dorf stress is negative for happy dorfs and positive for unhappy ones. Line 33 creates a threshold that is, therefore, above 100 for happy dorfs and below 100 for unhappy ones.

Line 90 in master asks for a 0-100 roll to be *below* this threshold for emigration to occur. This means that happy dorfs will *always* emigrate (contra line 14) and unhappy ones are increasingly unlikely to the unhappier they get.

You can observe this behaviour in a new fort: I saw six out of seven dorfs leave almost instantly.