### PR TITLE
make the unsuspend overlay always on in graphics mode

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ that repo.
 - `emigration`: now saves its state with your fort
 - `prioritize`: now saves its state with your fort
 - `unsuspend`: overlay now displays different letters for different suspend states so they can be differentiated in graphics mode (P=planning, x=suspended, X=repeatedly suspended)
+- `unsuspend`: overlay now shows a marker all the time when in graphics mode.  ascii mode still only shows when paused so that you can see what's underneath.
 - `gui/gm-editor`: converted to a movable, resizable, mouse-enabled window
 - `gui/launcher`: now supports a smaller, minimal mode. click the toggle in the launcher UI or start in minimal mode via the ``Ctrl-Shift-P`` keybinding
 - `gui/launcher`: can now be dragged from anywhere on the window body

--- a/unsuspend.lua
+++ b/unsuspend.lua
@@ -163,7 +163,7 @@ function SuspendOverlay:render_marker(dc, bld, screen_pos)
 end
 
 function SuspendOverlay:onRenderFrame(dc)
-    if not df.global.pause_state then
+    if not df.global.pause_state and not dfhack.screen.inGraphicsMode() then
         return
     end
 


### PR DESCRIPTION
We need to only show the overlay when paused in ascii mode since otherwise there's no way to see what's underneath.

in graphics mode, we can show the overlay all the time since it only takes up a small part of the tile and the majority of the building tile is still visible. it's also very useful to be able to see suspension state of buildings at all times.