### PR TITLE
support larger textures in devel/tile-browser

### DIFF
--- a/devel/tile-browser.lua
+++ b/devel/tile-browser.lua
@@ -13,86 +13,58 @@ function TileBrowser:init()
         drag_anchors={title=true, body=true},
         resizable=true,
         resize_min={h=20},
-        frame_inset=0,
-        frame_background=gui.TRANSPARENT_PEN, -- shine through, you sparkling tiles
         on_layout=self:callback('on_resize'),
         frame_title='Tile Browser',
     }
 
     main_panel:addviews{
+        widgets.EditField{
+            view_id='start_index',
+            frame={t=0, l=0},
+            key='CUSTOM_CTRL_A',
+            label_text='Start index: ',
+            text='0',
+            on_submit=self:callback('set_start_index'),
+            on_char=function(ch) return ch:match('%d') end},
+        widgets.HotkeyLabel{
+            frame={t=1, l=0},
+            label='Prev',
+            key='KEYBOARD_CURSOR_UP_FAST',
+            on_activate=self:callback('shift_start_index', -1000)},
+        widgets.Label{
+            frame={t=1, l=6, w=1},
+            text={{text=string.char(24), pen=COLOR_LIGHTGREEN}}},
+        widgets.HotkeyLabel{
+            frame={t=1, l=15},
+            label='Next',
+            key='KEYBOARD_CURSOR_DOWN_FAST',
+            on_activate=self:callback('shift_start_index', 1000)},
+        widgets.Label{
+            frame={t=1, l=21, w=1},
+            text={{text=string.char(25), pen=COLOR_LIGHTGREEN}}},
+        widgets.Label{
+            view_id='header',
+            frame={t=3, l=0, r=2}},
         widgets.Panel{
-            frame={t=0, l=0, r=0, h=5},
-            frame_background=gui.CLEAR_PEN,
-            frame_inset={t=1, l=1, r=1},
-            subviews={
-                widgets.EditField{
-                    view_id='start_index',
-                    frame={t=0, l=0},
-                    key='CUSTOM_CTRL_A',
-                    label_text='Start index: ',
-                    text='0',
-                    on_submit=self:callback('set_start_index'),
-                    on_char=function(ch) return ch:match('%d') end},
-                widgets.HotkeyLabel{
-                    frame={t=1, l=0},
-                    label='Prev',
-                    key='KEYBOARD_CURSOR_UP_FAST',
-                    on_activate=self:callback('shift_start_index', -1000)},
-                widgets.Label{
-                    frame={t=1, l=6, w=1},
-                    text={{text=string.char(24), pen=COLOR_LIGHTGREEN}}},
-                widgets.HotkeyLabel{
-                    frame={t=1, l=15},
-                    label='Next',
-                    key='KEYBOARD_CURSOR_DOWN_FAST',
-                    on_activate=self:callback('shift_start_index', 1000)},
-                widgets.Label{
-                    frame={t=1, l=21, w=1},
-                    text={{text=string.char(25), pen=COLOR_LIGHTGREEN}}},
-                widgets.Label{
-                    view_id='header',
-                    frame={t=3, l=0, r=2}},
-            },
-        },
-        widgets.Panel{
-            view_id='margin',
-            frame={t=5, b=5, l=0, w=5},
-            frame_background=gui.CLEAR_PEN,
-        },
-        widgets.Panel{
-            frame={t=5, b=5, r=0, w=3},
-            frame_background=gui.CLEAR_PEN,
-        },
-        widgets.Panel{
-            frame={t=5, b=5},
-            frame_inset={l=1, r=1},
-            subviews={
-                widgets.Label{
-                    view_id='report',
-                    frame={t=0, b=0},
-                    scroll_keys={
-                        STANDARDSCROLL_UP = -1,
-                        KEYBOARD_CURSOR_UP = -1,
-                        STANDARDSCROLL_DOWN = 1,
-                        KEYBOARD_CURSOR_DOWN = 1,
-                        STANDARDSCROLL_PAGEUP = '-page',
-                        STANDARDSCROLL_PAGEDOWN = '+page',
-                    }},
-            },
-        },
-        widgets.Panel{
-            frame={b=0, l=0, r=0, h=5},
-            frame_inset={b=1, l=1, r=1},
-            frame_background=gui.CLEAR_PEN,
-            subviews={
-                widgets.Label{
-                    view_id='footer',
-                    frame={b=3, l=0, r=2}},
-                widgets.WrappedLabel{
-                    frame={b=0},
-                    text_to_wrap='Please resize window to change visible tile size.'},
-            },
-        },
+            view_id='transparent_area',
+            frame={t=4, b=4, l=5, r=2},
+            frame_background=gui.TRANSPARENT_PEN},
+        widgets.Label{
+            view_id='report',
+            frame={t=4, b=4},
+            scroll_keys={
+                STANDARDSCROLL_UP = -1,
+                KEYBOARD_CURSOR_UP = -1,
+                STANDARDSCROLL_DOWN = 1,
+                KEYBOARD_CURSOR_DOWN = 1,
+                STANDARDSCROLL_PAGEUP = '-page',
+                STANDARDSCROLL_PAGEDOWN = '+page'}},
+        widgets.Label{
+            view_id='footer',
+            frame={b=3, l=0, r=2}},
+        widgets.WrappedLabel{
+            frame={b=0},
+            text_to_wrap='Please resize window to change visible tile size.'},
     }
     self:addviews{main_panel}
 
@@ -111,7 +83,7 @@ function TileBrowser:set_start_index(idx)
 
     idx = idx - (idx % 20) -- floor to nearest multiple of 20
     self.subviews.start_index:setText(tostring(idx))
-    self.subviews.margin.frame.w = #tostring(idx) + 5
+    self.subviews.transparent_area.frame.l = #tostring(idx) + 4
     self.dirty = true
 end
 

--- a/devel/tile-browser.lua
+++ b/devel/tile-browser.lua
@@ -5,57 +5,94 @@ TileBrowser = defclass(TileBrowser, gui.ZScreen)
 
 function TileBrowser:init()
     self.max_texpos = #df.global.enabler.textures.raws
+    self.tile_size = 1
 
     local main_panel = widgets.Window{
         view_id='main',
-        frame={w=36, h=59},
+        frame={w=32, h=30},
         drag_anchors={title=true, body=true},
         resizable=true,
         resize_min={h=20},
+        frame_inset=0,
+        on_layout=self:callback('on_resize'),
         frame_title='Tile Browser',
     }
+    main_panel.frame_background=nil -- shine through, you sparkling tiles
+
     main_panel:addviews{
-        widgets.EditField{
-            view_id='start_index',
-            frame={t=0, l=0},
-            key='CUSTOM_CTRL_A',
-            label_text='Start index: ',
-            text='0',
-            on_submit=self:callback('set_start_index'),
-            on_char=function(ch) return ch:match('%d') end},
-        widgets.HotkeyLabel{
-            frame={t=1, l=0},
-            label='Prev',
-            key='KEYBOARD_CURSOR_UP_FAST',
-            on_activate=self:callback('shift_start_index', -1000)},
-        widgets.Label{
-            frame={t=1, l=6, w=1},
-            text={{text=string.char(24), pen=COLOR_LIGHTGREEN}}},
-        widgets.HotkeyLabel{
-            frame={t=1, l=15},
-            label='Next',
-            key='KEYBOARD_CURSOR_DOWN_FAST',
-            on_activate=self:callback('shift_start_index', 1000)},
-        widgets.Label{
-            frame={t=1, l=21, w=1},
-            text={{text=string.char(25), pen=COLOR_LIGHTGREEN}}},
-        widgets.Label{
-            view_id='header',
-            frame={t=3}},
-        widgets.Label{
-            view_id='report',
-            frame={t=4, b=1},
-            scroll_keys={
-                STANDARDSCROLL_UP = -1,
-                KEYBOARD_CURSOR_UP = -1,
-                STANDARDSCROLL_DOWN = 1,
-                KEYBOARD_CURSOR_DOWN = 1,
-                STANDARDSCROLL_PAGEUP = '-page',
-                STANDARDSCROLL_PAGEDOWN = '+page',
-            }},
-        widgets.Label{
-            view_id='footer',
-            frame={b=0}},
+        widgets.Panel{
+            frame={t=0, l=0, r=0, h=5},
+            frame_background=gui.CLEAR_PEN,
+            frame_inset={t=1, l=1, r=1},
+            subviews={
+                widgets.EditField{
+                    view_id='start_index',
+                    frame={t=0, l=0},
+                    key='CUSTOM_CTRL_A',
+                    label_text='Start index: ',
+                    text='0',
+                    on_submit=self:callback('set_start_index'),
+                    on_char=function(ch) return ch:match('%d') end},
+                widgets.HotkeyLabel{
+                    frame={t=1, l=0},
+                    label='Prev',
+                    key='KEYBOARD_CURSOR_UP_FAST',
+                    on_activate=self:callback('shift_start_index', -1000)},
+                widgets.Label{
+                    frame={t=1, l=6, w=1},
+                    text={{text=string.char(24), pen=COLOR_LIGHTGREEN}}},
+                widgets.HotkeyLabel{
+                    frame={t=1, l=15},
+                    label='Next',
+                    key='KEYBOARD_CURSOR_DOWN_FAST',
+                    on_activate=self:callback('shift_start_index', 1000)},
+                widgets.Label{
+                    frame={t=1, l=21, w=1},
+                    text={{text=string.char(25), pen=COLOR_LIGHTGREEN}}},
+                widgets.Label{
+                    view_id='header',
+                    frame={t=3, l=0, r=2}},
+            },
+        },
+        widgets.Panel{
+            view_id='margin',
+            frame={t=5, b=5, l=0, w=5},
+            frame_background=gui.CLEAR_PEN,
+        },
+        widgets.Panel{
+            frame={t=5, b=5, r=0, w=3},
+            frame_background=gui.CLEAR_PEN,
+        },
+        widgets.Panel{
+            frame={t=5, b=5},
+            frame_inset={l=1, r=1},
+            subviews={
+                widgets.Label{
+                    view_id='report',
+                    frame={t=0, b=0},
+                    scroll_keys={
+                        STANDARDSCROLL_UP = -1,
+                        KEYBOARD_CURSOR_UP = -1,
+                        STANDARDSCROLL_DOWN = 1,
+                        KEYBOARD_CURSOR_DOWN = 1,
+                        STANDARDSCROLL_PAGEUP = '-page',
+                        STANDARDSCROLL_PAGEDOWN = '+page',
+                    }},
+            },
+        },
+        widgets.Panel{
+            frame={b=0, l=0, r=0, h=5},
+            frame_inset={b=1, l=1, r=1},
+            frame_background=gui.CLEAR_PEN,
+            subviews={
+                widgets.Label{
+                    view_id='footer',
+                    frame={b=3, l=0, r=2}},
+                widgets.WrappedLabel{
+                    frame={b=0},
+                    text_to_wrap='Please resize window to change visible tile size.'},
+            },
+        },
     }
     self:addviews{main_panel}
 
@@ -74,6 +111,7 @@ function TileBrowser:set_start_index(idx)
 
     idx = idx - (idx % 20) -- floor to nearest multiple of 20
     self.subviews.start_index:setText(tostring(idx))
+    self.subviews.margin.frame.w = #tostring(idx) + 5
     self.dirty = true
 end
 
@@ -84,7 +122,13 @@ function TileBrowser:update_report()
 
     local guide = {}
     table.insert(guide, {text='', width=prefix_len})
-    table.insert(guide, '0123456789 0123456789')
+    for n=0,9 do
+        table.insert(guide, {text=tostring(n), width=self.tile_size})
+    end
+    table.insert(guide, {text='', width=self.tile_size})
+    for n=0,9 do
+        table.insert(guide, {text=tostring(n), width=self.tile_size})
+    end
     self.subviews.header:setText(guide)
     self.subviews.footer:setText(guide)
 
@@ -93,16 +137,27 @@ function TileBrowser:update_report()
         if texpos % 20 == 0 then
             table.insert(report, {text=tostring(texpos), width=prefix_len})
         elseif texpos % 10 == 0 then
-            table.insert(report, ' ')
+            table.insert(report, {text='', pad_char=' ', width=self.tile_size})
         end
-        table.insert(report, {tile=texpos})
+        table.insert(report, {tile=texpos, pen=gui.KEEP_LOWER_PEN, width=self.tile_size})
         if (texpos+1) % 20 == 0 then
-            table.insert(report, NEWLINE)
+            for n=1,self.tile_size do
+                table.insert(report, NEWLINE)
+            end
         end
     end
 
     self.subviews.report:setText(report)
     self.subviews.main:updateLayout()
+end
+
+function TileBrowser:on_resize(body)
+    local report_width = body.width - 15
+    local prev_tile_size = self.tile_size
+    self.tile_size = (report_width // 21) + 1
+    if prev_tile_size ~= self.tile_size then
+        self.dirty = true
+    end
 end
 
 function TileBrowser:onRenderFrame()

--- a/devel/tile-browser.lua
+++ b/devel/tile-browser.lua
@@ -14,10 +14,10 @@ function TileBrowser:init()
         resizable=true,
         resize_min={h=20},
         frame_inset=0,
+        frame_background=gui.TRANSPARENT_PEN, -- shine through, you sparkling tiles
         on_layout=self:callback('on_resize'),
         frame_title='Tile Browser',
     }
-    main_panel.frame_background=nil -- shine through, you sparkling tiles
 
     main_panel:addviews{
         widgets.Panel{

--- a/docs/devel/tile-browser.rst
+++ b/docs/devel/tile-browser.rst
@@ -9,9 +9,10 @@ This script pops up a panel that shows a page of 1000 textures. You can change
 the starting texpos index with :kbd:`Ctrl`:kbd:`A` or scan forward or backwards
 in increments of 1000 with :kbd:`Shift` :kbd:`Up`/:kbd:`Down`.
 
-For textures that take up more than one grid position, only the upper-left tile
-of the texture will be shown. For large enough textures, though, you can see the
-rest of it peeking out from behind the Tile Browser window.
+Textures that take up more than one grid position may have only their upper-left
+tiles shown. Increase the tile browser window (drag the bottom right corner to
+resize) to see larger tiles Note there may be transparent space visible through
+the window for tiles that don't take up the entire allotted space.
 
 Usage
 -----


### PR DESCRIPTION
Fixes DFHack/dfhack#2589

depends on DFHack/dfhack#2591 for the tile render width in Label

![image](https://user-images.githubusercontent.com/977482/212182483-9650c56b-cca9-48a5-94f6-3293d39f09a3.png)