### PR TITLE
Fix property name for ignored keys in skill editor

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ that repo.
 ## New Scripts
 
 ## Fixes
+- `gui/gm-unit`: fixed behavior of ``+`` and ``-`` again to adjust skill values instead of populating the search field
 
 ## Misc Improvements
 

--- a/internal/gm-unit/editor_skills.lua
+++ b/internal/gm-unit/editor_skills.lua
@@ -68,7 +68,7 @@ function Editor_Skills:init( args )
             choices=skill_list,
             frame = {t=0, b=1,l=1},
             view_id="skills",
-            ignore_keys={"SECONDSCROLL_UP", "SECONDSCROLL_DOWN"},
+            edit_ignore_keys={"SECONDSCROLL_UP", "SECONDSCROLL_DOWN"},
         },
         widgets.Label{
             frame = { b=0,l=1},


### PR DESCRIPTION
Fixes https://github.com/DFHack/dfhack/issues/2308 
Fixes #424