### PR TITLE
[gui/launcher] usability improvements

### DIFF
--- a/docs/gui/launcher.rst
+++ b/docs/gui/launcher.rst
@@ -6,23 +6,26 @@ gui/launcher
     :tags: dfhack
 
 This tool is the primary GUI interface for running DFHack commands. You can open
-it from any screen with the \` hotkey. If you opened it by mistake, tap \` again
-to close.
+it from any screen with the \` hotkey. Tap \` again (or hit :kbd:`Esc`) to
+close.
 
-Usage::
+Usage
+-----
+
+::
 
     gui/launcher [initial commandline]
 
 Examples
 --------
 
-- ``gui/launcher``
-    Opens the launcher dialog with the default help message.
-- ``gui/launcher prospect --show ores,veins``
-    Opens the launcher dialog with the given command visible in the edit area,
-    ready for modification or running. Commands related to the ``prospect``
-    command will appear in the autocomplete list, and help text for the
-    ``prospect`` command will be displayed in the help area.
+``gui/launcher``
+    Open the launcher dialog with a blank initial commandline.
+``gui/launcher prospect --show ores,veins``
+    Open the launcher dialog with the edit area pre-populated with the given
+    command, ready for modification or running. Tools related to ``prospect``
+    will appear in the autocomplete list, and help text for ``prospect`` will be
+    displayed in the help area.
 
 Editing and running commands
 ----------------------------
@@ -30,13 +33,12 @@ Editing and running commands
 Enter the command you want to run by typing its name. If you want to start over,
 :kbd:`Ctrl`:kbd:`C` will clear the line. When you are happy with the command,
 hit :kbd:`Enter` or click on the ``run`` button to run it. Any output from the
-command will appear in the help area. If you want to run the command and close
-the dialog so you can get back to the game, use :kbd:`Shift`:kbd:`Enter` or hold
-down the :kbd:`Shift` key and click on the ``run`` button instead. The dialog
-also closes automatically if you run a command that brings up a new GUI screen.
-In either case, if the launcher window doesn't come back up to show the command
-output, then the command output (if any) will appear in the DFHack terminal
-console.
+command will appear in the help area. If you want to run the command but close
+the dialog immediately so you can get back to the game, use
+:kbd:`Shift`:kbd:`Enter` or hold down the :kbd:`Shift` key and click on the
+``run`` button instead. The dialog also closes automatically if you run a
+command that brings up a new GUI screen. In any case, the command output will
+also be written to the DFHack terminal console.
 
 Autocomplete
 ------------
@@ -67,7 +69,7 @@ Command history
 ``gui/launcher`` keeps a history of commands you have run to let you quickly run
 those commands again. You can scroll through your command history with the
 :kbd:`Up` and :kbd:`Down` cursor keys, or you can search your history for
-something specific with the :kbd:`Alt`:kbd:`S` hotkey. After you hit
+something specific with the :kbd:`Alt`:kbd:`S` hotkey. When you hit
 :kbd:`Alt`:kbd:`S`, start typing to search your history for a match. To find the
 next match for what you've already typed, hit :kbd:`Alt`:kbd:`S` again. You can
 run the matched command immediately with :kbd:`Enter` (or

--- a/docs/gui/launcher.rst
+++ b/docs/gui/launcher.rst
@@ -47,9 +47,7 @@ As you type, autocomplete options for DFHack commands appear in the right
 column. If the first word of what you've typed matches a valid command, then the
 autocomplete options will also include commands that have similar functionality
 to the one that you've named. Click on an autocomplete option to select it or
-cycle through them with :kbd:`Tab` or :kbd:`Shift`:kbd:`Tab`. Hit
-:kbd:`Alt`:kbd:`Left` if you want to undo the autocomplete and go back to the
-text you had before you autocompleted.
+cycle through them with :kbd:`Tab` or :kbd:`Shift`:kbd:`Tab`.
 
 Context-sensitive help
 ----------------------

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -224,6 +224,12 @@ function EditPanel:init()
             key='CUSTOM_ALT_S',
             label_text='history search: ',
             on_change=function(text) self:on_search_text(text) end,
+            on_focus=function()
+                local text = self.subviews.editfield.text
+                if #text:trim() > 0 then
+                    self.subviews.search:setText(text)
+                    self:on_search_text(text)
+                end end,
             on_unfocus=function()
                 self.subviews.search:setText('')
                 self.subviews.editfield:setFocus(true) end,

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -592,8 +592,12 @@ function LauncherUI:onInput(keys)
         self:dismiss()
         return true
     elseif keys.CUSTOM_CTRL_C then
-        self.subviews.edit:set_text('')
-        self:on_edit_input('')
+        if self.focus_group.cur == self.subviews.editfield then
+            self.subviews.edit:set_text('')
+            self:on_edit_input('')
+        else
+            self.focus_group.cur:setText('')
+        end
     elseif keys.CUSTOM_CTRL_D then
         dev_mode = not dev_mode
         self:update_autocomplete(get_first_word(self.subviews.editfield.text))

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -537,18 +537,18 @@ local function safe_run(reappear, command, prev_parent_focus)
     -- hotkey guards and tools that detect the top viewscreen to work reliably.
     script.sleep(2, 'frames')
     local output = dfhack.run_command_silent(command)
+    if #output > 0 then
+        print('Output from command run from gui/launcher:')
+        print('> ' .. command)
+        print()
+        print(output)
+    end
     -- if we displayed a new dfhack screen, don't come back up even if reappear
     -- is true. otherwise, the user can't interact with the new screen. if we're
     -- not reappearing with the output, print the output to the console.
     local parent_focus = dfhack.gui.getCurFocus(true)
     if not reappear or (parent_focus:startswith('dfhack/') and
                         parent_focus ~= prev_parent_focus) then
-        if #output > 0 then
-            print('Output from command run from gui/launcher:')
-            print('> ' .. command)
-            print()
-            print(output)
-        end
         return
     end
     -- reappear and show the command output

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -238,26 +238,9 @@ function EditPanel:reset_history_idx()
     self.history_idx = #history + 1
 end
 
--- set the edit field text and save the current text in the stack in case the
--- user wants it back
-function EditPanel:set_text(text, push)
-    local editfield = self.subviews.editfield
-    if push and #editfield.text > 0 then
-        table.insert(self.stack, editfield.text)
-    end
-    editfield:setText(text)
+function EditPanel:set_text(text)
+    self.subviews.editfield:setText(text)
     self:reset_history_idx()
-end
-
-function EditPanel:pop_text()
-    local editfield = self.subviews.editfield
-    local text = self.stack[#self.stack]
-    if text then
-        self.stack[#self.stack] = nil
-        self:reset_history_idx()
-        editfield:setText(text)
-        self.on_change(text)
-    end
 end
 
 function EditPanel:move_history(delta)
@@ -308,9 +291,6 @@ function EditPanel:onInput(keys)
         -- search to the next match with the current search string
         -- only reaches here if the search field is already active
         self:on_search_text(self.subviews.search.text, true)
-        return true
-    elseif keys.A_CARE_MOVE_W then -- Alt-Left
-        self:pop_text()
         return true
     end
 end
@@ -502,16 +482,14 @@ function LauncherUI:update_autocomplete(firstword)
 end
 
 function LauncherUI:on_edit_input(text)
-    self.input_is_worth_saving = true
     local firstword = get_first_word(text)
     self:update_help(text, firstword)
     self:update_autocomplete(firstword)
 end
 
 function LauncherUI:on_autocomplete(_, option)
-    self.subviews.edit:set_text(option.text, self.input_is_worth_saving)
+    self.subviews.edit:set_text(option.text)
     self:update_help(option.text)
-    self.input_is_worth_saving = false
 end
 
 local function launch(kwargs)
@@ -614,7 +592,7 @@ function LauncherUI:onInput(keys)
         self:dismiss()
         return true
     elseif keys.CUSTOM_CTRL_C then
-        self.subviews.edit:set_text('', self.input_is_worth_saving)
+        self.subviews.edit:set_text('')
         self:on_edit_input('')
     elseif keys.CUSTOM_CTRL_D then
         dev_mode = not dev_mode


### PR DESCRIPTION
- unconditionally tee output to the terminal so the command output is recorded and is accessible for copy/paste
- simplify launcher command edit field by removing the edit stack (before, you could "un-autocomplete", but this behavior was confusing, complicated the code, and was difficult to explain. Moreover, it's just not very hard to retype/re-search-for what was there originally). (also the Alt-Left hotkey was appropriated by the EditField for "Home" functionality, so the launcher feature was inaccessible anyway, and it's just not worth it to find another hotkey for it.)
- let Ctrl-C clear the EditField that has focus. This lets the same hotkey clear the search text if that's where the focus is.
- if there is text already typed into the command EditField, use it as the initial search if the user hits Alt-S. This simplifies searching the history if the command is already partially typed.