### PR TITLE
[docs] remove quotes around literal square brackets

### DIFF
--- a/docs/assign-attributes.rst
+++ b/docs/assign-attributes.rst
@@ -44,7 +44,7 @@ Options
 ``--unit <id>``
     The target unit ID. If not present, the currently selected unit will be the
     target.
-``--attributes "[" <attribute> <tier> [<attribute> <tier> ...] "]"``
+``--attributes [ <attribute> <tier> [<attribute> <tier> ...] ]``
     The list of the attributes to modify and their tiers. The valid attribute
     names can be found in the :wiki:`Attribute` (substitute any space with
     underscores). Tiers range from -4 to 4. There must be a space before and

--- a/docs/assign-beliefs.rst
+++ b/docs/assign-beliefs.rst
@@ -44,7 +44,7 @@ Options
 ``--unit <id>``
     The target unit ID. If not present, the currently selected unit will be the
     target.
-``--beliefs "[" <belief> <level> [<belief> <level> ...] "]"``
+``--beliefs [ <belief> <level> [<belief> <level> ...] ]``
     The list of the beliefs to modify and their levels. The valid belief tokens
     can be found in the :wiki:`Personality_trait` (substitute any space with
     underscores). Levels range from -3 to 3. There must be a space before and

--- a/docs/assign-facets.rst
+++ b/docs/assign-facets.rst
@@ -41,7 +41,7 @@ Options
 ``--unit <id>``
     The target unit ID. If not present, the currently selected unit will be the
     target.
-``--facets "[" <facet> <level> [<facet> <level> ...] "]"``
+``--facets [ <facet> <level> [<facet> <level> ...] ]``
     The list of the facets to modify and their levels. The valid facet tokens
     can be found in the :wiki:`Personality_trait` (substitute any space with
     underscores). Levels range from -3 to 3. There must be a space before and

--- a/docs/assign-goals.rst
+++ b/docs/assign-goals.rst
@@ -36,7 +36,7 @@ Options
 ``--unit <id>``
     The target unit ID. If not present, the currently selected unit will be the
     target.
-``--goals "[" <goal> false [<goal> false ...] "]"``
+``--goals [ <goal> false [<goal> false ...] ]``
     The list of goals to add. The valid goal tokens can be found in the
     :wiki:`Personality_trait` (substitute any space with underscores). There
     must be a space before and after each square bracket.

--- a/docs/assign-preferences.rst
+++ b/docs/assign-preferences.rst
@@ -72,25 +72,25 @@ brackets can be omitted.
 ``--unit <id>``
     The target unit ID. If not present, the currently selected unit will be the
     target.
-``--likematerial "[" <token> [<token> ...] "]"``
+``--likematerial [ <token> [<token> ...] ]``
     This is usually set to three tokens: a type of stone, a type of metal, and a
     type of gem. It can also be a type of wood, glass, leather, horn, pearl,
     ivory, a decoration material - coral or amber, bone, shell, silk, yarn, or
     cloth. Please include the full tokens, not just a part.
-``--likecreature "[" <token> [<token> ...] "]"``
+``--likecreature [ <token> [<token> ...] ]``
     For this preference, you can just list the species as the token. For
     example, a creature token can be something like ``CREATURE:SPARROW:SKIN``.
     Here, you can just say ``SPARROW``.
-``--likefood "[" <token> [<token> ...] "]"``
+``--likefood [ <token> [<token> ...] ]``
     This usually contains at least a type of alcohol. It can also be a type of
     meat, fish, cheese, edible plant, cookable plant/creature extract, cookable
     mill powder, cookable plant seed, or cookable plant leaf. Please write the
     full tokens.
-``--hatecreature "[" <token> [<token> ...] "]"``
+``--hatecreature [ <token> [<token> ...] ]``
     As in ``--likecreature`` above, you can just list the species in the token.
     The creature should be a type of ``HATEABLE`` vermin which isn't already
     explicitly liked, but no check is performed to enforce this.
-``--likeitem "[" <token> [<token> ...] "]"``
+``--likeitem [ <token> [<token> ...] ]``
     This can be a kind of weapon, a kind of ammo, a piece of armor, a piece of
     clothing (including backpacks or quivers), a type of furniture (doors,
     floodgates, beds, chairs, windows, cages, barrels, tables, coffins, statues,
@@ -106,15 +106,15 @@ brackets can be omitted.
     column "Subtype" of the wiki page (they are in the "/raw/ojects/" folder),
     then specify the items using the full tokens found in those files (see
     examples in this help).
-``--likeplant "[" <token> [<token> ...] "]"``
+``--likeplant [ <token> [<token> ...] ]``
     As in ``--likecreature`` above, you can just list the tree or plant species
     in the token.
-``--likecolor "[" <token> [<token> ...] "]"``
+``--likecolor [ <token> [<token> ...] ]``
     You can find the color tokens here:
     https://dwarffortresswiki.org/index.php/DF2014:Color#Color_tokens
     or inside the "descriptor_color_standard.txt" file (in the "/raw/ojects/"
     folder). You can use the full token or just the color name.
-``--likeshape "[" <token> [<token> ...] "]"``
+``--likeshape [ <token> [<token> ...] ]``
     I couldn't find a list of shape tokens in the wiki, but you can find them
     inside the "descriptor_shape_standard.txt" file (in the "/raw/ojects/"
     folder). You can use the full token or just the shape name.

--- a/docs/assign-skills.rst
+++ b/docs/assign-skills.rst
@@ -31,7 +31,7 @@ Options
 ``--unit <id>``
     The target unit ID. If not present, the currently selected unit will be the
     target.
-``--skills "[" <skill> <rank> [<skill> <rank> ...] "]"``
+``--skills [ <skill> <rank> [<skill> <rank> ...] ]``
     The list of the skills to modify and their ranks. Rank values range from -1
     (the skill is not learned) to 20 (legendary + 5). It is actually possible to
     go beyond 20 (no check is performed), but the effect on the game may not be

--- a/docs/dwarf-op.rst
+++ b/docs/dwarf-op.rst
@@ -76,9 +76,9 @@ instead of ``all``.
 ``drunks``
     Selects any dwarves who have the ``DRUNK`` profession, including those who
     have been zeroed by the ``--clear`` command option.
-``jobs "[" jobs <jobname> [<jobname> ...] "]"``
+``jobs [ jobs <jobname> [<jobname> ...] ]``
     Selects any dwarves with the specified custom professions.
-``waves "[" waves <num> [<num> ...] "]"``
+``waves [ waves <num> [<num> ...] ]``
     Selects dwarves from the specified migration waves. Waves are enumerated
     starting at 0 and increasing by 1 with each wave. The waves go by season and
     year and thus should match what you see in `list-waves` or Dwarf Therapist.
@@ -122,13 +122,13 @@ Command options
 ``--optimize``
     Performs a job search for unoptimized dwarves. Run
     ``dwarf-op --list job_distribution`` to see how jobs are distributed.
-``--applyjobs "[" <job> [<job> ...] "]"``
+``--applyjobs [ <job> [<job> ...] ]``
     Applies the listed jobs to the selected dwarves. Run
     ``dwarf-op --list jobs`` to see available jobs.
-``--applyprofessions "[" <profession> [<profession> ...] "]"``
+``--applyprofessions [ <profession> [<profession> ...] ]``
     Applies the listed professions to the selected dwarves. Run
     ``dwarf-op --list professions`` to see available professions.
-``--applytypes "[" <profession> [<profession> ...] "]"``
+``--applytypes [ <profession> [<profession> ...] ]``
     Applies the listed types to the selected dwarves. Run
     ``dwarf-op --list dwf_types`` to see available types.
 ``--renamejob <name>``

--- a/docs/extinguish.rst
+++ b/docs/extinguish.rst
@@ -19,7 +19,7 @@ Usage
     Put out the fire under the cursor.
 ``extinguish --all``
     Put out all fires on the map.
-``extinguish --location "[" <x> <y> <z> "]"``
+``extinguish --location [ <x> <y> <z> ]``
     Put out the fire at the specified map coordinates. You can use the
     `position` tool to find out what the coordinates under the cursor are.
 

--- a/docs/repeat.rst
+++ b/docs/repeat.rst
@@ -12,7 +12,7 @@ called every once in a while but don't want to have to remember to run yourself.
 Usage
 -----
 
-``repeat [--name <name>] --time <delay> [--timeUnits <units>] --command "[" <command> "]"``
+``repeat [--name <name>] --time <delay> [--timeUnits <units>] --command [ <command> ]``
     Register the given command to be run periodically.
 ``repeat --list``
     Show the currently registered commands and their names.
@@ -46,7 +46,7 @@ Options
     ``frames`` (raw FPS), ``ticks`` (unpaused game frames), or the in-world time
     measurements of ``days``, ``months``, or ``years``. If not specified,
     ``ticks`` is the default.
-``--command "[" ... "]"``
+``--command [ ... ]``
     The ``...`` specifies the command to be run, just as you would write it on
     the commandline. Note that the command must be enclosed in square brackets.
 


### PR DESCRIPTION
to make them easier to read (they're already hard to understand with that syntax, but at least there are examples that show how they should look)