### PR TITLE
[unsuspend] port resume's suspended building overlay to the overlay framework

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ that repo.
 ## Misc Improvements
 - `gui/blueprint`: support new blueprint phases and options
 - `modtools/create-unit`: better unit naming, more argument checks, assign nemesis save data for units without civilization so they can be properly saved when offloaded
+- `unsuspend`: new `overlay` for displaying status of suspended buildings (functionality migrated from removed `resume` plugin)
 
 ## Removed
 - `gui/create-item`: removed ``--restricted`` option. it is now the default behavior

--- a/docs/unsuspend.rst
+++ b/docs/unsuspend.rst
@@ -6,8 +6,11 @@ unsuspend
     :tags: fort productivity jobs
 
 Unsuspends building construction jobs, except for jobs managed by `buildingplan`
-and those where water flow is greater than 1. See `autounsuspend` for keeping
-new jobs unsuspended.
+and those where water flow is greater than 1. This allows you to quickly recover
+if a bunch of jobs were suspended due to the workers getting scared off by
+wildlife or items temporarily blocking building sites.
+
+See `autounsuspend` for periodic automatic unsuspending of suspended jobs.
 
 Usage
 -----
@@ -15,3 +18,15 @@ Usage
 ::
 
     unsuspend
+
+Overlay
+-------
+
+This script also provides an overlay that is managed by the `overlay` framework.
+When enabled, it will display a colored 'X' over suspended buildings. A green
+'X' indicates that the building is waiting on materials, and `buildingplan` will
+unsuspend it for you when those materials become available. A yellow 'X' means
+that the building is suspended and that you can unsuspend it manually or with
+the `unsuspend` command. A red 'X' indicates that the building has been
+re-suspended multiple times, and that you might need to look into whatever is
+preventing the building from being built.

--- a/unsuspend.lua
+++ b/unsuspend.lua
@@ -1,37 +1,197 @@
 -- unsuspend construction jobs; buildingplan-safe
---[====[
+--@module = true
 
-unsuspend
-=========
-Unsuspends building construction jobs, except for jobs managed by `buildingplan`
-and those where water flow > 1. See `autounsuspend` for keeping new jobs
-unsuspended.
-]====]
+local guidm = require('gui.dwarfmode')
+local utils = require('utils')
 
 local buildingplan = require('plugins.buildingplan')
+local overlay = require('plugins.overlay')
 
-local joblist = df.global.world.jobs.list.next
-local unsuspended_count, flow_count, buildingplan_count = 0, 0, 0
-
-while joblist do
-    local job = joblist.item
-    joblist = joblist.next
-
-    if job.job_type == df.job_type.ConstructBuilding and job.flags.suspend then
-        if dfhack.maps.getTileFlags(job.pos).flow_size > 1 then
-            flow_count = flow_count + 1
-            goto continue
+local function foreach_construction_job(fn)
+    for _,job in utils.listpairs(df.global.world.jobs.list) do
+        if job.job_type == df.job_type.ConstructBuilding then
+            fn(job)
         end
-        local bld = dfhack.buildings.findAtTile(job.pos)
-        if bld and buildingplan.isPlannedBuilding(bld) then
-            buildingplan_count = buildingplan_count + 1
-            goto continue
-        end
-        job.flags.suspend = false
-        unsuspended_count = unsuspended_count + 1
-        ::continue::
     end
 end
+
+SuspendOverlay = defclass(SuspendOverlay, overlay.OverlayWidget)
+SuspendOverlay.ATTRS{
+    viewscreens='dwarfmode',
+    overlay_onupdate_max_freq_seconds=30,
+}
+
+function SuspendOverlay:init()
+    self:reset()
+    -- there can only be one of these widgets allocated at a time, so this is
+    -- safe
+    dfhack.onStateChange.unsuspend = function(code)
+        if code ~= SC_MAP_LOADED then return end
+        self:reset()
+    end
+end
+
+function SuspendOverlay:reset()
+    -- value of df.global.building_next_id on last scan
+    self.prev_building_next_id = 0
+
+    -- increments on every refresh so we can clear old data from the map
+    self.data_version = 0
+
+    -- map of building id -> {suspended=bool, suspend_count=int, version=int}
+    -- suspended is the job suspension state as of the last refresh
+    -- if suspend_count > 1 then this is a repeat offender (red 'X')
+    -- only buildings whose construction is in progress should be in this map.
+    self.in_progress_buildings = {}
+
+    -- viewport for cached screen_buildings
+    self.viewport = {}
+
+    -- map of building ids to current visible screen position
+    self.screen_buildings = {}
+end
+
+function SuspendOverlay:overlay_onupdate()
+    local added = false
+    self.data_version = self.data_version + 1
+    foreach_construction_job(function(job)
+        self:update_building(dfhack.job.getHolder(job).id, job)
+        added = true
+    end)
+    self.prev_building_next_id = df.global.building_next_id
+    if added then
+        -- invalidate screen_buildings cache
+        self.viewport = {}
+    end
+    -- clear out old data
+    for bld_id,data in pairs(self.in_progress_buildings) do
+        if data.version ~= self.data_version then
+            self.in_progress_buildings[bld_id] = nil
+        end
+    end
+end
+
+function SuspendOverlay:update_building(bld_id, job)
+    local suspended = job.flags.suspend
+    local data = self.in_progress_buildings[bld_id]
+    if not data then
+        self.in_progress_buildings[bld_id] = {suspended=suspended,
+                suspend_count=suspended and 1 or 0, version=self.data_version}
+    else
+        if suspended and suspended ~= data.suspended then
+            data.suspend_count = data.suspend_count + 1
+        end
+        data.suspended = suspended
+        data.version = self.data_version
+    end
+end
+
+function SuspendOverlay:process_new_buildings()
+    local added = false
+    for bld_id=self.prev_building_next_id,df.global.building_next_id-1 do
+        local bld = df.building.find(bld_id)
+        if not bld or #bld.jobs ~= 1 then
+            goto continue
+        end
+        local job = bld.jobs[0]
+        if job.job_type ~= df.job_type.ConstructBuilding then
+            goto continue
+        end
+        self:update_building(bld_id, job)
+        added = true
+        ::continue::
+    end
+    self.prev_building_next_id = df.global.building_next_id
+    if added then
+        -- invalidate screen_buildings cache
+        self.viewport = {}
+    end
+end
+
+-- returns true if viewport has changed
+function SuspendOverlay:update_viewport(viewport)
+    local pviewport = self.viewport
+    if viewport.z == pviewport.z
+            and viewport.x1 == pviewport.x1 and viewport.x2 == pviewport.x2
+            and viewport.y1 == pviewport.y1 and viewport.y2 == pviewport.y2 then
+        return false
+    end
+    self.viewport = viewport
+    return true
+end
+
+function SuspendOverlay:refresh_screen_buildings()
+    local viewport = guidm.Viewport.get()
+    if not self:update_viewport(viewport) then return end
+    local screen_buildings, z = {}, viewport.z
+    for bld_id,data in pairs(self.in_progress_buildings) do
+        local bld = df.building.find(bld_id)
+        local pos = {x=bld.centerx, y=bld.centery, z=bld.z}
+        if bld and viewport:isVisible(pos) then
+            local screen_pos = viewport:tileToScreen(pos)
+            screen_buildings[bld_id] = screen_pos
+        end
+    end
+    self.screen_buildings = screen_buildings
+end
+
+function SuspendOverlay:render_marker(dc, bld, screen_pos)
+    if not bld or #bld.jobs ~= 1 then return end
+    local data = self.in_progress_buildings[bld.id]
+    if not data then return end
+    local job = bld.jobs[0]
+    if job.job_type ~= df.job_type.ConstructBuilding
+            or not job.flags.suspend then
+        return
+    end
+    local color = COLOR_YELLOW
+    if data.suspend_count > 1 then
+        color = COLOR_RED
+    elseif buildingplan.isPlannedBuilding(bld) then
+        color = COLOR_GREEN
+    end
+    -- + 1 for the screen border
+    dc:seek(screen_pos.x + 1, screen_pos.y + 1):string('X', color)
+end
+
+function SuspendOverlay:onRenderFrame(dc)
+    if not df.global.pause_state
+            or df.global.ui.main.mode ~= df.ui_sidebar_mode.Default then
+        return
+    end
+
+    self:process_new_buildings()
+    self:refresh_screen_buildings()
+
+    dc:map(true)
+    for bld_id,screen_pos in pairs(self.screen_buildings) do
+        self:render_marker(dc, df.building.find(bld_id), screen_pos)
+    end
+    dc:map(false)
+end
+
+OVERLAY_WIDGETS = {overlay=SuspendOverlay}
+
+if dfhack_flags.module then
+    return
+end
+
+local unsuspended_count, flow_count, buildingplan_count = 0, 0, 0
+
+foreach_construction_job(function(job)
+    if not job.flags.suspend then return end
+    if dfhack.maps.getTileFlags(job.pos).flow_size > 1 then
+        flow_count = flow_count + 1
+        return
+    end
+    local bld = dfhack.buildings.findAtTile(job.pos)
+    if bld and buildingplan.isPlannedBuilding(bld) then
+        buildingplan_count = buildingplan_count + 1
+        return
+    end
+    job.flags.suspend = false
+    unsuspended_count = unsuspended_count + 1
+end)
 
 if flow_count > 0 then
     print(string.format('Skipped %d underwater job(s)', flow_count))


### PR DESCRIPTION
DFHack/dfhack#2333

resume and unsuspend always had functionality overlap (with unsuspend's implementation being superior). now with the overlay framework, unsuspend take take on all of resume's functionality and we can turn down resume.