### PR TITLE
No need to lint turned-down ruby

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,10 +40,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3
-    - name: Set up Ruby 2.7
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -60,6 +56,3 @@ jobs:
     - name: Check Lua syntax
       if: success() || failure()
       run: python $HOME/dfhack/ci/script-syntax.py --ext=lua --cmd="luac5.3 -p" --github-actions
-    - name: Check Ruby syntax
-      if: success() || failure()
-      run: python $HOME/dfhack/ci/script-syntax.py --ext=rb --cmd="ruby -c" --github-actions


### PR DESCRIPTION
This removes the Ruby steps from the CI.

Not sure if this should go in after all of them are migrated, but while it was on my mind I opened a PR.