### PR TITLE
update gui/quickcmd

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,9 +21,10 @@ that repo.
 ## Misc Improvements
 - `emigration`: now saves its state with your fort
 - `prioritize`: now saves its state with your fort
-- `gui/gm-editor`: converted to a movable, resizable window
+- `gui/gm-editor`: converted to a movable, resizable, mouse-enabled window
 - `gui/launcher`: now supports a smaller, minimal mode. click the toggle in the launcher UI or start in minimal mode via the ``Ctrl-Shift-P`` keybinding
-- `gui/gm-unit`: converted to a movable, resizable window
+- `gui/gm-unit`: converted to a movable, resizable, mouse-enabled window
+- `gui/quickcmd`: converted to a movable, resizable, mouse-enabled window, also commands are stored globally now so you don't have to recreate commands for every fort
 - `devel/inspect-screen`: updated for new rendering semantics and can now also inspect map textures
 
 ## Documentation

--- a/gui/quickcmd.lua
+++ b/gui/quickcmd.lua
@@ -1,14 +1,4 @@
 --- Simple menu to quickly execute common commands.
---[====[
-
-gui/quickcmd
-============
-A list of commands which you can edit while in-game, and which you can execute
-quickly and easily. For stuff you use often enough to not want to type it, but
-not often enough to be bothered to find a free keybinding.
-
-]====]
-
 --[[
 Copyright (c) 2014, Michon van Dooren
 All rights reserved.
@@ -39,104 +29,112 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ]]
 
-local gui = require 'gui'
-local widgets = require 'gui.widgets'
-local dlg = require 'gui.dialogs'
+local dlg = require('gui.dialogs')
+local json = require('json')
+local gui = require('gui')
+local widgets = require('gui.widgets')
 
+local CONFIG_FILE = 'dfhack-config/quickcmd.json'
 local HOTKEYWIDTH = 7
-local COMMANDWIDTH = 28 - HOTKEYWIDTH - 3
-local STORAGEKEY = 'quickcmd.command'
 local HOTKEYS = 'asdfghjklqwertyuiopzxcvbnm'
 
-QCMDDialog = defclass(QCMDDialog, gui.FramedScreen)
-QCMDDialog.focus_path = 'QuickCMDDialog'
+local function load_commands()
+    local ok, data = pcall(json.decode_file, CONFIG_FILE)
+    return ok and data or {}
+end
+
+local function save_commands(data)
+    json.encode_file(data, CONFIG_FILE)
+end
+
+QCMDDialog = defclass(QCMDDialog, gui.Screen)
 QCMDDialog.ATTRS {
-    frame_title = 'Quick Command',
+    focus_path='quickcmd',
 }
 
 function QCMDDialog:init(info)
-    self:addviews{
-        widgets.Panel{
-            frame = { t = 0, r = 0, b = 0, l = 0 },
-            frame_inset = 1,
-            subviews = {
-                widgets.Label{
-                    frame = { t = 0 },
-                    text = {
-                        { text = 'Hotkey', width = HOTKEYWIDTH }, ' ',
-                        { text = 'Command', width = COMMANDWIDTH },
-                    },
-                },
-                widgets.List{
-                    view_id = 'list',
-                    frame = { t = 2, b = 3 },
-                    not_found_label = 'Command list is empty.',
-                },
-                widgets.Label{
-                    frame = { b = 0, h = 2 },
-                    text = {
-                        { key = 'CUSTOM_SHIFT_A', text = ': Add command',
-                          on_activate = self:callback('onAddCommand') }, ' ',
-                        { key = 'CUSTOM_SHIFT_D', text = ': Delete command',
-                          on_activate = self:callback('onDelCommand') }, NEWLINE,
-                        { key = 'CUSTOM_SHIFT_E', text = ': Edit command',
-                          on_activate = self:callback('onEditCommand') }, ' ',
-                    },
-                }
+    self.commands = load_commands()
+
+    local main_panel = widgets.Window{
+        frame_title='Quick Command',
+        frame={w=40, h=28},
+        resizable=true,
+    }
+
+    main_panel:addviews{
+        widgets.Label{
+            frame={t=0},
+            text={{text='Hotkey', width=HOTKEYWIDTH}, ' Command'},
+            visible=function() return #self.commands > 0 end,
+        },
+        widgets.List{
+            view_id='list',
+            frame={t=2, b=3},
+            on_submit=self:callback('submit'),
+        },
+        widgets.Label{
+            frame={t=0},
+            text={'Command list is empty.', NEWLINE, 'Hit "A" to add one!'},
+            visible=function() return #self.commands == 0 end,
+        },
+        widgets.Label{
+            frame={b=0, h=2},
+            text={
+                {key='CUSTOM_SHIFT_A', text=': Add command',
+                 on_activate=self:callback('onAddCommand')}, ' ',
+                {key='CUSTOM_SHIFT_D', text=': Delete command',
+                 on_activate=self:callback('onDelCommand')}, NEWLINE,
+                {key='CUSTOM_SHIFT_E', text=': Edit command',
+                 on_activate=self:callback('onEditCommand')},
             },
         },
     }
 
+    self:addviews{main_panel}
     self:updateList()
 end
 
-function QCMDDialog:updateList()
-    -- Get the stored commands.
-    local entries = dfhack.persistent.get_all(STORAGEKEY) or {}
+function QCMDDialog:submit(idx, choice)
+    self:dismiss()
+    dfhack.run_command(choice.command)
+end
 
+function QCMDDialog:updateList()
     -- Build the list entries.
-    self.commands = {}
-    for i, entry in ipairs(entries) do
+    local choices = {}
+    for i,command in ipairs(self.commands) do
         -- Get the hotkey for this entry.
         local hotkey = nil
         if i <= HOTKEYS:len() then
             hotkey = HOTKEYS:sub(i, i)
-
-            -- Store the entry.
-            table.insert(self.commands, {
-                text = {
-                        { text = hotkey or '', width = HOTKEYWIDTH }, ' ',
-                        { text = entry.value, width = COMMANDWIDTH },
-                },
-                entry = entry,
-                command = entry.value,
-                hotkey = 'CUSTOM_' .. hotkey:upper(),
-            })
         end
-    end
-    self.subviews.list:setChoices(self.commands);
-end
 
-function QCMDDialog:getWantedFrameSize(rect)
-    return 40, 28
+        -- Store the entry.
+        table.insert(choices, {
+            text={{text=hotkey or '', width=HOTKEYWIDTH}, ' ', command},
+            command=command,
+            hotkey=hotkey and ('CUSTOM_' .. hotkey:upper()) or '',
+        })
+    end
+    self.subviews.list:setChoices(choices);
 end
 
 function QCMDDialog:onInput(keys)
     if keys.LEAVESCREEN then
         self:dismiss()
-    else
-        -- If the pressed key is a hotkey, perform that command and close.
-        for _, command in pairs(self.commands) do
-            if keys[command.hotkey] then
-                dfhack.run_command(command.command)
-                self:dismiss()
-                return
-            end
-        end
-
-        -- Else, let the parent handle it.
-        QCMDDialog.super.onInput(self, keys)
+        return true
     end
+
+    -- If the pressed key is a hotkey, perform that command and close.
+    for idx,choice in ipairs(self.subviews.list:getChoices()) do
+        if keys[choice.hotkey] then
+            self:submit(idx, choice)
+            return true
+        end
+    end
+
+    -- Else, let the parent handle it.
+    return QCMDDialog.super.onInput(self, keys)
 end
 
 function QCMDDialog:onAddCommand()
@@ -146,10 +144,8 @@ function QCMDDialog:onAddCommand()
         COLOR_GREEN,
         '',
         function(command)
-            dfhack.persistent.save({
-                key = STORAGEKEY,
-                value = command
-            }, true)
+            table.insert(self.commands, command)
+            save_commands(self.commands)
             self:updateList()
         end
     )
@@ -165,10 +161,11 @@ function QCMDDialog:onDelCommand()
     -- Prompt for confirmation.
     dlg.showYesNoPrompt(
         'Delete command',
-        'Are you sure you want to delete this command: ' .. NEWLINE .. item.entry.value,
+        'Are you sure you want to delete this command: ' .. NEWLINE .. item.command,
         COLOR_GREEN,
         function()
-            item.entry:delete()
+            table.remove(self.commands, index)
+            save_commands(self.commands)
             self:updateList()
         end
     )
@@ -186,14 +183,21 @@ function QCMDDialog:onEditCommand()
         'Edit command',
         'Enter command:',
         COLOR_GREEN,
-        item.entry.value,
+        item.command,
         function(command)
-            item.entry.value = command
-            item.entry:save()
+            self.commands[index] = command
+            save_commands(self.commands)
             self:updateList()
         end
     )
 end
 
-local screen = QCMDDialog{}
-screen:show()
+function QCMDDialog:onRenderFrame()
+    self:renderParent()
+end
+
+function QCMDDialog:onDismiss()
+    view = nil
+end
+
+view = view or QCMDDialog{}:show()


### PR DESCRIPTION
- convert into a movable, resizable, mouse-enabled window
- run commands by selecting them in the list with the keyboard or mouse
- don't limit to 26 commands
- store commands globally, not per save
- displayed commands are no longer truncated to just a few characters

Fixes DFHack/dfhack#1112
Fixes DFHack/dfhack#2268