### PR TITLE
Add launcher autocomplete label

### DIFF
--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -126,11 +126,16 @@ AutocompletePanel.ATTRS{
 function AutocompletePanel:init()
     self:addviews{
         widgets.Label{
+            view_id="autocomplete_label",
             frame={l=0, t=0},
+            text='All scripts'
+        },
+        widgets.Label{
+            frame={l=0, t=2},
             text='Click or select via'
         },
         widgets.Label{
-            frame={l=1, t=1},
+            frame={l=1, t=3},
             text={{text='Shift+'..string.char(26), pen=COLOR_LIGHTGREEN},
                   {text='/'},
                   {text='Shift+'..string.char(27), pen=COLOR_LIGHTGREEN}}},
@@ -138,7 +143,7 @@ function AutocompletePanel:init()
             view_id='autocomplete_list',
             scroll_keys={},
             on_select=self:callback('on_list_select'),
-            frame={l=0, r=0, t=3, b=1}},
+            frame={l=0, r=0, t=5, b=1}},
     }
 end
 
@@ -684,8 +689,16 @@ function LauncherUI:update_autocomplete(firstword)
     sort_by_freq(entries)
     if found then
         table.insert(entries, 1, firstword)
+        self.subviews.autocomplete_label:setText("Similar scripts")
         add_top_related_entries(entries, firstword, 20)
+    else
+        self.subviews.autocomplete_label:setText("Suggestions")
     end
+
+    if #firstword == 0 then
+        self.subviews.autocomplete_label:setText("All scripts")
+    end
+
     self.subviews.autocomplete:set_options(entries, found)
 end
 


### PR DESCRIPTION
Closes: https://github.com/DFHack/dfhack/issues/2503

Adds three label states to the launcher indicating the sidebar is showing either `All scripts`, `Suggestions`, or `Similar scripts`.