### PR TITLE
[gui/quickfort] don't close when applying a blueprint

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ that repo.
 ## Fixes
 
 ## Misc Improvements
+- `gui/quickfort`: don't close the window when applying a blueprint so players can apply the same blueprint multiple times more easily
 
 ## Removed
 

--- a/gui/quickfort.lua
+++ b/gui/quickfort.lua
@@ -610,9 +610,7 @@ function Quickfort:onInput(keys)
 end
 
 function Quickfort:commit()
-    if self.mode ~= 'notes' then
-        self.parent_view:dismiss()
-    end
+    -- don't dismiss the window in case the player wants to lay down more copies
     self:do_command('run', false)
 end
 


### PR DESCRIPTION
so players can more easily lay them down multiple times right click or esc still exits as normal

Fixes DFHack/dfhack#2672