### PR TITLE
Make locate-ore work on discovered veins by default

### DIFF
--- a/docs/locate-ore.rst
+++ b/docs/locate-ore.rst
@@ -9,6 +9,8 @@ This tool finds and designates for digging one tile of a specific metal ore. If
 you want to dig **all** tiles of that kind of ore, select that tile with the
 cursor and run `digtype <dig>`.
 
+By default, the tool only searches for visible ore veins.
+
 Usage
 -----
 
@@ -18,6 +20,12 @@ Usage
     Finds a tile of the specified ore type, zooms the screen so that tile is
     visible, and designates that tile for digging.
 
+Options
+-------
+
+``-a``, ``--all``
+    Allow undiscovered ore veins to be marked.
+
 Examples
 --------
 
@@ -25,7 +33,7 @@ Examples
 
     locate-ore hematite
     locate-ore iron
-    locate-ore silver
+    locate-ore silver --all
 
 Note that looking for a particular metal might find an ore that contains that
 metal along with other metals. For example, locating silver may find

--- a/locate-ore.lua
+++ b/locate-ore.lua
@@ -1,4 +1,7 @@
--- scan the map for ore veins
+-- Scan the map for ore veins
+
+local argparse = require('argparse')
+
 local tile_attrs = df.tiletype.attrs
 
 local function extractKeys(target_table)
@@ -77,20 +80,24 @@ local function matchesMetalOreById(mat_indices, target_ore)
     return false
 end
 
-local function findOreVeins(target_ore)
+local function findOreVeins(target_ore, show_undiscovered)
     if target_ore then
         target_ore = string.lower(target_ore)
     end
 
     local ore_veins = {}
     for _, block in pairs(df.global.world.map.map_blocks) do
-        for _, bevent in pairs(block.block_events) do
+        for _, bevent in pairs(block.block_events) do    
             if bevent:getType() ~= df.block_square_event_type.mineral then
                 goto skipevent
             end
 
             local ino_raw = df.global.world.raws.inorganics[bevent.inorganic_mat]
             if not ino_raw.flags.METAL_ORE then
+                goto skipevent
+            end
+
+            if not show_undiscovered and not bevent.flags.discovered then
                 goto skipevent
             end
 
@@ -132,25 +139,36 @@ local function getOreDescription(ore)
     return str
 end
 
-local args = {...}
-local target = args[1]
+local options, args = {
+    help = false,
+    list = false,
+    show_undiscovered = false
+}, {...}
 
-if not target or target == "help" then
+local positionals = argparse.processArgsGetopt(args, {
+    {'h', 'help', handler=function() options.help = true end},
+    {'l', 'list', handler=function() options.list = true end},
+    {'a', 'all', handler=function() options.show_undiscovered = true end},
+})
+
+if positionals[1] == "help" or options.help then
     print(dfhack.script_help())
     return
 end
 
-if target == "list" then
-    local veins = findOreVeins(nil)
+if positionals[1] == list or options.list then
+    local veins = findOreVeins(nil, options.show_undiscovered)
     local sorted = sortTableBy(veins, function(a, b) return #a.positions < #b.positions end)
+
     for _, vein in ipairs(sorted) do
         print("  " .. getOreDescription(vein))
     end
 else
-    local veins = findOreVeins(target)
+    local veins = findOreVeins(positionals[1], options.show_undiscovered)
     local vein_keys = extractKeys(veins)
+
     if #vein_keys == 0 then
-        qerror("Cannot find unmined " .. target)
+        qerror("Cannot find unmined " .. positionals[1])
     end
 
     local target_vein = getRandomFromTable(veins)
@@ -178,6 +196,10 @@ else
                     goto skip_pos
                 end
 
+                if not options.show_undiscovered and not dfhack.maps.isTileVisible(pos) then
+                    goto skip_pos
+                end
+
                 local tile_type = dfhack.maps.getTileType(pos)
                 local tile_mat = tile_attrs[tile_type].material
                 local shape = tile_attrs[tile_type].shape
@@ -191,11 +213,14 @@ else
             end
         end
     end
+
     :: complete ::
 
     if target_pos ~= nil then
         dfhack.gui.pauseRecenter(target_pos)
         designateDig(target_pos)
         print(("Here is some %s at (%d, %d, %d)"):format(target_vein.inorganic_id, target_pos.x, target_pos.y, target_pos.z))
+    else
+        qerror("Cannot find unmined " .. positionals[1])
     end
 end

--- a/locate-ore.lua
+++ b/locate-ore.lua
@@ -141,13 +141,11 @@ end
 
 local options, args = {
     help = false,
-    list = false,
     show_undiscovered = false
 }, {...}
 
 local positionals = argparse.processArgsGetopt(args, {
     {'h', 'help', handler=function() options.help = true end},
-    {'l', 'list', handler=function() options.list = true end},
     {'a', 'all', handler=function() options.show_undiscovered = true end},
 })
 
@@ -156,13 +154,15 @@ if positionals[1] == "help" or options.help then
     return
 end
 
-if positionals[1] == list or options.list then
+if positionals[1] == nil or positionals[1] == "list" then
+    print(dfhack.script_help())
     local veins = findOreVeins(nil, options.show_undiscovered)
     local sorted = sortTableBy(veins, function(a, b) return #a.positions < #b.positions end)
 
     for _, vein in ipairs(sorted) do
         print("  " .. getOreDescription(vein))
     end
+    return
 else
     local veins = findOreVeins(positionals[1], options.show_undiscovered)
     local vein_keys = extractKeys(veins)

--- a/locate-ore.lua
+++ b/locate-ore.lua
@@ -87,7 +87,7 @@ local function findOreVeins(target_ore, show_undiscovered)
 
     local ore_veins = {}
     for _, block in pairs(df.global.world.map.map_blocks) do
-        for _, bevent in pairs(block.block_events) do    
+        for _, bevent in pairs(block.block_events) do
             if bevent:getType() ~= df.block_square_event_type.mineral then
                 goto skipevent
             end


### PR DESCRIPTION
Closes https://github.com/DFHack/dfhack/issues/2426

locate-ore now takes a `--all` option, which allows it to look at undiscovered veins/ores.