### PR TITLE
use the overlay framework's new overlay_only attr

### DIFF
--- a/unsuspend.lua
+++ b/unsuspend.lua
@@ -18,6 +18,7 @@ end
 SuspendOverlay = defclass(SuspendOverlay, overlay.OverlayWidget)
 SuspendOverlay.ATTRS{
     viewscreens='dwarfmode',
+    overlay_only=true,
     overlay_onupdate_max_freq_seconds=30,
 }
 


### PR DESCRIPTION
so the unsuspend overlay doesn't get a useless draggable frame for repositioning its non-existent widget UI