### PR TITLE
Convert gui tools to ZScreens

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,7 +27,7 @@ that repo.
 - `gui/gm-editor`: converted to a movable, resizable, mouse-enabled window
 - `gui/launcher`: now supports a smaller, minimal mode. click the toggle in the launcher UI or start in minimal mode via the ``Ctrl-Shift-P`` keybinding
 - `gui/launcher`: can now be dragged from anywhere on the window body
-- `gui/launcher`: now closes on r-click
+- `gui/launcher`: now remembers its size and position between invocations
 - `gui/gm-unit`: converted to a movable, resizable, mouse-enabled window
 - `gui/cp437-table`: converted to a movable, mouse-enabled window
 - `gui/quickcmd`: converted to a movable, resizable, mouse-enabled window

--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,8 @@ that repo.
 - `unsuspend`: overlay now displays different letters for different suspend states so they can be differentiated in graphics mode (P=planning, x=suspended, X=repeatedly suspended)
 - `gui/gm-editor`: converted to a movable, resizable, mouse-enabled window
 - `gui/launcher`: now supports a smaller, minimal mode. click the toggle in the launcher UI or start in minimal mode via the ``Ctrl-Shift-P`` keybinding
+- `gui/launcher`: can now be dragged from anywhere on the window body
+- `gui/launcher`: now closes on r-click
 - `gui/gm-unit`: converted to a movable, resizable, mouse-enabled window
 - `gui/cp437-table`: converted to a movable, mouse-enabled window
 - `gui/quickcmd`: converted to a movable, resizable, mouse-enabled window

--- a/devel/inspect-screen.lua
+++ b/devel/inspect-screen.lua
@@ -315,7 +315,7 @@ function InspectScreen:onRenderFrame()
 end
 
 function InspectScreen:onInput(keys)
-    if keys.LEAVESCREEN then
+    if keys.LEAVESCREEN or keys._MOUSE_R_DOWN then
         self:dismiss()
         return true
     elseif keys._MOUSE_L_DOWN and not self:mouse_is_over_window() then

--- a/docs/gui/pathable.rst
+++ b/docs/gui/pathable.rst
@@ -7,7 +7,7 @@ gui/pathable
 
 This tool highlights each visible map tile to indicate whether it is possible to
 path to that tile from the tile under the mouse cursor. You can move the mouse
-around and the highlight will change dynamically.
+(and the map) around and the highlight will change dynamically.
 
 If graphics are enabled, then tiles show a small yellow box if they are pathable
 and a small black box if not.
@@ -29,7 +29,7 @@ behavior:
   sections.
 
 You can drag the informational panel around while it is visible if it's in the
-way. You can also set the default panel position in `gui/overlay`.
+way.
 
 .. note::
     This tool uses a cache used by DF, which currently does *not* account for

--- a/gui/cp437-table.lua
+++ b/gui/cp437-table.lua
@@ -7,7 +7,8 @@ local widgets = require('gui.widgets')
 CPDialog = defclass(CPDialog, widgets.Window)
 CPDialog.ATTRS {
     focus_path='cp437-table',
-    frame_title = 'CP437 table',
+    frame_title='CP437 table',
+    drag_anchors={frame=true, body=true},
     frame={w=36, h=17},
 }
 

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -376,8 +376,9 @@ MainPanel = defclass(MainPanel, widgets.Window)
 MainPanel.ATTRS{
     frame_title=TITLE,
     frame_inset=0,
+    drag_anchors={title=true, body=true},
     resizable=true,
-    resize_min={w=AUTOCOMPLETE_PANEL_WIDTH+45, h=EDIT_PANEL_HEIGHT+20},
+    resize_min={w=AUTOCOMPLETE_PANEL_WIDTH+49, h=EDIT_PANEL_HEIGHT+20},
     get_minimal=DEFAULT_NIL,
 }
 
@@ -657,9 +658,9 @@ end
 function LauncherUI:onInput(keys)
     if self:inputToSubviews(keys) then
         return true
-    elseif keys.LEAVESCREEN then
+    end
+    if keys.LEAVESCREEN or keys._MOUSE_R_DOWN then
         self:dismiss()
-        return true
     elseif keys.CUSTOM_CTRL_C then
         if self.focus_group.cur == self.subviews.editfield then
             self.subviews.edit:set_text('')
@@ -674,7 +675,10 @@ function LauncherUI:onInput(keys)
         self.subviews.autocomplete:advance(1)
     elseif keys.KEYBOARD_CURSOR_LEFT_FAST then
         self.subviews.autocomplete:advance(-1)
+    elseif not self.subviews.main:getMousePos() and (keys._MOUSE_L or keys._MOUSE_M) then
+        gui.simulateInput(self._native.parent, keys)
     end
+    return true
 end
 
 local function getAny(scr, thing)

--- a/gui/pathable.lua
+++ b/gui/pathable.lua
@@ -5,7 +5,7 @@ local gui = require('gui')
 local plugin = require('plugins.pathable')
 local widgets = require('gui.widgets')
 
-Pathable = defclass(Pathable, gui.Screen)
+Pathable = defclass(Pathable, gui.ZScreen)
 Pathable.ATTRS{
     focus_path='pathable',
 }
@@ -57,10 +57,6 @@ function Pathable:init()
     self:addviews{window}
 end
 
-function Pathable:onRenderFrame()
-    self:renderParent()
-end
-
 function Pathable:onRenderBody()
     local target = self.subviews.lock:getOptionValue() and
             self.saved_target or dfhack.gui.getMousePos()
@@ -86,16 +82,8 @@ function Pathable:onRenderBody()
     end
 end
 
-function Pathable:onInput(keys)
-    if self:inputToSubviews(keys) then
-        return true
-    end
-    if keys._MOUSE_R_DOWN then
-        self:dismiss()
-        return true
-    end
-    gui.simulateInput(self._native.parent, keys)
-    return true
+function Pathable:isMouseOver()
+    return self.subviews.main:getMouseFramePos()
 end
 
 function Pathable:onDismiss()

--- a/gui/pathable.lua
+++ b/gui/pathable.lua
@@ -1,28 +1,24 @@
 -- View whether tiles on the map can be pathed to
---@module = true
+--@module=true
 
 local gui = require('gui')
-local overlay = require('plugins.overlay')
 local plugin = require('plugins.pathable')
 local widgets = require('gui.widgets')
 
-Pathable = defclass(Pathable, overlay.OverlayWidget)
+Pathable = defclass(Pathable, gui.Screen)
 Pathable.ATTRS{
-    viewscreens='dwarfmode',
-    default_pos={x=-3, y=20},
-    frame_title='Pathability viewer',
-    frame_style=gui.GREY_LINE_FRAME,
-    frame_background=gui.CLEAR_PEN,
-    frame={w=32, h=11},
-    draggable=true,
-    drag_anchors={title=true, body=true},
-    resizable=true,
-    frame_inset=1,
-    always_enabled=true,
+    focus_path='pathable',
 }
 
 function Pathable:init()
-    self:addviews{
+    local window = widgets.Window{
+        view_id='main',
+        frame={t=20, r=3, w=32, h=11},
+        frame_title='Pathability Viewer',
+        drag_anchors={title=true, frame=true, body=true},
+    }
+
+    window:addviews{
         widgets.ToggleHotkeyLabel{
             view_id='lock',
             frame={t=0, l=0},
@@ -54,27 +50,15 @@ function Pathable:init()
             frame={t=6, l=0},
             key='LEAVESCREEN',
             label='Close',
-            on_activate=self:callback('overlay_trigger'),
+            on_activate=self:callback('dismiss'),
         },
     }
+
+    self:addviews{window}
 end
 
-function Pathable:overlay_trigger()
-    if not dfhack.isMapLoaded() then
-        if not self.triggered then
-            dfhack.printerr('gui/pathable requires a fortress map to be loaded')
-        end
-        self.triggered = false
-        return
-    end
-
-    self.subviews.lock.option_idx = 2
-    self.triggered = not self.triggered
-end
-
-function Pathable:render(dc)
-    if not self.triggered then return end
-    Pathable.super.render(self, dc)
+function Pathable:onRenderFrame()
+    self:renderParent()
 end
 
 function Pathable:onRenderBody()
@@ -103,20 +87,28 @@ function Pathable:onRenderBody()
 end
 
 function Pathable:onInput(keys)
-    if not self.triggered then return end
-
-    if keys._MOUSE_R_DOWN then
-        self:overlay_trigger()
+    if self:inputToSubviews(keys) then
         return true
     end
-
-    return Pathable.super.onInput(self, keys)
+    if keys._MOUSE_R_DOWN then
+        self:dismiss()
+        return true
+    end
+    gui.simulateInput(self._native.parent, keys)
+    return true
 end
 
-OVERLAY_WIDGETS = {overlay=Pathable}
+function Pathable:onDismiss()
+    view = nil
+end
 
 if dfhack_flags.module then
     return
 end
 
-dfhack.run_command('overlay trigger gui/pathable.overlay')
+if not dfhack.isMapLoaded() then
+    dfhack.printerr('gui/pathable requires a fortress map to be loaded')
+    return
+end
+
+view = view or Pathable{}:show()

--- a/gui/prerelease-warning.lua
+++ b/gui/prerelease-warning.lua
@@ -1,15 +1,4 @@
 -- Shows the warning about missing configuration file.
---[====[
-
-gui/prerelease-warning
-======================
-Shows a warning on world load for pre-release builds.
-
-With no arguments passed, the warning is shown unless the "do not show again"
-option has been selected. With the ``force`` argument, the warning is always
-shown.
-
-]====]
 
 local gui = require 'gui'
 local dlg = require 'gui.dialogs'


### PR DESCRIPTION
let the game run uninterruped while DFHack tools are on the screen and allow DFHack tool windows to swap z-order. this allows, for example, map elements to be interacted with and the map itself to be dragged around while tool windows are up.

Depends on DFHack/dfhack#2556