### PR TITLE
[gui/gm-editor] fix use of invalid keybinding on help screen

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ that repo.
 ## New Scripts
 
 ## Fixes
+- `gui/gm-editor`: fix errors displayed while viewing help screen
 
 ## Misc Improvements
 

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -31,7 +31,7 @@ local keybindings_raw = {
     {name='start_filter', key="CUSTOM_S",desc="Start typing filter, Enter to finish"},
     {name='help', key="STRING_A063",desc="Show this help"},
     {name='displace', key="STRING_A093",desc="Open reference offseted by index"},
-    {name='NOT_USED', key="SEC_SELECT",desc="Edit selected entry as a number (for enums)"}, --not a binding...
+    --{name='NOT_USED', key="SEC_SELECT",desc="Edit selected entry as a number (for enums)"}, --not a binding...
 }
 
 local keybindings = {}


### PR DESCRIPTION
Fixes DFHack/dfhack#2655