### PR TITLE
migrate scripts to the new EditField:setText() api

### DIFF
--- a/gui/blueprint.lua
+++ b/gui/blueprint.lua
@@ -102,14 +102,14 @@ end
 function NamePanel:on_edit_focus()
     local name_view = self.subviews.name
     if name_view.text == 'blueprint' then
-        name_view.text = ''
+        name_view:setText('')
         self:update_tooltip()
     end
 end
 function NamePanel:on_edit_unfocus()
     local name_view = self.subviews.name
     if name_view.text == '' then
-        name_view.text = 'blueprint'
+        name_view:setText('blueprint')
         self:update_tooltip()
     end
 end
@@ -117,7 +117,7 @@ function NamePanel:detect_name_collision()
     -- don't let base names start with a slash - it would get ignored by
     -- the blueprint plugin later anyway
     local name = utils.normalizePath(self.subviews.name.text):gsub('^/','')
-    self.subviews.name.text = name
+    self.subviews.name:setText(name)
 
     if name == '' then
         self.has_name_collision = false

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -535,7 +535,7 @@ function GmEditorUi:pushTarget(target_to_push)
     end
     new_tbl.item_count=#new_tbl.keys
     table.insert(self.stack,new_tbl)
-    self.subviews.filter_input.text=""
+    self.subviews.filter_input:setText("")
     self:updateTarget()
 end
 function GmEditorUi:popTarget()
@@ -544,7 +544,7 @@ function GmEditorUi:popTarget()
         self:dismiss()
         return
     end
-    self.subviews.filter_input.text=self.stack[#self.stack].filter --restore filter
+    self.subviews.filter_input:setText(self.stack[#self.stack].filter) --restore filter
     self:updateTarget()
 end
 function show_editor(trg)

--- a/gui/quickfort.lua
+++ b/gui/quickfort.lua
@@ -431,7 +431,7 @@ end
 
 function QuickfortUI:on_adjust_repetitions(amt)
     repetitions = math.max(1, repetitions + amt)
-    self.subviews.repeat_times.text = tostring(repetitions)
+    self.subviews.repeat_times:setText(tostring(repetitions))
     self.dirty = true
 end
 
@@ -440,7 +440,7 @@ function QuickfortUI:on_repeat_times_submit(val)
     if not repetitions or repetitions < 1 then
         repetitions = 1
     end
-    self.subviews.repeat_times.text = tostring(repetitions)
+    self.subviews.repeat_times:setText(tostring(repetitions))
     self.dirty = true
 end
 

--- a/test/gui/workorder-details.lua
+++ b/test/gui/workorder-details.lua
@@ -24,7 +24,10 @@ if confirm.isEnabled() then
             if c.enabled then
                 confirmRemove = function()
                     wait()
-                    send_keys('CUSTOM_P', 'MANAGER_REMOVE')
+                    -- only pause and resend key if we're not already paused
+                    if not confirm.get_paused() then
+                        send_keys('CUSTOM_P', 'MANAGER_REMOVE')
+                    end
                 end
             end
             break
@@ -52,6 +55,7 @@ function test.changeOrderDetails()
     wait()
     send_keys('MANAGER_DETAILS')
     expect.true_(df.viewscreen_workquota_detailsst:is_instance(dfhack.gui.getCurViewscreen(true)), "We need to be in the workquota_details screen")
+    expect.eq(ordercount + 1, #df.global.world.manager_orders, "Test order should have been added")
     local job = dfhack.gui.getCurViewscreen(true).order
     local item = job.items[0]
 
@@ -107,6 +111,7 @@ function test.unsetAllItemTraits()
 
     --- create an order
     dfhack.run_command [[workorder "{ \"frequency\" : \"OneTime\", \"job\" : \"CutGems\", \"material\" : \"INORGANIC:SLADE\" }"]]
+    expect.eq(ordercount + 1, #df.global.world.manager_orders, "Test order should have been added")
     wait()
     send_keys('STANDARDSCROLL_UP') -- move cursor to newly created CUT SLADE
     wait()


### PR DESCRIPTION
so they can work with both the docs and develop branches

also fix a bug in the workorder-details test where an extra order was being removed if you happened to run the tests with orders already in the queue.