### PR TITLE
tag untested scripts with "untested" tag

### DIFF
--- a/docs/adaptation.rst
+++ b/docs/adaptation.rst
@@ -3,7 +3,7 @@ adaptation
 
 .. dfhack-tool::
     :summary: Adjust a unit's cave adaptation level.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 View or set level of cavern adaptation for the selected unit or the whole fort.
 

--- a/docs/add-recipe.rst
+++ b/docs/add-recipe.rst
@@ -3,7 +3,7 @@ add-recipe
 
 .. dfhack-tool::
     :summary: Add crafting recipes to a civ.
-    :tags: adventure fort gameplay
+    :tags: untested adventure fort gameplay
 
 Civilizations pick randomly from a pool of possible recipes, which means not all
 civs get high boots, for instance. This script can help fix that. Only weapons,

--- a/docs/add-thought.rst
+++ b/docs/add-thought.rst
@@ -3,7 +3,7 @@ add-thought
 
 .. dfhack-tool::
     :summary: Adds a thought to the selected unit.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 Usage
 -----

--- a/docs/adv-fix-sleepers.rst
+++ b/docs/adv-fix-sleepers.rst
@@ -3,7 +3,7 @@ adv-fix-sleepers
 
 .. dfhack-tool::
     :summary: Fix units who refuse to awaken in adventure mode.
-    :tags: adventure bugfix units
+    :tags: untested adventure bugfix units
 
 Use this tool if you encounter sleeping units who refuse to awaken regardless of
 talking to them, hitting them, or waiting so long you die of thirst

--- a/docs/adv-max-skills.rst
+++ b/docs/adv-max-skills.rst
@@ -3,7 +3,7 @@ adv-max-skills
 
 .. dfhack-tool::
     :summary: Raises adventurer stats to max.
-    :tags: adventure embark armok
+    :tags: untested adventure embark armok
 
 When creating an adventurer, raises all changeable skills and attributes to
 their maximum level.

--- a/docs/adv-rumors.rst
+++ b/docs/adv-rumors.rst
@@ -3,7 +3,7 @@ adv-rumors
 
 .. dfhack-tool::
     :summary: Improves the rumors menu in adventure mode.
-    :tags: adventure interface
+    :tags: untested adventure interface
 
 In adventure mode, start a conversation with someone and then run this tool
 to improve the "Bring up specific incident or rumor" menu. Specifically, this

--- a/docs/animal-control.rst
+++ b/docs/animal-control.rst
@@ -3,7 +3,7 @@ animal-control
 
 .. dfhack-tool::
     :summary: Quickly view, butcher, or geld groups of animals.
-    :tags: fort productivity animals
+    :tags: untested fort productivity animals
 
 Animal control is useful for browsing through your animals and deciding which
 to butcher or geld based on their stats.

--- a/docs/armoks-blessing.rst
+++ b/docs/armoks-blessing.rst
@@ -3,7 +3,7 @@ armoks-blessing
 
 .. dfhack-tool::
     :summary: Bless units with superior stats and traits.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 Runs the equivalent of `rejuvenate`, `elevate-physical`, `elevate-mental`, and
 `brainwash` on all dwarves currently on the map. This is an extreme change,

--- a/docs/assign-attributes.rst
+++ b/docs/assign-attributes.rst
@@ -3,7 +3,7 @@ assign-attributes
 
 .. dfhack-tool::
     :summary: Adjust physical and mental attributes.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 Attributes are divided into tiers from -4 to 4. Tier 0 is the standard level and
 represents the average values for that attribute, tier 4 is the maximum level,

--- a/docs/assign-beliefs.rst
+++ b/docs/assign-beliefs.rst
@@ -3,7 +3,7 @@ assign-beliefs
 
 .. dfhack-tool::
     :summary: Adjust a unit's beliefs and values.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 Beliefs are defined with the belief token and a number from -3 to 3,
 which describes the different levels of belief strength, as explained on the

--- a/docs/assign-facets.rst
+++ b/docs/assign-facets.rst
@@ -3,7 +3,7 @@ assign-facets
 
 .. dfhack-tool::
     :summary: Adjust a unit's facets and traits.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 Facets are defined with a token and a number from -3 to 3, which describes
 the different levels of facet strength, as explained on the

--- a/docs/assign-goals.rst
+++ b/docs/assign-goals.rst
@@ -3,7 +3,7 @@ assign-goals
 
 .. dfhack-tool::
     :summary: Adjust a unit's goals and dreams.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 Goals are defined with a goal token and a flag indicating whether the goal has
 been achieved. For now, this flag should always be set to false. For a list of

--- a/docs/assign-minecarts.rst
+++ b/docs/assign-minecarts.rst
@@ -3,7 +3,7 @@ assign-minecarts
 
 .. dfhack-tool::
     :summary: Assign minecarts to hauling routes.
-    :tags: fort productivity
+    :tags: untested fort productivity
 
 This script allows you to assign minecarts to hauling routes without having to
 use the in-game interface.

--- a/docs/assign-preferences.rst
+++ b/docs/assign-preferences.rst
@@ -3,7 +3,7 @@ assign-preferences
 
 .. dfhack-tool::
     :summary: Adjust a unit's preferences.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 You will need to know the token of the object you want your dwarf to like.
 You can find them in the wiki, otherwise in the folder "/raw/objects/" under

--- a/docs/assign-profile.rst
+++ b/docs/assign-profile.rst
@@ -3,7 +3,7 @@ assign-profile
 
 .. dfhack-tool::
     :summary: Adjust characteristics of a unit according to saved profiles.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 This tool can load a profile stored in a JSON file and apply the
 characteristics to a unit.

--- a/docs/assign-skills.rst
+++ b/docs/assign-skills.rst
@@ -3,7 +3,7 @@ assign-skills
 
 .. dfhack-tool::
     :summary: Adjust a unit's skills.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 Skills are defined by their token and their rank. You can see a list of valid
 skill tokens by running ``devel/query --table df.job_skill`` or by browsing the

--- a/docs/autolabor-artisans.rst
+++ b/docs/autolabor-artisans.rst
@@ -3,7 +3,7 @@ autolabor-artisans
 
 .. dfhack-tool::
     :summary: Configures autolabor to produce artisan dwarves.
-    :tags: fort auto labors
+    :tags: untested fort labors
 
 This script runs an `autolabor` command for all labors where skill level
 influences output quality (e.g. Carpentry, Stone detailing, Weaponsmithing,

--- a/docs/autonick.rst
+++ b/docs/autonick.rst
@@ -3,7 +3,7 @@ autonick
 
 .. dfhack-tool::
     :summary: Give dwarves random unique nicknames.
-    :tags: fort productivity units
+    :tags: untested fort productivity units
 
 Names are chosen randomly from the ``dfhack-config/autonick.txt`` config file,
 which you can edit with your own preferred names, if you like.

--- a/docs/binpatch.rst
+++ b/docs/binpatch.rst
@@ -3,7 +3,7 @@ binpatch
 
 .. dfhack-tool::
     :summary: Applies or removes binary patches.
-    :tags: dev
+    :tags: untested dev
 
 See `binpatches` for more info.
 

--- a/docs/bodyswap.rst
+++ b/docs/bodyswap.rst
@@ -3,7 +3,7 @@ bodyswap
 
 .. dfhack-tool::
     :summary: Take direct control of any visible unit.
-    :tags: adventure armok units
+    :tags: untested adventure armok units
 
 This script allows the player to take direct control of any unit present in
 adventure mode whilst giving up control of their current player character.

--- a/docs/brainwash.rst
+++ b/docs/brainwash.rst
@@ -3,7 +3,7 @@ brainwash
 
 .. dfhack-tool::
     :summary: Set the personality of a dwarf to an ideal.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 Modify the traits of the selected dwarf to match an idealized personality: as
 stable and reliable as possible to prevent tantrums even after months of misery.

--- a/docs/break-dance.rst
+++ b/docs/break-dance.rst
@@ -3,7 +3,7 @@ break-dance
 
 .. dfhack-tool::
     :summary: Fixes buggy tavern dances.
-    :tags: fort bugfix units
+    :tags: untested fort bugfix units
 
 Sometimes when a unit can't find a dance partner, the dance becomes stuck and
 never stops. This tool can get them unstuck.

--- a/docs/build-now.rst
+++ b/docs/build-now.rst
@@ -3,7 +3,7 @@ build-now
 
 .. dfhack-tool::
     :summary: Instantly completes building construction jobs.
-    :tags: fort armok buildings
+    :tags: untested fort armok buildings
 
 By default, all unsuspended buildings on the map are completed, but the area of
 effect is configurable.

--- a/docs/burial.rst
+++ b/docs/burial.rst
@@ -3,7 +3,7 @@ burial
 
 .. dfhack-tool::
     :summary: Configures all unowned coffins to allow burial.
-    :tags: fort productivity buildings
+    :tags: untested fort productivity buildings
 
 Usage
 -----

--- a/docs/cannibalism.rst
+++ b/docs/cannibalism.rst
@@ -3,7 +3,7 @@ cannibalism
 
 .. dfhack-tool::
     :summary: Allows a player character to consume sapient corpses.
-    :tags: adventure gameplay
+    :tags: untested adventure gameplay
 
 This tool clears the flag from items that mark them as being from a sapient
 creature. Use from an adventurer's inventory screen or an individual item's

--- a/docs/caravan.rst
+++ b/docs/caravan.rst
@@ -3,7 +3,7 @@ caravan
 
 .. dfhack-tool::
     :summary: Adjust properties of caravans on the map.
-    :tags: fort armok bugfix
+    :tags: untested fort armok bugfix
 
 This tool can help with caravans that are leaving too quickly, refuse to unload,
 or are just plain unhappy that you are such a poor negotiator.

--- a/docs/catsplosion.rst
+++ b/docs/catsplosion.rst
@@ -3,7 +3,7 @@ catsplosion
 
 .. dfhack-tool::
     :summary: Cause pregnancies.
-    :tags: fort armok animals
+    :tags: untested fort armok animals
 
 This tool makes cats (or anything else) immediately pregnant. If you value your
 fps, it is a good idea to use this tool sparingly.

--- a/docs/clear-smoke.rst
+++ b/docs/clear-smoke.rst
@@ -3,7 +3,7 @@ clear-smoke
 
 .. dfhack-tool::
     :summary: Removes all smoke from the map.
-    :tags: fort armok fps map
+    :tags: untested fort armok fps map
 
 Note that this can leak memory and should be used sparingly.
 

--- a/docs/clear-webs.rst
+++ b/docs/clear-webs.rst
@@ -3,7 +3,7 @@ clear-webs
 
 .. dfhack-tool::
     :summary: Removes all webs from the map.
-    :tags: adventure fort armok map units
+    :tags: untested adventure fort armok map units
 
 In addition to removing webs, this tool also frees any creatures who have been
 caught in one. Usable in both fortress and adventurer mode.

--- a/docs/colonies.rst
+++ b/docs/colonies.rst
@@ -3,7 +3,7 @@ colonies
 
 .. dfhack-tool::
     :summary: Manipulate vermin colonies and hives.
-    :tags: fort armok map
+    :tags: untested fort armok map
 
 Usage
 -----

--- a/docs/color-schemes.rst
+++ b/docs/color-schemes.rst
@@ -3,7 +3,7 @@ color-schemes
 
 .. dfhack-tool::
     :summary: Modify the colors used by the DF UI.
-    :tags: fort gameplay graphics
+    :tags: untested fort gameplay graphics
 
 This tool allows you to set exactly which shades of colors should be used in the
 DF interface color palette.

--- a/docs/combat-harden.rst
+++ b/docs/combat-harden.rst
@@ -3,7 +3,7 @@ combat-harden
 
 .. dfhack-tool::
     :summary: Set the combat-hardened value on a unit.
-    :tags: fort armok military units
+    :tags: untested fort armok military units
 
 This tool can make a unit care more/less about seeing corpses.
 

--- a/docs/combine-drinks.rst
+++ b/docs/combine-drinks.rst
@@ -3,7 +3,7 @@ combine-drinks
 
 .. dfhack-tool::
     :summary: Merge stacks of drinks in the selected stockpile.
-    :tags: fort productivity items
+    :tags: untested fort productivity items
 
 Usage
 -----

--- a/docs/combine-plants.rst
+++ b/docs/combine-plants.rst
@@ -3,7 +3,7 @@ combine-plants
 
 .. dfhack-tool::
     :summary: Merge stacks of plants in the selected container or stockpile.
-    :tags: fort productivity items plants
+    :tags: untested fort productivity items plants
 
 Usage
 -----

--- a/docs/create-items.rst
+++ b/docs/create-items.rst
@@ -3,7 +3,7 @@ create-items
 
 .. dfhack-tool::
     :summary: Spawn items under the cursor.
-    :tags: fort armok items
+    :tags: untested fort armok items
 
 This script is handy to create basic resources you need to get your fortress
 started.

--- a/docs/deep-embark.rst
+++ b/docs/deep-embark.rst
@@ -3,7 +3,7 @@ deep-embark
 
 .. dfhack-tool::
     :summary: Start a fort deep underground.
-    :tags: embark fort gameplay
+    :tags: untested embark fort gameplay
 
 Moves the starting units and equipment to a specified underground region upon
 embarking so you can start your fort from there.

--- a/docs/deteriorate.rst
+++ b/docs/deteriorate.rst
@@ -3,7 +3,7 @@ deteriorate
 
 .. dfhack-tool::
     :summary: Cause corpses, clothes, and/or food to rot away over time.
-    :tags: fort auto fps gameplay items plants
+    :tags: untested fort auto fps gameplay items plants
 
 When enabled, this script will cause the specified item types to slowly rot
 away. By default, items disappear after a few months, but you can choose to slow

--- a/docs/devel/all-bob.rst
+++ b/docs/devel/all-bob.rst
@@ -3,7 +3,7 @@ devel/all-bob
 
 .. dfhack-tool::
     :summary: Changes the first name of all units to "Bob"..
-    :tags: dev
+    :tags: untested dev
 
 Useful for testing `modtools/interaction-trigger` events.
 

--- a/docs/devel/annc-monitor.rst
+++ b/docs/devel/annc-monitor.rst
@@ -3,7 +3,7 @@ devel/annc-monitor
 
 .. dfhack-tool::
     :summary: Track announcements and reports and echo them to the console.
-    :tags: dev
+    :tags: untested dev
 
 This tool monitors announcements and reports and echoes their contents to the
 console.

--- a/docs/devel/block-borders.rst
+++ b/docs/devel/block-borders.rst
@@ -3,7 +3,7 @@ devel/block-borders
 
 .. dfhack-tool::
     :summary: Outline map blocks on the map screen.
-    :tags: dev map
+    :tags: untested dev map
 
 This tool displays an overlay that highlights the borders of map blocks. See
 :doc:`/docs/api/Maps` for details on map blocks.

--- a/docs/devel/check-other-ids.rst
+++ b/docs/devel/check-other-ids.rst
@@ -3,7 +3,7 @@ devel/check-other-ids
 
 .. dfhack-tool::
     :summary: Verify that game entities are referenced by the correct vectors.
-    :tags: dev
+    :tags: untested dev
 
 This script runs through all ``world.items.other`` and ``world.buildings.other`` vectors
 and verifies that the items contained in them have the expected types.

--- a/docs/devel/check-release.rst
+++ b/docs/devel/check-release.rst
@@ -3,7 +3,7 @@ devel/check-release
 
 .. dfhack-tool::
     :summary: Perform basic checks for DFHack release readiness.
-    :tags: dev
+    :tags: untested dev
 
 This script is run as part of the DFHack release process to check that release
 flags are properly set.

--- a/docs/devel/clear-script-env.rst
+++ b/docs/devel/clear-script-env.rst
@@ -3,7 +3,7 @@ devel/clear-script-env
 
 .. dfhack-tool::
     :summary: Clear a lua script environment.
-    :tags: dev
+    :tags: untested dev
 
 This tool can clear the environment of the specified lua script(s). This is
 useful during development since if you remove a global function, an old version

--- a/docs/devel/click-monitor.rst
+++ b/docs/devel/click-monitor.rst
@@ -3,7 +3,7 @@ devel/click-monitor
 
 .. dfhack-tool::
     :summary: Displays the grid coordinates of mouse clicks in the console.
-    :tags: dev
+    :tags: untested dev
 
 This tool will watch for mouse activity and print relevant information to the
 console. Useful for plugin/script development.

--- a/docs/devel/cmptiles.rst
+++ b/docs/devel/cmptiles.rst
@@ -3,7 +3,7 @@ devel/cmptiles
 
 .. dfhack-tool::
     :summary: List or compare two tiletype material groups.
-    :tags: dev inspection
+    :tags: untested dev
 
 Lists and/or compares two tiletype material groups. You can see the list of
 valid material groups by running::

--- a/docs/devel/dump-offsets.rst
+++ b/docs/devel/dump-offsets.rst
@@ -3,7 +3,7 @@ devel/dump-offsets
 
 .. dfhack-tool::
     :summary: Dump the contents of the table of global addresses.
-    :tags: dev
+    :tags: untested dev
 
 .. warning::
 

--- a/docs/devel/export-dt-ini.rst
+++ b/docs/devel/export-dt-ini.rst
@@ -3,7 +3,7 @@ devel/export-dt-ini
 
 .. dfhack-tool::
     :summary: Export memory addresses for Dwarf Therapist configuration.
-    :tags: dev
+    :tags: untested dev
 
 This tool exports an ini file containing memory addresses for Dwarf Therapist.
 

--- a/docs/devel/find-offsets.rst
+++ b/docs/devel/find-offsets.rst
@@ -3,7 +3,7 @@ devel/find-offsets
 
 .. dfhack-tool::
     :summary: Find memory offsets of DF data structures.
-    :tags: dev
+    :tags: untested dev
 
 .. warning::
 

--- a/docs/devel/find-primitive.rst
+++ b/docs/devel/find-primitive.rst
@@ -3,7 +3,7 @@ devel/find-primitive
 
 .. dfhack-tool::
     :summary: Discover memory offsets for new variables.
-    :tags: dev
+    :tags: untested dev
 
 This tool helps find a primitive variable in DF's data section, relying on the
 user to change its value and then scanning for memory that has changed to that

--- a/docs/devel/find-twbt.rst
+++ b/docs/devel/find-twbt.rst
@@ -3,7 +3,7 @@ devel/find-twbt
 
 .. dfhack-tool::
     :summary: Display the memory offsets of some important TWBT functions.
-    :tags: dev
+    :tags: untested dev
 
 Finds some TWBT-related offsets - currently just ``twbt_render_map``.
 

--- a/docs/devel/hello-world.rst
+++ b/docs/devel/hello-world.rst
@@ -3,7 +3,7 @@ devel/hello-world
 
 .. dfhack-tool::
     :summary: A basic GUI example script.
-    :tags: dev
+    :tags: untested dev
 
 A basic example for testing, or to start your own script from.
 

--- a/docs/devel/inject-raws.rst
+++ b/docs/devel/inject-raws.rst
@@ -3,7 +3,7 @@ devel/inject-raws
 
 .. dfhack-tool::
     :summary: Add objects and reactions into an existing world.
-    :tags: dev
+    :tags: untested dev
 
 WARNING: THIS SCRIPT CAN PERMANENTLY DAMAGE YOUR SAVE.
 

--- a/docs/devel/kill-hf.rst
+++ b/docs/devel/kill-hf.rst
@@ -3,7 +3,7 @@ devel/kill-hf
 
 .. dfhack-tool::
     :summary: Kill a historical figure.
-    :tags: dev
+    :tags: untested dev
 
 This tool can kill the specified historical figure, even if off-site, or
 terminate a pregnancy. Useful for working around :bug:`11549`.

--- a/docs/devel/light.rst
+++ b/docs/devel/light.rst
@@ -3,7 +3,7 @@ devel/light
 
 .. dfhack-tool::
     :summary: Experiment with lighting overlays.
-    :tags: dev graphics
+    :tags: untested dev graphics
 
 This is an experimental lighting engine for DF, using the `rendermax` plugin.
 

--- a/docs/devel/list-filters.rst
+++ b/docs/devel/list-filters.rst
@@ -3,7 +3,7 @@ devel/list-filters
 
 .. dfhack-tool::
     :summary: List input items for the selected building type.
-    :tags: dev
+    :tags: untested dev
 
 This tool lists input items for the building that is currently being built. You
 must be in build mode and have a building type selected for placement. This is

--- a/docs/devel/lsmem.rst
+++ b/docs/devel/lsmem.rst
@@ -3,7 +3,7 @@ devel/lsmem
 
 .. dfhack-tool::
     :summary: Print memory ranges of the DF process.
-    :tags: dev
+    :tags: untested dev
 
 Useful for checking whether a pointer is valid, whether a certain library/plugin
 is loaded, etc.

--- a/docs/devel/lua-example.rst
+++ b/docs/devel/lua-example.rst
@@ -3,7 +3,7 @@ devel/lua-example
 
 .. dfhack-tool::
     :summary: An example lua script.
-    :tags: dev
+    :tags: untested dev
 
 This is an example Lua script which just reports the number of times it has been
 called. Useful for testing environment persistence.

--- a/docs/devel/luacov.rst
+++ b/docs/devel/luacov.rst
@@ -3,7 +3,7 @@ devel/luacov
 
 .. dfhack-tool::
     :summary: Lua script coverage report generator.
-    :tags: dev
+    :tags: untested dev
 
 This script generates a coverage report from collected statistics. By default it
 reports on every Lua file in all of DFHack. To filter filenames, specify one or

--- a/docs/devel/modstate-monitor.rst
+++ b/docs/devel/modstate-monitor.rst
@@ -3,7 +3,7 @@ devel/modstate-monitor
 
 .. dfhack-tool::
     :summary: Display changes in key modifier state.
-    :tags: dev
+    :tags: untested dev
 
 This tool will show changes in :kbd:`Ctrl`, :kbd:`Alt`, and :kbd:`Shift`
 modifier states.

--- a/docs/devel/nuke-items.rst
+++ b/docs/devel/nuke-items.rst
@@ -3,7 +3,7 @@ devel/nuke-items
 
 .. dfhack-tool::
     :summary: Deletes all free items in the game.
-    :tags: dev fps items
+    :tags: untested dev fps items
 
 This tool deletes **ALL** items not referred to by units, buildings, or jobs.
 Intended solely for lag investigation.

--- a/docs/devel/prepare-save.rst
+++ b/docs/devel/prepare-save.rst
@@ -3,7 +3,7 @@ devel/prepare-save
 
 .. dfhack-tool::
     :summary: Set internal game state to known values for memory analysis.
-    :tags: dev
+    :tags: untested dev
 
 .. warning::
 

--- a/docs/devel/print-args.rst
+++ b/docs/devel/print-args.rst
@@ -3,7 +3,7 @@ devel/print-args
 
 .. dfhack-tool::
     :summary: Echo parameters to the output.
-    :tags: dev
+    :tags: untested dev
 
 Prints all the arguments you supply to the script, one per line.
 

--- a/docs/devel/print-args2.rst
+++ b/docs/devel/print-args2.rst
@@ -3,7 +3,7 @@ devel/print-args2
 
 .. dfhack-tool::
     :summary: Echo parameters to the output.
-    :tags: dev
+    :tags: untested dev
 
 Prints all the arguments you supply to the script, one per line, with quotes
 around them.

--- a/docs/devel/print-event.rst
+++ b/docs/devel/print-event.rst
@@ -3,7 +3,7 @@ devel/print-event
 
 .. dfhack-tool::
     :summary: Show historical events.
-    :tags: dev inspection
+    :tags: untested dev
 
 This tool displays the description of a historical event.
 

--- a/docs/devel/query.rst
+++ b/docs/devel/query.rst
@@ -3,7 +3,7 @@ devel/query
 
 .. dfhack-tool::
     :summary: Search/print data algorithmically.
-    :tags: dev inspection
+    :tags: untested dev inspection
 
 Query is a useful script for finding and reading values of data structure
 fields. Players can use it to explore data structures or list elements of enums

--- a/docs/devel/save-version.rst
+++ b/docs/devel/save-version.rst
@@ -3,7 +3,7 @@ devel/save-version
 
 .. dfhack-tool::
     :summary: Display what DF version has handled the current save.
-    :tags: dev inspection
+    :tags: untested dev
 
 This tool displays the DF version that created the game, the most recent DF
 version that has loaded and saved the game, and the current DF version.

--- a/docs/devel/sc.rst
+++ b/docs/devel/sc.rst
@@ -3,7 +3,7 @@ devel/sc
 
 .. dfhack-tool::
     :summary: Scan DF structures for errors.
-    :tags: dev
+    :tags: untested dev
 
 Size Check: scans structures for invalid vectors, misaligned structures, and
 unidentified enum values.

--- a/docs/devel/scanitemother.rst
+++ b/docs/devel/scanitemother.rst
@@ -3,7 +3,7 @@ devel/scanitemother
 
 .. dfhack-tool::
     :summary: Display the item lists that the selected item is part of.
-    :tags: dev inspection
+    :tags: untested dev
 
 When an item is selected in the UI, this tool will list the indices in
 ``world.item.other[]`` where the item appears. For example, if a piece of good

--- a/docs/devel/send-key.rst
+++ b/docs/devel/send-key.rst
@@ -3,7 +3,7 @@ devel/send-key
 
 .. dfhack-tool::
     :summary: Deliver key input to a viewscreen.
-    :tags: dev interface
+    :tags: untested dev interface
 
 This tool can send a key to the current screen or to a parent screen. Note that
 if you are trying to dismiss a screen, `devel/pop-screen` may be more useful,

--- a/docs/devel/spawn-unit-helper.rst
+++ b/docs/devel/spawn-unit-helper.rst
@@ -3,7 +3,7 @@ devel/spawn-unit-helper
 
 .. dfhack-tool::
     :summary: Prepares the game for spawning creatures by switching to arena.
-    :tags: dev fort
+    :tags: untested dev
 
 This script initializes game state to allow you to switch to arena mode, spawn
 creatures, and then switch back to fortress mode.

--- a/docs/devel/test-perlin.rst
+++ b/docs/devel/test-perlin.rst
@@ -3,7 +3,7 @@ devel/test-perlin
 
 .. dfhack-tool::
     :summary: Generate an image based on perlin noise.
-    :tags: dev
+    :tags: untested dev
 
 Generates an image using multiple octaves of perlin noise.
 

--- a/docs/devel/unit-path.rst
+++ b/docs/devel/unit-path.rst
@@ -3,7 +3,7 @@ devel/unit-path
 
 .. dfhack-tool::
     :summary: Inspect where a unit is going and how it's getting there.
-    :tags: dev inspection
+    :tags: untested dev
 
 When run with a unit selected, the path that the unit is currently following is
 highlighted on the map. You can jump between the unit and the destination tile.

--- a/docs/devel/visualize-structure.rst
+++ b/docs/devel/visualize-structure.rst
@@ -3,7 +3,7 @@ devel/visualize-structure
 
 .. dfhack-tool::
     :summary: Display raw memory of a DF data structure.
-    :tags: dev inspection dfhack
+    :tags: untested dev
 
 Displays the raw memory of a structure, field by field. Useful for checking if
 structures are aligned.

--- a/docs/devel/watch-minecarts.rst
+++ b/docs/devel/watch-minecarts.rst
@@ -3,7 +3,7 @@ devel/watch-minecarts
 
 .. dfhack-tool::
     :summary: Inspect minecart coordinates and speeds.
-    :tags: dev inspection
+    :tags: untested dev
 
 When running, this tool will log minecart coordinates and speeds to the console.
 

--- a/docs/do-job-now.rst
+++ b/docs/do-job-now.rst
@@ -3,7 +3,7 @@ do-job-now
 
 .. dfhack-tool::
     :summary: Mark the job related to what you're looking at as high priority.
-    :tags: fort productivity jobs
+    :tags: untested fort productivity jobs
 
 The script will try its best to find a job related to the selected entity (which
 can be a job, dwarf, animal, item, building, plant or work order) and then mark

--- a/docs/dwarf-op.rst
+++ b/docs/dwarf-op.rst
@@ -3,7 +3,7 @@ dwarf-op
 
 .. dfhack-tool::
     :summary: Tune units to perform underrepresented job roles in your fortress.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 ``dwarf-op`` examines the distribution of skills and attributes across the
 dwarves in your fortress and can rewrite the characteristics of a dwarf (or

--- a/docs/elevate-mental.rst
+++ b/docs/elevate-mental.rst
@@ -3,7 +3,7 @@ elevate-mental
 
 .. dfhack-tool::
     :summary: Set mental attributes of a dwarf to an ideal.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 Set all mental attributes of the selected dwarf to the maximum possible, or
 any value between 0 and 5000.

--- a/docs/elevate-physical.rst
+++ b/docs/elevate-physical.rst
@@ -3,7 +3,7 @@ elevate-physical
 
 .. dfhack-tool::
     :summary: Set physical attributes of a dwarf to an ideal.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 Set all physical attributes of the selected dwarf to the maximum possible, or
 any value between 0 and 5000. Higher is usually better, but an ineffective

--- a/docs/embark-skills.rst
+++ b/docs/embark-skills.rst
@@ -3,7 +3,7 @@ embark-skills
 
 .. dfhack-tool::
     :summary: Adjust dwarves' skills when embarking.
-    :tags: embark fort armok units
+    :tags: untested embark fort armok units
 
 When selecting starting skills for your dwarves on the embark screen, this tool
 can manipulate the skill values or adjust the number of points you have

--- a/docs/emigration.rst
+++ b/docs/emigration.rst
@@ -3,7 +3,7 @@ emigration
 
 .. dfhack-tool::
     :summary: Allow dwarves to emigrate from the fortress when stressed.
-    :tags: fort auto gameplay units
+    :tags: untested fort auto gameplay units
 
 If a dwarf is spiraling downward and is unable to cope in your fort, this tool
 will give them the choice to leave the fortress (and the map).

--- a/docs/empty-bin.rst
+++ b/docs/empty-bin.rst
@@ -3,7 +3,7 @@ empty-bin
 
 .. dfhack-tool::
     :summary: Empty the contents of containers onto the floor.
-    :tags: fort productivity items
+    :tags: untested fort productivity items
 
 This tool can quickly empty the contents of the selected container (bin,
 barrel, or pot) onto the floor, allowing you to access individual items that

--- a/docs/exportlegends.rst
+++ b/docs/exportlegends.rst
@@ -3,7 +3,7 @@ exportlegends
 
 .. dfhack-tool::
     :summary: Exports legends data for external viewing.
-    :tags: legends inspection
+    :tags: untested legends inspection
 
 When run from legends mode, you can export detailed data about your world so
 that it can be browsed with external programs like

--- a/docs/exterminate.rst
+++ b/docs/exterminate.rst
@@ -3,7 +3,7 @@ exterminate
 
 .. dfhack-tool::
     :summary: Kills things.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 Kills any unit, or all units of a given race. You can target any unit on a
 revealed tile of the map, including ambushers, but caged/chained creatures are

--- a/docs/extinguish.rst
+++ b/docs/extinguish.rst
@@ -3,7 +3,7 @@ extinguish
 
 .. dfhack-tool::
     :summary: Put out fires.
-    :tags: fort armok buildings items map units
+    :tags: untested fort armok buildings items map units
 
 With this tool, you can put out fires affecting map tiles, plants, units, items,
 and buildings.

--- a/docs/feature.rst
+++ b/docs/feature.rst
@@ -3,7 +3,7 @@ feature
 
 .. dfhack-tool::
     :summary: Control discovery flags for map features.
-    :tags: fort armok map
+    :tags: untested fort armok map
 
 This tool allows you to toggle the flags that the game uses to track your
 discoveries of map features. For example, you can make the game think that you

--- a/docs/fillneeds.rst
+++ b/docs/fillneeds.rst
@@ -3,7 +3,7 @@ fillneeds
 
 .. dfhack-tool::
     :summary: Temporarily satisfy the needs of a unit.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 Use with a unit selected to make them focused and unstressed.
 

--- a/docs/firestarter.rst
+++ b/docs/firestarter.rst
@@ -3,7 +3,7 @@ firestarter
 
 .. dfhack-tool::
     :summary: Lights things on fire.
-    :tags: fort armok items map units
+    :tags: untested fort armok items map units
 
 Feel the need to burn something? Set items, locations, or even entire
 inventories on fire! Use while viewing an item, with the cursor over a map tile,

--- a/docs/fix-ster.rst
+++ b/docs/fix-ster.rst
@@ -3,7 +3,7 @@ fix-ster
 
 .. dfhack-tool::
     :summary: Toggle infertility for units.
-    :tags: fort armok animals
+    :tags: untested fort armok animals
 
 Now you can restore fertility to infertile creatures or inflict infertility on
 creatures that you do not want to breed.

--- a/docs/fix/corrupt-equipment.rst
+++ b/docs/fix/corrupt-equipment.rst
@@ -3,7 +3,7 @@ fix/corrupt-equipment
 
 .. dfhack-tool::
     :summary: Fixes some game crashes caused by corrupt military equipment.
-    :tags: fort bugfix military
+    :tags: untested fort bugfix military
 
 This fix corrects some kinds of corruption that can occur in equipment lists, as
 in :bug:`11014`. Run this script at least every time a squad comes back from a

--- a/docs/fix/dead-units.rst
+++ b/docs/fix/dead-units.rst
@@ -3,7 +3,7 @@ fix/dead-units
 
 .. dfhack-tool::
     :summary: Remove dead units from the list so migrants can arrive again.
-    :tags: fort bugfix units
+    :tags: untested fort bugfix units
 
 If so many units have died at your fort that your dead units list exceeds about
 3000 units, migrant waves can stop coming. This fix removes uninteresting units

--- a/docs/fix/drop-webs.rst
+++ b/docs/fix/drop-webs.rst
@@ -3,7 +3,7 @@ fix/drop-webs
 
 .. dfhack-tool::
     :summary: Make floating webs drop to the ground.
-    :tags: fort bugfix items
+    :tags: untested fort bugfix items
 
 Webs can be left floating in mid-air for a variety of reasons, such as getting
 caught in a tree and the tree subsequently being chopped down (:bug:`595`). This

--- a/docs/fix/dry-buckets.rst
+++ b/docs/fix/dry-buckets.rst
@@ -3,7 +3,7 @@ fix/dry-buckets
 
 .. dfhack-tool::
     :summary: Allow discarded water buckets to be used again.
-    :tags: fort bugfix items
+    :tags: untested fort bugfix items
 
 Sometimes, dwarves drop buckets of water on the ground if their water hauling
 job is interrupted. These buckets then become unavailable for any other kind of

--- a/docs/fix/item-occupancy.rst
+++ b/docs/fix/item-occupancy.rst
@@ -3,7 +3,7 @@ fix/item-occupancy
 
 .. dfhack-tool::
     :summary: Fixes errors with phantom items occupying site.
-    :tags: fort bugfix map
+    :tags: untested fort bugfix map
 
 This tool diagnoses and fixes issues with nonexistent 'items occupying site',
 usually caused by hacking mishaps with items being improperly moved about.

--- a/docs/fix/loyaltycascade.rst
+++ b/docs/fix/loyaltycascade.rst
@@ -3,7 +3,7 @@ fix/loyaltycascade
 
 .. dfhack-tool::
     :summary: Halts loyalty cascades where dwarves are fighting dwarves.
-    :tags: fort bugfix units
+    :tags: untested fort bugfix units
 
 This tool aborts loyalty cascades by fixing units who consider their own
 civilization to be the enemy.

--- a/docs/fix/population-cap.rst
+++ b/docs/fix/population-cap.rst
@@ -3,7 +3,7 @@ fix/population-cap
 
 .. dfhack-tool::
     :summary: Ensure the population cap is respected.
-    :tags: fort bugfix units
+    :tags: untested fort bugfix units
 
 Run this after every migrant wave to ensure your population cap is not exceeded.
 

--- a/docs/fix/retrieve-units.rst
+++ b/docs/fix/retrieve-units.rst
@@ -3,7 +3,7 @@ fix/retrieve-units
 
 .. dfhack-tool::
     :summary: Allow stuck offscreen units to enter the map.
-    :tags: fort bugfix units
+    :tags: untested fort bugfix units
 
 This script finds units that are marked as pending entry to the active map and
 forces them to enter. This can fix issues such as:

--- a/docs/fix/stable-temp.rst
+++ b/docs/fix/stable-temp.rst
@@ -3,7 +3,7 @@ fix/stable-temp
 
 .. dfhack-tool::
     :summary: Solve FPS issues caused by fluctuating temperature.
-    :tags: fort bugfix fps map
+    :tags: untested fort bugfix fps map
 
 This tool instantly sets the temperature of all free-lying items to be in
 equilibrium with the environment. This effectively halts FPS-draining

--- a/docs/fix/stuck-merchants.rst
+++ b/docs/fix/stuck-merchants.rst
@@ -3,7 +3,7 @@ fix/stuck-merchants
 
 .. dfhack-tool::
     :summary: Dismiss merchants that are stuck off the edge of the map.
-    :tags: fort bugfix units
+    :tags: untested fort bugfix units
 
 This tool dismisses merchants that haven't entered the map yet. This can fix
 :bug:`9593`. Where you get a trade caravan announcement, but no merchants ever

--- a/docs/fix/tile-occupancy.rst
+++ b/docs/fix/tile-occupancy.rst
@@ -3,7 +3,7 @@ fix/tile-occupancy
 
 .. dfhack-tool::
     :summary: Fix tile occupancy flags.
-    :tags: fort bugfix map
+    :tags: untested fort bugfix map
 
 This tool clears bad occupancy flags at the selected tile. It is useful for
 getting rid of phantom "building present" messages when trying to build

--- a/docs/fixnaked.rst
+++ b/docs/fixnaked.rst
@@ -3,7 +3,7 @@ fixnaked
 
 .. dfhack-tool::
     :summary: Removes all unhappy thoughts due to lack of clothing.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 If you're having trouble keeping your dwarves properly clothed and the stress is
 mounting, this tool can help you calm things down. ``fixnaked`` will go through

--- a/docs/flashstep.rst
+++ b/docs/flashstep.rst
@@ -3,7 +3,7 @@ flashstep
 
 .. dfhack-tool::
     :summary: Teleport your adventurer to the cursor.
-    :tags: adventure armok
+    :tags: untested adventure armok
 
 ``flashstep`` is a hotkey-friendly teleport that places your adventurer where
 your cursor is.

--- a/docs/force.rst
+++ b/docs/force.rst
@@ -3,7 +3,7 @@ force
 
 .. dfhack-tool::
     :summary: Trigger in-game events.
-    :tags: fort armok gameplay
+    :tags: untested fort armok gameplay
 
 This tool triggers events like megabeasts, caravans, and migrants. Note that you
 can only trigger one caravan per civ at the same time, and that DF may choose to

--- a/docs/forget-dead-body.rst
+++ b/docs/forget-dead-body.rst
@@ -3,7 +3,7 @@ forget-dead-body
 
 .. dfhack-tool::
     :summary: Removes emotions associated with seeing a dead body.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 This tool can help your dwarves recover from seeing a massacre. It removes all
 emotions associated with seeing a dead body. If your dwarves are traumatized and

--- a/docs/forum-dwarves.rst
+++ b/docs/forum-dwarves.rst
@@ -3,7 +3,7 @@ forum-dwarves
 
 .. dfhack-tool::
     :summary: Exports the text you see on the screen for posting to the forums.
-    :tags: dfhack
+    :tags: untested dfhack
 
 This tool saves a copy of a text screen, formatted in BBcode for posting to the
 Bay12 Forums. Text color and layout is preserved. See `markdown` if you want to

--- a/docs/full-heal.rst
+++ b/docs/full-heal.rst
@@ -3,7 +3,7 @@ full-heal
 
 .. dfhack-tool::
     :summary: Fully heal the selected unit.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 This script attempts to heal the selected unit from anything, optionally
 including death.

--- a/docs/gaydar.rst
+++ b/docs/gaydar.rst
@@ -3,7 +3,7 @@ gaydar
 
 .. dfhack-tool::
     :summary: Shows the sexual orientation of units.
-    :tags: fort inspection animals units
+    :tags: untested fort inspection animals units
 
 ``gaydar`` is useful for social engineering or checking the viability of
 livestock breeding programs.

--- a/docs/geld.rst
+++ b/docs/geld.rst
@@ -3,7 +3,7 @@ geld
 
 .. dfhack-tool::
     :summary: Geld and ungeld animals.
-    :tags: fort armok animals
+    :tags: untested fort armok animals
 
 Usage
 -----

--- a/docs/ghostly.rst
+++ b/docs/ghostly.rst
@@ -3,7 +3,7 @@ ghostly
 
 .. dfhack-tool::
     :summary: Toggles an adventurer's ghost status.
-    :tags: adventure armok units
+    :tags: untested adventure armok units
 
 This is useful for walking through walls, avoiding attacks, or recovering after
 a death.

--- a/docs/growcrops.rst
+++ b/docs/growcrops.rst
@@ -3,7 +3,7 @@ growcrops
 
 .. dfhack-tool::
     :summary: Instantly grow planted seeds into crops.
-    :tags: fort armok plants
+    :tags: untested fort armok plants
 
 With no parameters, this command lists the seed types currently planted in your
 farming plots. With a seed type, the script will grow those seeds, ready to be

--- a/docs/gui/advfort.rst
+++ b/docs/gui/advfort.rst
@@ -3,7 +3,7 @@ gui/advfort
 
 .. dfhack-tool::
     :summary: Perform fort-like jobs in adventure mode.
-    :tags: adventure gameplay
+    :tags: untested adventure gameplay
 
 This script allows performing jobs in adventure mode. For interactive help,
 press :kbd:`?` while the script is running.

--- a/docs/gui/autogems.rst
+++ b/docs/gui/autogems.rst
@@ -4,7 +4,7 @@ gui/autogems
 
 .. dfhack-tool::
     :summary: Automatically cut rough gems.
-    :tags: fort auto workorders
+    :tags: untested fort auto workorders
 
 This is a frontend for the `autogems` plugin that allows interactively
 configuring the gem types that you want to be cut.

--- a/docs/gui/blueprint.rst
+++ b/docs/gui/blueprint.rst
@@ -3,7 +3,7 @@ gui/blueprint
 
 .. dfhack-tool::
     :summary: Record a live game map in a quickfort blueprint.
-    :tags: fort design buildings map stockpiles
+    :tags: untested fort design buildings map stockpiles
 
 
 The `blueprint` plugin records the structure of a portion of your fortress in

--- a/docs/gui/choose-weapons.rst
+++ b/docs/gui/choose-weapons.rst
@@ -3,7 +3,7 @@ gui/choose-weapons
 
 .. dfhack-tool::
     :summary: Ensure military dwarves choose appropriate weapons.
-    :tags: fort productivity military
+    :tags: untested fort productivity military
 
 Activate in the :guilabel:`Equip->View/Customize` page of the military screen.
 

--- a/docs/gui/clone-uniform.rst
+++ b/docs/gui/clone-uniform.rst
@@ -3,7 +3,7 @@ gui/clone-uniform
 
 .. dfhack-tool::
     :summary: Duplicate an existing military uniform.
-    :tags: fort productivity military
+    :tags: untested fort productivity military
 
 When invoked, this tool duplicates the currently selected uniform template and
 selects the newly created copy. Activate in the :guilabel:`Uniforms` page of the

--- a/docs/gui/color-schemes.rst
+++ b/docs/gui/color-schemes.rst
@@ -3,7 +3,7 @@ gui/color-schemes
 
 .. dfhack-tool::
     :summary: Modify the colors in the DF UI.
-    :tags: graphics
+    :tags: untested graphics
 
 This is an in-game interface for `color-schemes`, which allows you to modify the
 colors in the Dwarf Fortress interface. This script must be called from either

--- a/docs/gui/companion-order.rst
+++ b/docs/gui/companion-order.rst
@@ -3,7 +3,7 @@ gui/companion-order
 
 .. dfhack-tool::
     :summary: Issue orders to companions.
-    :tags: adventure interface
+    :tags: untested adventure interface
 
 This tool allows you to issue orders to your adventurer's companions. Select
 which companions to issue orders to with lower case letters (green when

--- a/docs/gui/confirm-opts.rst
+++ b/docs/gui/confirm-opts.rst
@@ -3,7 +3,7 @@ gui/confirm-opts
 
 .. dfhack-tool::
     :summary: Configure which confirmation dialogs are enabled.
-    :tags: fort productivity interface
+    :tags: untested fort productivity interface
 
 This tool is a basic configuration interface for the `confirm` plugin. You can
 see current state, and you can interactively choose which confirmation dialogs

--- a/docs/gui/create-item.rst
+++ b/docs/gui/create-item.rst
@@ -3,7 +3,7 @@ gui/create-item
 
 .. dfhack-tool::
     :summary: Magically summon any item.
-    :tags: fort armok items
+    :tags: untested fort armok items
 
 This tool provides a graphical interface for creating items of your choice. It
 walks you through the creation process with a series of prompts, asking you

--- a/docs/gui/create-tree.rst
+++ b/docs/gui/create-tree.rst
@@ -3,7 +3,7 @@ gui/create-tree
 
 .. dfhack-tool::
     :summary: Create a tree.
-    :tags: fort armok plants
+    :tags: untested fort armok plants
 
 This tool provides a graphical interface for creating trees.
 

--- a/docs/gui/dfstatus.rst
+++ b/docs/gui/dfstatus.rst
@@ -3,7 +3,7 @@ gui/dfstatus
 
 .. dfhack-tool::
     :summary: Show a quick overview of critical stock quantities.
-    :tags: fort inspection
+    :tags: untested fort inspection
 
 This tool show a quick overview of stock quantities for:
 

--- a/docs/gui/extended-status.rst
+++ b/docs/gui/extended-status.rst
@@ -3,7 +3,7 @@ gui/extended-status
 
 .. dfhack-tool::
     :summary: Add information on beds and bedrooms to the status screen.
-    :tags: fort inspection interface
+    :tags: untested fort inspection interface
 
 Adds an additional page to the ``z`` status screen where you can see information
 about beds, bedrooms, and whether your dwarves have bedrooms of their own.

--- a/docs/gui/family-affairs.rst
+++ b/docs/gui/family-affairs.rst
@@ -3,7 +3,7 @@ gui/family-affairs
 
 .. dfhack-tool::
     :summary: Inspect or meddle with romantic relationships.
-    :tags: fort armok inspection units
+    :tags: untested fort armok inspection units
 
 This tool provides a user-friendly interface to view romantic relationships,
 with the ability to add, remove, or otherwise change them at your whim -

--- a/docs/gui/guide-path.rst
+++ b/docs/gui/guide-path.rst
@@ -3,7 +3,7 @@ gui/guide-path
 
 .. dfhack-tool::
     :summary: Visualize minecart guide paths.
-    :tags: fort inspection map
+    :tags: untested fort inspection map
 
 This tool displays the cached path that will be used by the minecart guide
 order. The game computes this path when the order is executed for the first

--- a/docs/gui/kitchen-info.rst
+++ b/docs/gui/kitchen-info.rst
@@ -3,7 +3,7 @@ gui/kitchen-info
 
 .. dfhack-tool::
     :summary: Show food item uses in the kitchen status screen.
-    :tags: fort inspection
+    :tags: untested fort inspection
 
 This tool is an overlay that adds more info to the Kitchen screen, such as the potential
 alternate uses of the items that you could mark for cooking.

--- a/docs/gui/liquids.rst
+++ b/docs/gui/liquids.rst
@@ -3,7 +3,7 @@ gui/liquids
 
 .. dfhack-tool::
     :summary: Interactively paint liquids or obsidian onto the map.
-    :tags: fort armok map
+    :tags: untested fort armok map
 
 This tool is a gui front-end to `liquids` and works similarly, allowing you to
 add or remove water/magma, and create obsidian walls & floors.

--- a/docs/gui/load-screen.rst
+++ b/docs/gui/load-screen.rst
@@ -3,7 +3,7 @@ gui/load-screen
 
 .. dfhack-tool::
     :summary: Replace DF's continue game screen with a searchable list.
-    :tags: dfhack
+    :tags: untested dfhack
 
 If you tend to have many ongoing games, this tool can make it much easier to
 load the one you're looking for. It replaces DF's "continue game" screen with

--- a/docs/gui/manager-quantity.rst
+++ b/docs/gui/manager-quantity.rst
@@ -3,7 +3,7 @@ gui/manager-quantity
 
 .. dfhack-tool::
     :summary: Set the quantity of the selected manager workorder.
-    :tags: fort workorders
+    :tags: untested fort workorders
 
 There is no way in the base DF game to change the quantity for an existing
 manager workorder. Select a workorder on the j-m or u-m screens and run this

--- a/docs/gui/mass-remove.rst
+++ b/docs/gui/mass-remove.rst
@@ -3,7 +3,7 @@ gui/mass-remove
 
 .. dfhack-tool::
     :summary: Mass select buildings and constructions to suspend or remove.
-    :tags: fort productivity buildings stockpiles
+    :tags: untested fort productivity buildings stockpiles
 
 This tool lets you remove buildings/constructions or suspend/unsuspend
 construction jobs using a mouse-driven box selection.

--- a/docs/gui/mechanisms.rst
+++ b/docs/gui/mechanisms.rst
@@ -3,7 +3,7 @@ gui/mechanisms
 
 .. dfhack-tool::
     :summary: List mechanisms and links connected to a building.
-    :tags: fort inspection buildings
+    :tags: untested fort inspection buildings
 
 This convenient tool lists the mechanisms connected to the building and the
 buildings linked via the mechanisms. Navigating the list centers the view on the

--- a/docs/gui/mod-manager.rst
+++ b/docs/gui/mod-manager.rst
@@ -3,7 +3,7 @@ gui/mod-manager
 
 .. dfhack-tool::
     :summary: Easily install and uninstall mods.
-    :tags: dfhack
+    :tags: untested dfhack
 
 This tool provides a simple way to install and remove small mods that you have
 downloaded from the internet -- or have created yourself! Several mods are

--- a/docs/gui/petitions.rst
+++ b/docs/gui/petitions.rst
@@ -3,7 +3,7 @@ gui/petitions
 
 .. dfhack-tool::
     :summary: Show information about your fort's petitions.
-    :tags: fort inspection
+    :tags: untested fort inspection
 
 Show your fort's petitions, both pending and fulfilled.
 

--- a/docs/gui/power-meter.rst
+++ b/docs/gui/power-meter.rst
@@ -3,7 +3,7 @@ gui/power-meter
 
 .. dfhack-tool::
     :summary: Allow pressure plates to measure power.
-    :tags: fort gameplay buildings
+    :tags: untested fort gameplay buildings
 
 If you run this tool after selecting :guilabel:`Pressure Plate` in the build
 menu, you will build a power meter building instead of a regular pressure plate.

--- a/docs/gui/quantum.rst
+++ b/docs/gui/quantum.rst
@@ -3,7 +3,7 @@ gui/quantum
 
 .. dfhack-tool::
     :summary: Quickly and easily create quantum stockpiles.
-    :tags: fort productivity stockpiles
+    :tags: untested fort productivity stockpiles
 
 This tool provides a visual, interactive interface for creating quantum
 stockpiles.

--- a/docs/gui/quickfort.rst
+++ b/docs/gui/quickfort.rst
@@ -3,7 +3,7 @@ gui/quickfort
 
 .. dfhack-tool::
     :summary: Apply pre-designed blueprints to your fort.
-    :tags: fort design productivity buildings map stockpiles
+    :tags: untested fort design productivity buildings map stockpiles
 
 This is the graphical interface for the `quickfort` script. Once you load a
 blueprint, you will see a blinking "shadow" over the tiles that will be

--- a/docs/gui/rename.rst
+++ b/docs/gui/rename.rst
@@ -3,7 +3,7 @@ gui/rename
 
 .. dfhack-tool::
     :summary: Give buildings and units new names, optionally with special chars.
-    :tags: fort productivity buildings stockpiles units
+    :tags: untested fort productivity buildings stockpiles units
 
 Once you select a target on the game map, this tool allows you to rename it. It
 is more powerful than the in-game rename functionality since it allows you to

--- a/docs/gui/room-list.rst
+++ b/docs/gui/room-list.rst
@@ -3,7 +3,7 @@ gui/room-list
 
 .. dfhack-tool::
     :summary: Manage rooms owned by a dwarf.
-    :tags: fort inspection
+    :tags: untested fort inspection
 
 When invoked in :kbd:`q` mode with the cursor over an owned room, this tool
 lists other rooms owned by the same owner, or by the unit selected in the assign

--- a/docs/gui/settings-manager.rst
+++ b/docs/gui/settings-manager.rst
@@ -3,7 +3,7 @@ gui/settings-manager
 
 .. dfhack-tool::
     :summary: Dynamically adjust global DF settings.
-    :tags: dfhack
+    :tags: untested dfhack
 
 This tool is an in-game editor for settings defined in
 :file:`data/init/init.txt` and :file:`data/init/d_init.txt`. Changes are written

--- a/docs/gui/siege-engine.rst
+++ b/docs/gui/siege-engine.rst
@@ -3,7 +3,7 @@ gui/siege-engine
 
 .. dfhack-tool::
     :summary: Extend the functionality and usability of siege engines.
-    :tags: fort gameplay buildings
+    :tags: untested fort gameplay buildings
 
 This tool is an in-game interface for `siege-engine`, which allows you to link
 siege engines to stockpiles, restrict operation to certain dwarves, fire a

--- a/docs/gui/stamper.rst
+++ b/docs/gui/stamper.rst
@@ -3,7 +3,7 @@ gui/stamper
 
 .. dfhack-tool::
     :summary: Copy, paste, and transform dig designations.
-    :tags: fort design map
+    :tags: untested fort design map
 
 This tool allows you to copy and paste blocks of dig designations. You can also
 transform what you have copied by shifting it, reflecting it, rotating it,

--- a/docs/gui/stockpiles.rst
+++ b/docs/gui/stockpiles.rst
@@ -3,7 +3,7 @@ gui/stockpiles
 
 .. dfhack-tool::
     :summary: Import and export stockpile settings.
-    :tags: fort design stockpiles
+    :tags: untested fort design stockpiles
 
 With a stockpile selected in :kbd:`q` mode, you can use this tool to load
 stockpile settings from a file or save them to a file for later loading, in

--- a/docs/gui/teleport.rst
+++ b/docs/gui/teleport.rst
@@ -3,7 +3,7 @@ gui/teleport
 
 .. dfhack-tool::
     :summary: Teleport a unit anywhere.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 This tool is a front-end for the `teleport` tool. It allows you to interactively
 choose a unit to teleport and a destination tile using the in-game cursor.

--- a/docs/gui/unit-info-viewer.rst
+++ b/docs/gui/unit-info-viewer.rst
@@ -3,7 +3,7 @@ gui/unit-info-viewer
 
 .. dfhack-tool::
     :summary: Display detailed information about a unit.
-    :tags: fort inspection units
+    :tags: untested fort inspection units
 
 Displays information about age, birth, maxage, shearing, milking, grazing, egg
 laying, body size, and death for the selected unit.

--- a/docs/gui/workflow.rst
+++ b/docs/gui/workflow.rst
@@ -3,7 +3,7 @@ gui/workflow
 
 .. dfhack-tool::
     :summary: Manage automated item production rules.
-    :tags: fort auto jobs
+    :tags: untested fort auto jobs
 
 This tool provides a simple interface to item production constraints managed by
 `workflow`. When a workshop job is selected in :kbd:`q` mode and this tool is

--- a/docs/gui/workorder-details.rst
+++ b/docs/gui/workorder-details.rst
@@ -3,7 +3,7 @@ gui/workorder-details
 
 .. dfhack-tool::
     :summary: Adjust input materials and traits for workorders.
-    :tags: fort inspection workorders
+    :tags: untested fort inspection workorders
 
 This tool allows you to adjust item types, materials, and/or traits for items
 used in manager workorders. The jobs created from those workorders will inherit

--- a/docs/gui/workshop-job.rst
+++ b/docs/gui/workshop-job.rst
@@ -3,7 +3,7 @@ gui/workshop-job
 
 .. dfhack-tool::
     :summary: Adjust the input materials used for a job at a workshop.
-    :tags: fort inspection jobs
+    :tags: untested fort inspection jobs
 
 This tool allows you to inspect or change the input reagents for the selected
 workshop job (in :kbd:`q` mode).

--- a/docs/hermit.rst
+++ b/docs/hermit.rst
@@ -3,7 +3,7 @@ hermit
 
 .. dfhack-tool::
     :summary: Go it alone in your fortress and attempt the hermit challenge.
-    :tags: fort gameplay
+    :tags: untested fort auto gameplay
 
 This script blocks all caravans, migrants, diplomats, and forgotten beasts (not
 wildlife) from entering your fort. Useful for attempting the

--- a/docs/hotkey-notes.rst
+++ b/docs/hotkey-notes.rst
@@ -3,7 +3,7 @@ hotkey-notes
 
 .. dfhack-tool::
     :summary: Show info on DF map location hotkeys.
-    :tags: fort inspection
+    :tags: untested fort inspection
 
 This command lists the key (e.g. :kbd:`F1`), name, and jump position of the
 map location hotkeys you set in the :kbd:`H` menu.

--- a/docs/launch.rst
+++ b/docs/launch.rst
@@ -3,7 +3,7 @@ launch
 
 .. dfhack-tool::
     :summary: Thrash your enemies with a flying suplex.
-    :tags: adventure armok units
+    :tags: untested adventure armok units
 
 Attack another unit and then run this command to grab them and fly in a glorious
 parabolic arc to where you have placed the cursor. You'll land safely and your

--- a/docs/lever.rst
+++ b/docs/lever.rst
@@ -3,7 +3,7 @@ lever
 
 .. dfhack-tool::
     :summary: Inspect and pull levers.
-    :tags: fort armok inspection productivity buildings
+    :tags: untested fort armok inspection productivity buildings
 
 Usage
 -----

--- a/docs/light-aquifers-only.rst
+++ b/docs/light-aquifers-only.rst
@@ -3,7 +3,7 @@ light-aquifers-only
 
 .. dfhack-tool::
     :summary: Change heavy and varied aquifers to light aquifers.
-    :tags: embark fort armok map
+    :tags: untested embark fort armok map
 
 This script behaves differently depending on whether it's called pre-embark or
 post-embark. Pre-embark, it changes all aquifers in the world to light ones,

--- a/docs/linger.rst
+++ b/docs/linger.rst
@@ -3,7 +3,7 @@ linger
 
 .. dfhack-tool::
     :summary: Take control of your adventurer's killer.
-    :tags: adventure armok
+    :tags: untested adventure armok
 
 Run this script after being presented with the "You are deceased." message to
 abandon your dead adventurer and take control of your adventurer's killer.

--- a/docs/list-agreements.rst
+++ b/docs/list-agreements.rst
@@ -3,7 +3,7 @@ list-agreements
 
 .. dfhack-tool::
     :summary: List guildhall and temple agreements.
-    :tags: fort inspection
+    :tags: untested fort inspection
 
 If you have trouble remembering which guildhalls and temples you've agreed to
 build (and don't we all?), then this script is for you! You can use this command

--- a/docs/list-waves.rst
+++ b/docs/list-waves.rst
@@ -3,7 +3,7 @@ list-waves
 
 .. dfhack-tool::
     :summary: Show migration wave information for your dwarves.
-    :tags: fort inspection units
+    :tags: untested fort inspection units
 
 This script displays information about migration waves or identifies which wave
 a particular dwarf came from.

--- a/docs/load-save.rst
+++ b/docs/load-save.rst
@@ -3,7 +3,7 @@ load-save
 
 .. dfhack-tool::
     :summary: Load a savegame.
-    :tags: dfhack
+    :tags: untested dfhack
 
 When run on the Dwarf Fortress title screen or "load game" screen, this script
 will load the save with the given folder name without requiring interaction.

--- a/docs/lua.rst
+++ b/docs/lua.rst
@@ -3,7 +3,7 @@ lua
 
 .. dfhack-tool::
     :summary: Run Lua script commands.
-    :tags: dev
+    :tags: dfhack dev
 
 Usage
 -----

--- a/docs/make-legendary.rst
+++ b/docs/make-legendary.rst
@@ -3,7 +3,7 @@ make-legendary
 
 .. dfhack-tool::
     :summary: Boost skills of the selected dwarf.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 This tool can make the selected dwarf legendary in one skill, a group of skills,
 or all skills.

--- a/docs/make-monarch.rst
+++ b/docs/make-monarch.rst
@@ -3,7 +3,7 @@ make-monarch
 
 .. dfhack-tool::
     :summary: Crown the selected unit as a monarch.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 This tool can make the selected unit king or queen of your civilization.
 

--- a/docs/markdown.rst
+++ b/docs/markdown.rst
@@ -3,7 +3,7 @@ markdown
 
 .. dfhack-tool::
     :summary: Exports the text you see on the screen for posting online.
-    :tags: dfhack
+    :tags: untested dfhack
 
 This tool saves a copy of a text screen, formatted in markdown, for posting to
 Reddit (among other places). See `forum-dwarves` if you want to export BBCode

--- a/docs/masspit.rst
+++ b/docs/masspit.rst
@@ -3,7 +3,7 @@ masspit
 
 .. dfhack-tool::
     :summary: Designate creatures for pitting.
-    :tags: fort productivity animals
+    :tags: untested fort productivity animals
 
 If you have prepared an animal stockpile on top of a pit zone, and that
 stockpile has been filled with animals/prisoners in cages, then this tool can

--- a/docs/max-wave.rst
+++ b/docs/max-wave.rst
@@ -3,7 +3,7 @@ max-wave
 
 .. dfhack-tool::
     :summary: Dynamically limit the next immigration wave.
-    :tags: fort units
+    :tags: untested fort gameplay
 
 Limit the number of migrants that can arrive in the next wave by
 overriding the population cap value from data/init/d_init.txt.

--- a/docs/modtools/add-syndrome.rst
+++ b/docs/modtools/add-syndrome.rst
@@ -3,7 +3,7 @@ modtools/add-syndrome
 
 .. dfhack-tool::
     :summary: Add and remove syndromes from units.
-    :tags: dev
+    :tags: untested dev
 
 This allows adding and removing syndromes from units.
 

--- a/docs/modtools/anonymous-script.rst
+++ b/docs/modtools/anonymous-script.rst
@@ -3,7 +3,7 @@ modtools/anonymous-script
 
 .. dfhack-tool::
     :summary: Run dynamically generated script code.
-    :tags: dev
+    :tags: untested dev
 
 This allows running a short simple Lua script passed as an argument instead of
 running a script from a file. This is useful when you want to do something too

--- a/docs/modtools/change-build-menu.rst
+++ b/docs/modtools/change-build-menu.rst
@@ -3,7 +3,7 @@ modtools/change-build-menu
 
 .. dfhack-tool::
     :summary: Add or remove items from the build sidebar menus.
-    :tags: dev
+    :tags: untested dev
 
 Change the build sidebar menus.
 

--- a/docs/modtools/create-item.rst
+++ b/docs/modtools/create-item.rst
@@ -3,7 +3,7 @@ modtools/create-item
 
 .. dfhack-tool::
     :summary: Create arbitrary items.
-    :tags: dev
+    :tags: untested dev
 
 Replaces the `createitem` plugin, with standard
 arguments. The other versions will be phased out in a later version.

--- a/docs/modtools/create-tree.rst
+++ b/docs/modtools/create-tree.rst
@@ -3,7 +3,7 @@ modtools/create-tree
 
 .. dfhack-tool::
     :summary: Spawn trees.
-    :tags: dev
+    :tags: untested dev
 
 Spawns a tree.
 

--- a/docs/modtools/create-unit.rst
+++ b/docs/modtools/create-unit.rst
@@ -3,7 +3,7 @@ modtools/create-unit
 
 .. dfhack-tool::
     :summary: Create arbitrary units.
-    :tags: dev
+    :tags: untested dev
 
 Creates a unit.  Usage::
 

--- a/docs/modtools/equip-item.rst
+++ b/docs/modtools/equip-item.rst
@@ -3,7 +3,7 @@ modtools/equip-item
 
 .. dfhack-tool::
     :summary: Force a unit to equip an item.
-    :tags: dev
+    :tags: untested dev
 
 Force a unit to equip an item with a particular body part; useful in
 conjunction with the ``create`` scripts above.  See also `forceequip`.

--- a/docs/modtools/extra-gamelog.rst
+++ b/docs/modtools/extra-gamelog.rst
@@ -3,7 +3,7 @@ modtools/extra-gamelog
 
 .. dfhack-tool::
     :summary: Write info to the gamelog for Soundsense.
-    :tags: dev
+    :tags: untested dev
 
 This script writes extra information to the gamelog.
 This is useful for tools like :forums:`Soundsense <60287>`.

--- a/docs/modtools/fire-rate.rst
+++ b/docs/modtools/fire-rate.rst
@@ -3,7 +3,7 @@ modtools/fire-rate
 
 .. dfhack-tool::
     :summary: Alter the fire rate of ranged weapons.
-    :tags: dev
+    :tags: untested dev
 
 Allows altering the fire rates of ranged weapons. Each are defined on a per-item
 basis. As this is done in an on-world basis, commands for this should be placed

--- a/docs/modtools/force.rst
+++ b/docs/modtools/force.rst
@@ -3,7 +3,7 @@ modtools/force
 
 .. dfhack-tool::
     :summary: Trigger game events.
-    :tags: dev
+    :tags: untested dev
 
 This tool triggers events like megabeasts, caravans, and migrants.
 

--- a/docs/modtools/if-entity.rst
+++ b/docs/modtools/if-entity.rst
@@ -3,7 +3,7 @@ modtools/if-entity
 
 .. dfhack-tool::
     :summary: Run DFHack commands based on current civ id.
-    :tags: dev
+    :tags: untested dev
 
 Run a command if the current entity matches a given ID.
 

--- a/docs/modtools/interaction-trigger.rst
+++ b/docs/modtools/interaction-trigger.rst
@@ -3,7 +3,7 @@ modtools/interaction-trigger
 
 .. dfhack-tool::
     :summary: Run DFHack commands when a unit attacks or defends.
-    :tags: dev
+    :tags: untested dev
 
 This triggers events when a unit uses an interaction on another. It works by
 scanning the announcements for the correct attack verb, so the attack verb

--- a/docs/modtools/invader-item-destroyer.rst
+++ b/docs/modtools/invader-item-destroyer.rst
@@ -3,7 +3,7 @@ modtools/invader-item-destroyer
 
 .. dfhack-tool::
     :summary: Destroy invader items when they die.
-    :tags: dev
+    :tags: untested dev
 
 This tool can destroy invader items to prevent clutter or to prevent
 the player from getting tools exclusive to certain races.

--- a/docs/modtools/item-trigger.rst
+++ b/docs/modtools/item-trigger.rst
@@ -3,7 +3,7 @@ modtools/item-trigger
 
 .. dfhack-tool::
     :summary: Run DFHack commands when a unit uses an item.
-    :tags: dev
+    :tags: untested dev
 
 This powerful tool triggers DFHack commands when a unit equips, unequips, or
 attacks another unit with specified item types, specified item materials, or

--- a/docs/modtools/moddable-gods.rst
+++ b/docs/modtools/moddable-gods.rst
@@ -3,7 +3,7 @@ modtools/moddable-gods
 
 .. dfhack-tool::
     :summary: Create deities.
-    :tags: dev
+    :tags: untested dev
 
 This is a standardized version of Putnam's moddableGods script. It allows you
 to create gods on the command-line.

--- a/docs/modtools/outside-only.rst
+++ b/docs/modtools/outside-only.rst
@@ -3,7 +3,7 @@ modtools/outside-only
 
 .. dfhack-tool::
     :summary: Set building inside/outside restrictions.
-    :tags: dev
+    :tags: untested dev
 
 This allows you to specify certain custom buildings as outside only, or inside
 only. If the player attempts to build a building in an inappropriate location,

--- a/docs/modtools/pref-edit.rst
+++ b/docs/modtools/pref-edit.rst
@@ -3,7 +3,7 @@ modtools/pref-edit
 
 .. dfhack-tool::
     :summary: Modify unit preferences.
-    :tags: dev
+    :tags: untested dev
 
 Add, remove, or edit the preferences of a unit.
 Requires a modifier, a unit argument, and filters.

--- a/docs/modtools/projectile-trigger.rst
+++ b/docs/modtools/projectile-trigger.rst
@@ -3,7 +3,7 @@ modtools/projectile-trigger
 
 .. dfhack-tool::
     :summary: Run DFHack commands when projectiles hit their targets.
-    :tags: dev
+    :tags: untested dev
 
 This triggers dfhack commands when projectiles hit their targets.  Usage::
 

--- a/docs/modtools/random-trigger.rst
+++ b/docs/modtools/random-trigger.rst
@@ -3,7 +3,7 @@ modtools/random-trigger
 
 .. dfhack-tool::
     :summary: Randomly select DFHack scripts to run.
-    :tags: dev
+    :tags: untested dev
 
 Trigger random dfhack commands with specified probabilities.
 Register a few scripts, then tell it to "go" and it will pick one

--- a/docs/modtools/raw-lint.rst
+++ b/docs/modtools/raw-lint.rst
@@ -3,6 +3,6 @@ modtools/raw-lint
 
 .. dfhack-tool::
     :summary: Check for errors in raw files.
-    :tags: dev
+    :tags: untested dev
 
 Checks for simple issues with raw files. Can be run automatically.

--- a/docs/modtools/reaction-product-trigger.rst
+++ b/docs/modtools/reaction-product-trigger.rst
@@ -3,7 +3,7 @@ modtools/reaction-product-trigger
 
 .. dfhack-tool::
     :summary: Call DFHack commands when reaction products are produced.
-    :tags: dev
+    :tags: untested dev
 
 This triggers dfhack commands when reaction products are produced, once per
 product.  Usage::

--- a/docs/modtools/reaction-trigger-transition.rst
+++ b/docs/modtools/reaction-trigger-transition.rst
@@ -3,7 +3,7 @@ modtools/reaction-trigger-transition
 
 .. dfhack-tool::
     :summary: Help create reaction triggers.
-    :tags: dev
+    :tags: untested dev
 
 Prints useful things to the console and a file to help modders
 transition from ``autoSyndrome`` to `modtools/reaction-trigger`.

--- a/docs/modtools/reaction-trigger.rst
+++ b/docs/modtools/reaction-trigger.rst
@@ -3,7 +3,7 @@ modtools/reaction-trigger
 
 .. dfhack-tool::
     :summary: Run DFHack commands when custom reactions complete.
-    :tags: dev
+    :tags: untested dev
 
 Triggers dfhack commands when custom reactions complete, regardless of whether
 it produced anything, once per completion.  Arguments::

--- a/docs/modtools/set-belief.rst
+++ b/docs/modtools/set-belief.rst
@@ -3,7 +3,7 @@ modtools/set-belief
 
 .. dfhack-tool::
     :summary: Change the beliefs/values of a unit.
-    :tags: dev
+    :tags: untested dev
 
 Changes the beliefs (values) of units.
 Requires a belief, modifier, and a target.

--- a/docs/modtools/set-need.rst
+++ b/docs/modtools/set-need.rst
@@ -3,7 +3,7 @@ modtools/set-need
 
 .. dfhack-tool::
     :summary: Change the needs of a unit.
-    :tags: dev
+    :tags: untested dev
 
 Sets and edits unit needs.
 

--- a/docs/modtools/set-personality.rst
+++ b/docs/modtools/set-personality.rst
@@ -3,7 +3,7 @@ modtools/set-personality
 
 .. dfhack-tool::
     :summary: Change a unit's personality.
-    :tags: dev
+    :tags: untested dev
 
 Changes the personality of units.
 

--- a/docs/modtools/skill-change.rst
+++ b/docs/modtools/skill-change.rst
@@ -3,7 +3,7 @@ modtools/skill-change
 
 .. dfhack-tool::
     :summary: Modify unit skills.
-    :tags: dev
+    :tags: untested dev
 
 Sets or modifies a skill of a unit.
 

--- a/docs/modtools/spawn-flow.rst
+++ b/docs/modtools/spawn-flow.rst
@@ -3,7 +3,7 @@ modtools/spawn-flow
 
 .. dfhack-tool::
     :summary: Creates flows at the specified location.
-    :tags: dev
+    :tags: untested dev
 
 Creates flows at the specified location.
 

--- a/docs/modtools/spawn-liquid.rst
+++ b/docs/modtools/spawn-liquid.rst
@@ -3,7 +3,7 @@ modtools/spawn-liquid
 
 .. dfhack-tool::
     :summary: Spawn water or lava.
-    :tags: dev
+    :tags: untested dev
 
 This script spawns liquid at the given coordinates.
 

--- a/docs/modtools/syndrome-trigger.rst
+++ b/docs/modtools/syndrome-trigger.rst
@@ -3,7 +3,7 @@ modtools/syndrome-trigger
 
 .. dfhack-tool::
     :summary: Trigger DFHack commands when units acquire syndromes.
-    :tags: dev
+    :tags: untested dev
 
 This script helps you set up commands that trigger when syndromes are applied to
 units.

--- a/docs/modtools/transform-unit.rst
+++ b/docs/modtools/transform-unit.rst
@@ -3,7 +3,7 @@ modtools/transform-unit
 
 .. dfhack-tool::
     :summary: Transform a unit into another unit type.
-    :tags: dev
+    :tags: untested dev
 
 This tool transforms a unit into another unit type, either temporarily or
 permanently.

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -3,7 +3,7 @@ names
 
 .. dfhack-tool::
     :summary: Rename units or items with the DF name generator.
-    :tags: fort productivity units
+    :tags: untested fort productivity units
 
 This tool allows you to rename the selected unit or item (including artifacts)
 with the native Dwarf Fortress name generation interface.

--- a/docs/open-legends.rst
+++ b/docs/open-legends.rst
@@ -3,7 +3,7 @@ open-legends
 
 .. dfhack-tool::
     :summary: Open a legends screen from fort or adventure mode.
-    :tags: adventure fort legends
+    :tags: untested adventure fort legends
 
 You can use this tool to open legends mode from a world loaded in fortress or
 adventure mode. You can browse around, or even run `exportlegends` while you're

--- a/docs/points.rst
+++ b/docs/points.rst
@@ -3,7 +3,7 @@ points
 
 .. dfhack-tool::
     :summary: Sets available points at the embark screen.
-    :tags: embark fort armok
+    :tags: untested embark fort armok
 
 Run at the embark screen when you are choosing items to bring with you and
 skills to assign to your dwarves. You can set the available points to any

--- a/docs/pop-control.rst
+++ b/docs/pop-control.rst
@@ -3,7 +3,7 @@ pop-control
 
 .. dfhack-tool::
     :summary: Controls population and migration caps persistently per-fort.
-    :tags: fort units
+    :tags: untested fort auto gameplay
 
 This script controls `hermit` and the various population caps per-fortress.
 It is intended to be run from ``dfhack-config/init/onMapLoad.init`` as

--- a/docs/position.rst
+++ b/docs/position.rst
@@ -3,7 +3,7 @@ position
 
 .. dfhack-tool::
     :summary: Report cursor and mouse position, along with other info.
-    :tags: fort inspection map
+    :tags: untested fort inspection map
 
 This tool reports the current date, clock time, month, and season. It also
 reports the cursor position (or just the z-level if no cursor), window size, and

--- a/docs/pref-adjust.rst
+++ b/docs/pref-adjust.rst
@@ -3,7 +3,7 @@ pref-adjust
 
 .. dfhack-tool::
     :summary: Set the preferences of a dwarf to an ideal.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 This tool replaces a dwarf's preferences with an "ideal" set which is easy to
 satisfy::

--- a/docs/prefchange.rst
+++ b/docs/prefchange.rst
@@ -3,7 +3,7 @@ prefchange
 
 .. dfhack-tool::
     :summary: Set strange mood preferences.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 This tool sets preferences for strange moods to include a weapon type, equipment
 type, and material. If you also wish to trigger a mood, see `strangemood`.

--- a/docs/putontable.rst
+++ b/docs/putontable.rst
@@ -3,7 +3,7 @@ putontable
 
 .. dfhack-tool::
     :summary: Make an item appear on a table.
-    :tags: fort armok items
+    :tags: untested fort armok items
 
 To use this tool, move an item to the ground on the same tile as a built table.
 Then, place the cursor over the table and item and run this command. The item

--- a/docs/questport.rst
+++ b/docs/questport.rst
@@ -3,7 +3,7 @@ questport
 
 .. dfhack-tool::
     :summary: Teleport to your quest log map cursor.
-    :tags: adventure armok
+    :tags: untested adventure armok
 
 If you open the quest log map and move the cursor to your target location, you
 can run this command to teleport straight there. This can be done both within

--- a/docs/quickfort.rst
+++ b/docs/quickfort.rst
@@ -3,7 +3,7 @@ quickfort
 
 .. dfhack-tool::
     :summary: Apply pre-designed blueprints to your fort.
-    :tags: fort design productivity buildings map stockpiles
+    :tags: untested fort design productivity buildings map stockpiles
 
 Quickfort reads blueprint files stored in the ``blueprints`` subfolder under the
 main DF game folder and applies the blueprint of your choice to the game map.

--- a/docs/quicksave.rst
+++ b/docs/quicksave.rst
@@ -3,7 +3,7 @@ quicksave
 
 .. dfhack-tool::
     :summary: Immediately save the game.
-    :tags: fort
+    :tags: dfhack fort
 
 When called in dwarf mode, this tool makes DF immediately save the game by
 setting a flag normally used for the seasonal auto-save.

--- a/docs/region-pops.rst
+++ b/docs/region-pops.rst
@@ -3,7 +3,7 @@ region-pops
 
 .. dfhack-tool::
     :summary: Change regional animal populations.
-    :tags: fort inspection animals
+    :tags: untested fort inspection animals
 
 This tool can show or modify the populations of animals in the region.
 

--- a/docs/rejuvenate.rst
+++ b/docs/rejuvenate.rst
@@ -3,7 +3,7 @@ rejuvenate
 
 .. dfhack-tool::
     :summary: Sets unit age to 20 years.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 If your most valuable citizens are getting old, this tool can save them. It
 decreases the age of the selected dwarf to 20 years.

--- a/docs/remove-stress.rst
+++ b/docs/remove-stress.rst
@@ -3,7 +3,7 @@ remove-stress
 
 .. dfhack-tool::
     :summary: Reduce stress values for fortress dwarves.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 Generally happy dwarves have stress values in the range of 0 to 500,000. If they
 encounter things that stress them out, or if their needs are not being met, that

--- a/docs/remove-wear.rst
+++ b/docs/remove-wear.rst
@@ -3,7 +3,7 @@ remove-wear
 
 .. dfhack-tool::
     :summary: Remove wear from items in your fort.
-    :tags: fort armok items
+    :tags: untested fort armok items
 
 If your clothes are all wearing out and you wish you could just repair them
 instead of having to make new clothes, then this tool is for you! This tool will

--- a/docs/resurrect-adv.rst
+++ b/docs/resurrect-adv.rst
@@ -3,7 +3,7 @@ resurrect-adv
 
 .. dfhack-tool::
     :summary: Bring a dead adventurer back to life.
-    :tags: adventure armok
+    :tags: untested adventure armok
 
 Have you ever died, but wish you hadn't? This tool can help : ) When you see the
 "You are deceased" message, run this command to be resurrected and fully healed.

--- a/docs/reveal-adv-map.rst
+++ b/docs/reveal-adv-map.rst
@@ -3,7 +3,7 @@ reveal-adv-map
 
 .. dfhack-tool::
     :summary: Reveal or hide the world map.
-    :tags: adventure armok map
+    :tags: untested adventure armok map
 
 This tool can be used to either reveal or hide all tiles on the world map in
 adventure mode (visible when viewing the quest log or fast traveling).

--- a/docs/reveal-hidden-sites.rst
+++ b/docs/reveal-hidden-sites.rst
@@ -3,7 +3,7 @@ reveal-hidden-sites
 
 .. dfhack-tool::
     :summary: Reveal all sites in the world.
-    :tags: adventure armok map
+    :tags: untested adventure fort armok map
 
 This tool reveals all sites in the world that have yet to be discovered by the
 player (camps, lairs, shrines, vaults, etc), making them visible on the map.

--- a/docs/reveal-hidden-units.rst
+++ b/docs/reveal-hidden-units.rst
@@ -3,7 +3,7 @@ reveal-hidden-units
 
 .. dfhack-tool::
     :summary: Reveal sneaking units.
-    :tags: adventure fort armok map units
+    :tags: untested adventure fort armok map units
 
 This tool exposes all units on the map who are currently sneaking or waiting in
 ambush, and thus hidden from the player's view.

--- a/docs/season-palette.rst
+++ b/docs/season-palette.rst
@@ -3,7 +3,7 @@ season-palette
 
 .. dfhack-tool::
     :summary: Swap color palettes when the seasons change.
-    :tags: fort gameplay graphics
+    :tags: untested fort auto graphics
 
 For this tool to work you need to add *at least* one color palette file to your
 save raw directory. These files must be in the same format as

--- a/docs/set-orientation.rst
+++ b/docs/set-orientation.rst
@@ -3,7 +3,7 @@ set-orientation
 
 .. dfhack-tool::
     :summary: Alter a unit's romantic inclinations.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 This tool lets you tinker with the interest levels your dwarves have towards
 dwarves of the same/different sex.

--- a/docs/set-timeskip-duration.rst
+++ b/docs/set-timeskip-duration.rst
@@ -3,7 +3,7 @@ set-timeskip-duration
 
 .. dfhack-tool::
     :summary: Modify the duration of the pre-game world update.
-    :tags: adventure embark fort armok
+    :tags: untested adventure embark fort armok
 
 Starting a new fortress/adventurer session is preceded by an "Updating World"
 process which is normally 2 weeks long. This script allows you to modify the

--- a/docs/setfps.rst
+++ b/docs/setfps.rst
@@ -3,7 +3,7 @@ setfps
 
 .. dfhack-tool::
     :summary: Set the graphics FPS cap.
-    :tags: fps
+    :tags: dfhack fps
 
 This command can set the FPS cap at runtime. This is useful for when you want to
 speed up the game or watch combat in slow motion.

--- a/docs/show-unit-syndromes.rst
+++ b/docs/show-unit-syndromes.rst
@@ -3,7 +3,7 @@ show-unit-syndromes
 
 .. dfhack-tool::
     :summary: Inspect syndrome details.
-    :tags: fort inspection units
+    :tags: untested fort inspection units
 
 This tool can list the syndromes affecting game units and the remaining and
 maximum duration of those syndromes, along with (optionally) substantial detail

--- a/docs/siren.rst
+++ b/docs/siren.rst
@@ -3,7 +3,7 @@ siren
 
 .. dfhack-tool::
     :summary: Wake up sleeping units and stop parties.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 Sound the alarm! This tool can shake your sleeping units awake and knock some
 sense into your party animal military dwarves so they can address a siege.

--- a/docs/spawnunit.rst
+++ b/docs/spawnunit.rst
@@ -3,7 +3,7 @@ spawnunit
 
 .. dfhack-tool::
     :summary: Create a unit.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 This tool allows you to easily spawn a unit of your choice. It is a simplified
 interface to `modtools/create-unit`, which this tool uses to actually create

--- a/docs/startdwarf.rst
+++ b/docs/startdwarf.rst
@@ -3,7 +3,7 @@ startdwarf
 
 .. dfhack-tool::
     :summary: Increase the number of dwarves you embark with.
-    :tags: embark fort armok
+    :tags: untested embark fort armok
 
 You must use this tool before embarking (e.g. at the site selection screen or
 any time before) to change the number of dwarves you embark with from the

--- a/docs/starvingdead.rst
+++ b/docs/starvingdead.rst
@@ -3,7 +3,7 @@ starvingdead
 
 .. dfhack-tool::
     :summary: Prevent infinite accumulation of roaming undead.
-    :tags: fort auto fps gameplay units
+    :tags: untested fort auto fps gameplay units
 
 With this tool running, all undead that have been on the map for one month
 gradually decay, losing strength, speed, and toughness. After six months,

--- a/docs/stripcaged.rst
+++ b/docs/stripcaged.rst
@@ -3,7 +3,7 @@ stripcaged
 
 .. dfhack-tool::
     :summary: Remove items from caged prisoners.
-    :tags: fort productivity items
+    :tags: untested fort productivity items
 
 This tool helps with the tedious task of going through all your cages and
 marking the items inside for dumping. This lets you get leftover seeds out of

--- a/docs/superdwarf.rst
+++ b/docs/superdwarf.rst
@@ -3,7 +3,7 @@ superdwarf
 
 .. dfhack-tool::
     :summary: Make a dwarf supernaturally speedy.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 Select a dwarf in-game and run this tool to make them super fast. They will
 complete tasks instantly and never need to rest.

--- a/docs/teleport.rst
+++ b/docs/teleport.rst
@@ -3,7 +3,7 @@ teleport
 
 .. dfhack-tool::
     :summary: Teleport a unit anywhere.
-    :tags: fort armok units
+    :tags: untested fort armok units
 
 This tool teleports any unit, friendly or hostile, to somewhere else on the map.
 

--- a/docs/tidlers.rst
+++ b/docs/tidlers.rst
@@ -3,7 +3,7 @@ tidlers
 
 .. dfhack-tool::
     :summary: Change where the idlers count is displayed.
-    :tags: interface
+    :tags: untested interface
 
 This tool simply cycles the idlers count among the possible positions where the
 idlers count can be placed, including making it disappear entirely.

--- a/docs/timestream.rst
+++ b/docs/timestream.rst
@@ -3,7 +3,7 @@ timestream
 
 .. dfhack-tool::
     :summary: Fix FPS death.
-    :tags: fort fps
+    :tags: untested fort auto fps
 
 Do you remember when you first start a new fort, your initial 7 dwarves zip
 around the screen and get things done so quickly? As a player, you never had

--- a/docs/troubleshoot-item.rst
+++ b/docs/troubleshoot-item.rst
@@ -3,7 +3,7 @@ troubleshoot-item
 
 .. dfhack-tool::
     :summary: Inspect properties of the selected item.
-    :tags: fort inspection items
+    :tags: untested fort inspection items
 
 This tool lets you inspect internal properties of the selected item. This is
 useful for troubleshooting issues such as dwarves refusing to touch certain

--- a/docs/undump-buildings.rst
+++ b/docs/undump-buildings.rst
@@ -3,7 +3,7 @@ undump-buildings
 
 .. dfhack-tool::
     :summary: Undesignate building base materials for dumping.
-    :tags: fort productivity buildings
+    :tags: untested fort productivity buildings
 
 If you designate a bunch of tiles in dump mode, all the items on those tiles
 will be marked for dumping. Unfortunately, if there are buildings on any of

--- a/docs/ungeld.rst
+++ b/docs/ungeld.rst
@@ -3,7 +3,7 @@ ungeld
 
 .. dfhack-tool::
     :summary: Undo gelding for an animal.
-    :tags: fort armok animals
+    :tags: untested fort armok animals
 
 This tool will restore an animal's ability to reproduce after it has been
 gelded. Also see `geld` if you'd like to re-geld the animal.

--- a/docs/uniform-unstick.rst
+++ b/docs/uniform-unstick.rst
@@ -3,7 +3,7 @@ uniform-unstick
 
 .. dfhack-tool::
     :summary: Make military units reevaluate their uniforms.
-    :tags: fort bugfix military
+    :tags: untested fort bugfix military
 
 This tool prompts military units to reevaluate their uniform, making them
 remove and drop potentially conflicting worn items.

--- a/docs/unretire-anyone.rst
+++ b/docs/unretire-anyone.rst
@@ -3,7 +3,7 @@ unretire-anyone
 
 .. dfhack-tool::
     :summary: Adventure as any living historical figure.
-    :tags: adventure embark armok
+    :tags: untested adventure embark armok
 
 This tool allows you to play as any living (or undead) historical figure (except
 for deities) in adventure mode.

--- a/docs/view-item-info.rst
+++ b/docs/view-item-info.rst
@@ -3,7 +3,7 @@ view-item-info
 
 .. dfhack-tool::
     :summary: Extend item and unit descriptions with more information.
-    :tags: adventure fort interface
+    :tags: untested adventure fort interface
 
 This tool extends the item or unit description viewscreen with additional
 information, including a custom description of each item (when available), and

--- a/docs/view-unit-reports.rst
+++ b/docs/view-unit-reports.rst
@@ -3,7 +3,7 @@ view-unit-reports
 
 .. dfhack-tool::
     :summary: Show combat reports for a unit.
-    :tags: fort inspection military
+    :tags: untested fort inspection military
 
 Show combat reports specifically for the selected unit. You can select a unit
 with the cursor in :kbd:`v` mode, from the list in :kbd:`u` mode, or from the

--- a/docs/warn-stealers.rst
+++ b/docs/warn-stealers.rst
@@ -3,7 +3,7 @@ warn-stealers
 
 .. dfhack-tool::
     :summary: Watch for and warn about units that like to steal your stuff.
-    :tags: fort armok auto units
+    :tags: untested fort armok auto units
 
 This script will watch for new units entering the map and will make a zoomable
 announcement whenever a creature that can eat food, guzzle drinks, or steal

--- a/docs/workorder-recheck.rst
+++ b/docs/workorder-recheck.rst
@@ -3,7 +3,7 @@ workorder-recheck
 
 .. dfhack-tool::
     :summary: Recheck start conditions for a manager workorder.
-    :tags: fort workorders
+    :tags: untested fort workorders
 
 Sets the status to ``Checking`` (from ``Active``) of the selected work order (in
 the ``j-m`` or ``u-m`` screens). This makes the manager reevaluate its

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -434,7 +434,7 @@ function MainPanel:onInput(keys)
         return true
     elseif keys.CUSTOM_CTRL_D then
         dev_mode = not dev_mode
-        self:update_autocomplete(get_first_word(self.subviews.editfield.text))
+        self.update_autocomplete(get_first_word(self.subviews.editfield.text))
         return true
     elseif keys.KEYBOARD_CURSOR_RIGHT_FAST then
         self.subviews.autocomplete:advance(1)

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -569,7 +569,7 @@ local function sort_by_freq(entries)
     table.sort(entries, stable_sort_by_frequency)
 end
 
-local DEV_FILTER = {tag={'dev'}}
+local DEV_FILTER = {tag={'dev', 'untested'}}
 
 -- adds the n most closely affiliated peer entries for the given entry that
 -- aren't already in the entries list. affiliation is determined by how many


### PR DESCRIPTION
ruby scripts are not moved so as not to disturb porting in progress

"unstable" scripts can still be run by prefixing them with "unstable/" (though the scripts that reqscript other unstable scripts will of course fail since the paths won't match. I don't want to make any code changes in this move). docs are likewise moved and show up properly in helpdb (and therefor in  `help` and `gui/launcher`)