### PR TITLE
Update gui/launcher hotkeys for v50

### DIFF
--- a/docs/gui/launcher.rst
+++ b/docs/gui/launcher.rst
@@ -57,7 +57,7 @@ As you type, autocomplete options for DFHack commands appear in the right
 column. If the first word of what you've typed matches a valid command, then the
 autocomplete options will also include commands that have similar functionality
 to the one that you've named. Click on an autocomplete list option to select it
-or cycle through them with :kbd:`Tab` and :kbd:`Shift`:kbd:`Tab`.
+or cycle through them with :kbd:`Shift`:kbd:`Left` and :kbd:`Shift`:kbd:`Right`.
 
 Context-sensitive help
 ----------------------
@@ -70,7 +70,7 @@ Once you have typed (or autocompleted) a word that matches a valid command, the
 help area shows the help for that command, including usage instructions and
 examples. You can scroll the help text by half-pages by clicking on the
 scrollbar or with :kbd:`PgUp` and :kbd:`PgDn`. You can also scroll line by line
-with :kbd:`Ctrl`:kbd:`Up` and :kbd:`Ctrl`:kbd:`Down`, or by clicking on the
+with :kbd:`Shift`:kbd:`Up` and :kbd:`Shift`:kbd:`Down`, or by clicking on the
 scrollbar arrows.
 
 Command history
@@ -92,20 +92,3 @@ Dev mode
 By default, commands intended for developers and modders are filtered out of the
 autocomplete list. You can toggle this filtering by hitting :kbd:`Ctrl`:kbd:`D`
 at any time.
-
-Autocomplete tab speed
-----------------------
-
-By default in DF, holding down the :kbd:`Tab` key is the same as just pressing
-it once. This makes scanning quickly through the autocomplete list with the
-keyboard quite slow. To speed things up, you can go to the DF keybinding
-configuration screen (hit :kbd:`Esc` from the main map and select
-``Key Bindings`` from the menu), select ``General``, and then ``Change tab or
-highlight selection``. If you change the configuration for that item to
-``Immediate repeat``, then holding :kbd:`Tab` will allow you to scan through
-the autocomplete list more quickly. Be sure to also change the configuration for
-the next item, ``Change tab or highlight selection, secondary``, to also allow
-:kbd:`Shift`:kbd:`Tab` to work the same way.
-
-Back at the main Key Bindings screen, select ``Save and exit`` to get back to
-the game.

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -131,12 +131,12 @@ function AutocompletePanel:init()
         },
         widgets.HotkeyLabel{
             frame={l=1, t=1},
-            key='CHANGETAB',
+            key='KEYBOARD_CURSOR_RIGHT_FAST',
             key_sep='/',
             label=''},
         widgets.HotkeyLabel{
-            frame={l=5, t=1},
-            key='SEC_CHANGETAB',
+            frame={l=9, t=1},
+            key='KEYBOARD_CURSOR_LEFT_FAST',
             key_sep='',
             label=''},
         widgets.List{
@@ -333,8 +333,8 @@ function HelpPanel:init()
             frame_inset={r=1},
             auto_height=false,
             scroll_keys={
-                A_MOVE_N_DOWN=-1, -- Ctrl-Up
-                A_MOVE_S_DOWN=1,  -- Ctrl-Down
+                KEYBOARD_CURSOR_UP_FAST=-1,  -- Shift-Up
+                KEYBOARD_CURSOR_DOWN_FAST=1, -- Shift-Down
                 STANDARDSCROLL_PAGEUP='-halfpage',
                 STANDARDSCROLL_PAGEDOWN='+halfpage',
             },
@@ -658,9 +658,9 @@ function LauncherUI:onInput(keys)
     elseif keys.CUSTOM_CTRL_D then
         dev_mode = not dev_mode
         self:update_autocomplete(get_first_word(self.subviews.editfield.text))
-    elseif keys.CHANGETAB then
+    elseif keys.KEYBOARD_CURSOR_RIGHT_FAST then
         self.subviews.autocomplete:advance(1)
-    elseif keys.SEC_CHANGETAB then
+    elseif keys.KEYBOARD_CURSOR_LEFT_FAST then
         self.subviews.autocomplete:advance(-1)
     end
 end


### PR DESCRIPTION
Some keys were removed and causing errors in the full display (see also dfhack/dfhack@6a61c750e)

![image](https://user-images.githubusercontent.com/3719547/209391116-024710aa-4599-4514-b9de-2b18601f6d0c.png)
