### PR TITLE
Fix issues with exterminate this and friendlies commands

### DIFF
--- a/exterminate.lua
+++ b/exterminate.lua
@@ -140,6 +140,7 @@ if positionals[1] == "this" then
     end
 
     killUnit(selected_unit)
+    return
 end
 
 if positionals[1] == nil then
@@ -161,7 +162,7 @@ if positionals[1] == nil then
     return
 end
 
-local map_races = getMapRaces(options.only_visible)
+local map_races = getMapRaces(options.only_visible, options.include_friendly)
 
 if string.find(positionals[1], "UNDEAD") then
     if map_races.UNDEAD then


### PR DESCRIPTION
Fixes two issues with exterminate.lua

`exterminate this` was killing the unit selected but returning a vague error to the user.
`exterminate DWARF --include-friendlies` and others were falsely claiming no units of the race were present on the map.