### PR TITLE
update gui/pathable to work with the new maps

### DIFF
--- a/docs/gui/pathable.rst
+++ b/docs/gui/pathable.rst
@@ -2,31 +2,40 @@ gui/pathable
 ============
 
 .. dfhack-tool::
-    :summary: Highlights reachable tiles.
+    :summary: Highlights tiles reachable from the selected tile.
     :tags: fort inspection map
 
 This tool highlights each visible map tile to indicate whether it is possible to
-path to that tile from the tile at the cursor. You can move the cursor around
-and the highlight will change dynamically. The highlight is green if pathing is
-possible and red if not, similar to the highlight DF uses to indicate which
-tiles can reach the trade depot.
+path to that tile from the tile under the mouse cursor. You can move the mouse
+around and the highlight will change dynamically.
+
+If graphics are enabled, then tiles show a small yellow box if they are pathable
+and a small black box if not.
+
+In ASCII mode, the tiles are highlighted in green if pathing is possible and red
+if not.
 
 While the UI is active, you can use the following hotkeys to change the
 behavior:
 
-- :kbd:`l`: Lock cursor: when enabled, the movement keys move the map instead of
-    moving the cursor. This is useful to check whether parts of the map far away
-    from the cursor can be pathed to from the cursor.
-- :kbd:`d`: Draw: allows temporarily disabling the highlighting entirely. This
-    allows you to see the map in its regular shading, if desired.
-- :kbd:`u`: Skip unrevealed: when enabled, unrevealed tiles will not be
-    highlighted at all. (These would otherwise be highlighted in red.)
+- :kbd:`Ctrl`:kbd:`l`: Lock target: when enabled, you can move the map around
+  and the target tile will not change. This is useful to check whether parts of
+  the map far away from the target tile can be pathed to from the target tile.
+- :kbd:`Ctrl`:kbd:`d`: Draw: allows temporarily disabling the highlighting
+  entirely. This allows you to see the map without the highlights, if desired.
+- :kbd:`Ctrl`:kbd:`u`: Skip unrevealed: when enabled, unrevealed tiles will not
+  be highlighted at all instead of being highlighted as not pathable. This might
+  be useful to turn off if you want to see the pathability of unrevealed cavern
+  sections.
+
+You can drag the informational panel around while it is visible if it's in the
+way. You can also set the default panel position in `gui/overlay`.
 
 .. note::
     This tool uses a cache used by DF, which currently does *not* account for
-    climbing. If an area of the map is only accessible by climbing, this tool
-    may report it as inaccessible. Care should be taken when digging into the
-    upper levels of caverns, for example.
+    climbing or flying. If an area of the map is only accessible by climbing or
+    flying, this tool may report it as inaccessible. Care should be taken when
+    digging into the upper levels of caverns, for example.
 
 Usage
 -----


### PR DESCRIPTION
Depends on DFHack/dfhack#2539, DFHack/dfhack#2540, and DFHack/dfhack#2541

`gui/pathable` is now an `always_enabled` overlay widget so it can appear over the map but still allow the map to be interacted with normally (e.g. dragged around with the middle mouse button).

dialog elements now use library widgets instead of drawing directly to the screen so elements are mouse-interactive

The panel can be resized and dragged around the screen

hotkeys were changed to avoid conflicts with default keybindings, like `d` used to toggle drawing, but now that's a map scroll key. Moved all the hotkeys to Ctrl equivalents.

![image](https://user-images.githubusercontent.com/977482/210161874-bb478971-a3dc-4343-ba9c-4c93e33748af.png)