### PR TITLE
[extra-gamelog.rst] Soundsense link points to the wrong forum thread.

### DIFF
--- a/docs/modtools/extra-gamelog.rst
+++ b/docs/modtools/extra-gamelog.rst
@@ -6,7 +6,7 @@ modtools/extra-gamelog
     :tags: dev
 
 This script writes extra information to the gamelog.
-This is useful for tools like :forums:`Soundsense <106497>`.
+This is useful for tools like :forums:`Soundsense <60287>`.
 
 Usage::
 


### PR DESCRIPTION
The link labelled as "Soundsense" is pointing to "Stonesense" forum thread.
Here directing it at the correct thread.