### PR TITLE
[gui/launcher] show help for :lua commands

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@ that repo.
 
 ## Misc Improvements
 - `gui/blueprint`: support new blueprint phases and options
+- `gui/launcher`: show help for commands that start with ':' (like ``:lua``)
 - `modtools/create-unit`: better unit naming, more argument checks, assign nemesis save data for units without civilization so they can be properly saved when offloaded
 
 ## Removed

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -93,7 +93,9 @@ local function get_frequency_data(fname)
 end
 
 local function get_first_word(text)
-    return text:trim():split(' +')[1]
+    local word = text:trim():split(' +')[1]
+    if word:startswith(':') then word = word:sub(2) end
+    return word
 end
 
 command_bias = command_bias or get_frequency_data(BASE_FREQUENCY_FILE)


### PR DESCRIPTION
update `get_first_word` routine to handle commands that start with a colon.