### PR TITLE
[gui/create-item] make --restricted default, add --unrestricted opt

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,12 +17,14 @@ that repo.
 
 ## Fixes
 - `gui/gm-unit`: fixed behavior of ``+`` and ``-`` again to adjust skill values instead of populating the search field
-- `warn-stealers`: fixed script not working because of an incorrect event name.
+- `gui/create-item`: restrict materials to those normally allowed by the game by default, introduce new ``--unrestricted`` option for full freedom in choosing materials
+- `warn-stealers`: fixed script not working because of an incorrect event name
 
 ## Misc Improvements
 - `gui/blueprint`: support new blueprint phases and options
 
 ## Removed
+- `gui/create-item`: removed ``--restricted`` option. it is now the default behavior
 
 # 0.47.05-r7
 

--- a/docs/gui/create-item.rst
+++ b/docs/gui/create-item.rst
@@ -26,13 +26,13 @@ Usage
 Examples
 --------
 
-``gui/create-item --restrictive --multi``
+``gui/create-item --multi``
     Only provide options for creating items that normally exist in the game.
     Also include the prompt for quantity so you can create more than just one
     item at a time.
-``gui/create-item``
+``gui/create-item --unrestricted``
     Create one item made of anything in the game. For example, you can create
-    a bar of vomit.
+    a bar of vomit, if you please.
 
 Options
 -------
@@ -42,9 +42,9 @@ Options
 ``--unit <id>``
     Use the specified unit as the "creator" of the generated item instead of the
     selected unit.
-``--restrictive``
-    Restrict the material options to only those that are normally appropriate
-    for the selected item type.
+``--unrestricted``
+    Don't restrict the material options to only those that are normally
+    appropriate for the selected item type.
 ``--startup``
     Instead of showing the item creation interface, start monitoring reactions
     for a modded reaction with a code of ``DFHACK_WISH``. When a reaction with

--- a/gui/create-item.lua
+++ b/gui/create-item.lua
@@ -1,18 +1,8 @@
--- create-item.lua
 -- A gui-based item creation script.
 -- author Putnam
 -- edited by expwnent
-
 --@module = true
---[====[
 
-gui/create-item
-===============
-A graphical interface for creating items.
-
-See also: `createitem`, `modtools/create-item`, :issue:`735`
-
-]====]
 function getGenderString(gender)
   local sym = df.pronoun_type.attrs[gender].symbol
   if not sym then
@@ -34,7 +24,7 @@ function getCreatureList()
 end
 
 function getRestrictiveMatFilter(itemType)
- if not args.restrictive then return nil end
+ if args.unrestricted then return nil end
  local itemTypes={
    WEAPON=function(mat,parent,typ,idx)
     return (mat.flags.ITEMS_WEAPON or mat.flags.ITEMS_WEAPON_RANGED)
@@ -249,7 +239,7 @@ utils=require('utils')
 
 validArgs = utils.invert({
  'startup',
- 'restrictive',
+ 'unrestricted',
  'unit',
  'multi'
 })


### PR DESCRIPTION
Don't lure casual players who just want to cheat in a few items into creating bars of vomit. Restrict materials to "normal" game items by default.