### PR TITLE
Fix parser error by removing lsp type comments

### DIFF
--- a/stripcaged.lua
+++ b/stripcaged.lua
@@ -13,10 +13,7 @@ local function plural(nr, name)
     return string.format('%s %s%s', nr, name, nr ~= 1 and 's' or '')
 end
 
----Checks item against opts to see if it's a vermin type that we ignore
----@param item any
----@param opts table
----@return boolean
+-- Checks item against opts to see if it's a vermin type that we ignore
 local function isexcludedvermin(item, opts)
     if df.item_verminst:is_instance(item) then
         if opts.include_vermin then


### PR DESCRIPTION
The type annotations give the following error when the dfhack tui window is loaded (not the one in the gui):

Parse error: param item any
Parse error: param opts table

Myk pointed out that this is due to the script parser looking for @module etc., so I've removed the type annotations for now.