### PR TITLE
create-unit: rework naming; add nemesis civless save data; add arg checks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ that repo.
 
 ## Misc Improvements
 - `gui/blueprint`: support new blueprint phases and options
+- `modtools/create-unit`: better unit naming, more argument checks, assign nemesis save data for units without civilization
 
 ## Removed
 - `gui/create-item`: removed ``--restricted`` option. it is now the default behavior

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,7 +24,7 @@ that repo.
 
 ## Misc Improvements
 - `gui/blueprint`: support new blueprint phases and options
-- `modtools/create-unit`: better unit naming, more argument checks, assign nemesis save data for units without civilization
+- `modtools/create-unit`: better unit naming, more argument checks, assign nemesis save data for units without civilization so they can be properly saved when offloaded
 
 ## Removed
 - `gui/create-item`: removed ``--restricted`` option. it is now the default behavior

--- a/docs/modtools/create-unit.rst
+++ b/docs/modtools/create-unit.rst
@@ -42,7 +42,7 @@ Creates a unit.  Usage::
     -name entityRawName
         Set the unit's name to be a random name appropriate for the
         given entity. \\LOCAL can be specified instead to automatically
-        use the fort group entity in fortress mode only. Can be passed 
+        use the fort group entity in fortress mode only. Can be passed
         empty to generate a wild name (random language, any words), i.e.
         the type of name that animal people historical figures have.
         examples:

--- a/docs/modtools/create-unit.rst
+++ b/docs/modtools/create-unit.rst
@@ -42,7 +42,9 @@ Creates a unit.  Usage::
     -name entityRawName
         Set the unit's name to be a random name appropriate for the
         given entity. \\LOCAL can be specified instead to automatically
-        use the fort group entity in fortress mode only.
+        use the fort group entity in fortress mode only. Can be passed 
+        empty to generate a wild name (random language, any words), i.e.
+        the type of name that animal people historical figures have.
         examples:
             MOUNTAIN
             EVIL

--- a/modtools/create-unit.lua
+++ b/modtools/create-unit.lua
@@ -448,13 +448,13 @@ local function allocateNewChunk(hist_entity)
     hist_entity.save_file_id = df.global.unit_chunk_next_id
     df.global.unit_chunk_next_id = df.global.unit_chunk_next_id+1
     hist_entity.next_member_idx = 0
-    print("allocating chunk:",hist_entity.save_file_id)
+    print("allocating chunk for entity "..hist_entity.id..":",hist_entity.save_file_id)
   else
     local chunkInfo = df.global.world.worldgen
     chunkInfo.next_unit_chunk_id = df.global.unit_chunk_next_id
     df.global.unit_chunk_next_id = df.global.unit_chunk_next_id+1
     chunkInfo.next_unit_chunk_offset = 0
-    print("allocating chunk:",chunkInfo.next_unit_chunk_id)
+    print("allocating chunk in worldgen:",chunkInfo.next_unit_chunk_id)
   end
 end
 

--- a/modtools/create-unit.lua
+++ b/modtools/create-unit.lua
@@ -66,7 +66,7 @@ function createUnit(raceStr, casteStr, pos, locationRange, locationType, age, do
       qerror('Invalid civId (must be a number): ' .. tostring(civ_id))
     end
     civ_id = tonumber(civ_id)
-	  local civ = df.historical_entity.find(civ_id)
+    local civ = df.historical_entity.find(civ_id)
     if civ_id ~= -1 and not civ then
       qerror('Civilisation not found: ' .. tostring(civ_id))
     end
@@ -627,8 +627,8 @@ function nameUnit(unit, entityRawName)
     end
   end
   --[[  When there's no language matching an entity's [TRANSLATION] as defined in the raws
-        or when the unit doesn't have an entity (empty string argument), the game picks a 
-        random non generated language for each name. ]]
+  or when the unit doesn't have an entity (empty string argument), the game picks a
+  random non generated language for each name. ]]
   if not translation then
     local validLanguages = {} --{number, df.language_translation}[]
     local index = 1
@@ -656,14 +656,14 @@ function nameUnit(unit, entityRawName)
     TOLERATED = PREFERRED
   end
   
-  function randomWord(language_word_table, compound) 
+  function randomWord(language_word_table, compound)
     local index = math.random(0, #language_word_table.words[compound] - 1)
     return language_word_table.words[compound][index], language_word_table.parts[compound][index] --number, number
   end
   
   local name = unit.name
   --one of the last names is drawn from preferred words and the other from tolerated words. 50-50
-  if math.random(0, 1)==1 then 
+  if math.random(0, 1)==1 then
     name.words.FrontCompound, name.parts_of_speech.FrontCompound = randomWord(PREFERRED, FrontCompound)
     repeat
       name.words.RearCompound, name.parts_of_speech.RearCompound = randomWord(TOLERATED, RearCompound)

--- a/modtools/create-unit.lua
+++ b/modtools/create-unit.lua
@@ -47,7 +47,7 @@ function createUnit(raceStr, casteStr, pos, locationRange, locationType, age, do
       qerror('Invalid duration (must be a number greater than 0): ' .. tostring(vanishDelay))
     end
   end
-  
+
   if entityRawName and entityRawName~="" then
     local isValidRawName
     for k,v in ipairs(df.global.world.raws.entities) do
@@ -642,12 +642,12 @@ function nameUnit(unit, entityRawName)
     translationIndex = validLanguages[choice][1]
     translation = validLanguages[choice][2]
   end
-  
+
   --language_word_table
   local PREFERRED -- words that the entity likes ([SELECT_SYMBOL])
   local TOLERATED -- all words except those that the entity dislikes ([CULL_SYMBOL])
   local FrontCompound, RearCompound, FirstName = 0, 1, 2  --indexes for language_word_table.words/.parts
-  
+
   if entity_raw then
     PREFERRED = entity_raw.symbols.symbols1.OTHER
     TOLERATED = entity_raw.symbols.symbols2.OTHER
@@ -655,12 +655,12 @@ function nameUnit(unit, entityRawName)
     PREFERRED = df.global.world.raws.language.word_table[0][35] -- a guess; this table has every word, and so do the ones at [0][37], [1][35] and [1][37]
     TOLERATED = PREFERRED
   end
-  
+
   function randomWord(language_word_table, compound)
     local index = math.random(0, #language_word_table.words[compound] - 1)
     return language_word_table.words[compound][index], language_word_table.parts[compound][index] --number, number
   end
-  
+
   local name = unit.name
   --one of the last names is drawn from preferred words and the other from tolerated words. 50-50
   if math.random(0, 1)==1 then


### PR DESCRIPTION
Mostly, made naming more accurately reflect the game's behavior. Added option to generate "wild" name (i.e. civless name) by passing `-name` empty. Made nemesis records created without a civId have proper save data. Fixed some argument checks and added more so civ_id has to actually be for a civilization and group_id can't be a civilization (also implies they can't be the same). Made history event generation take current year into account, and add history event for histfig joining group as well, to better emulate game behavior (using void migrants as reference).