### PR TITLE
[build-now] use new tiletypes API to build dirt roads

### DIFF
--- a/build-now.lua
+++ b/build-now.lua
@@ -3,6 +3,7 @@
 local argparse = require('argparse')
 local dig_now = require('plugins.dig-now')
 local gui = require('gui')
+local tiletypes = require('plugins.tiletypes')
 local utils = require('utils')
 
 local ok, buildingplan = pcall(require, 'plugins.buildingplan')
@@ -463,14 +464,28 @@ local function build_building(bld)
     end
     bld:setBuildStage(bld:getMaxBuildStage())
     bld.flags.exists = true
-    -- update occupancy flags
+    -- update occupancy flags and build dirt roads (they don't build themselves)
+    local bld_type = bld:getType()
+    local is_dirt_road = bld_type == df.building_type.RoadDirt
     for x = bld.x1,bld.x2 do
         for y = bld.y1,bld.y2 do
             bld:updateOccupancy(x, y)
+            if is_dirt_road and dfhack.buildings.containsTile(bld, x, y) then
+                -- note that this does not clear shrubs. we need to figure out
+                -- how to do that
+                if not tiletypes.tiletypes_setTile(xyz2pos(x, y, bld.z),
+                        -1, df.tiletype_material.SOIL, df.tiletype_special.NORMAL, -1) then
+                    dfhack.printerr('failed to build tile of dirt road')
+                end
+            end
         end
     end
-    -- doors link to adjacent smooth walls
-    if bld:getType() == df.building_type.Door then
+    -- all buildings call this, though it only appears to have an effect for
+    -- farm plots
+    bld:initFarmSeasons()
+    -- doors and floodgates link to adjacent smooth walls
+    if bld_type == df.building_type.Door or
+            bld_type == df.building_type.Floodgate then
         dig_now.link_adjacent_smooth_walls(bld.centerx, bld.centery, bld.z)
     end
 end

--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ that repo.
 - `gui/quickfort`: don't close the window when applying a blueprint so players can apply the same blueprint multiple times more easily
 - `locate-ore`: now only searches revealed tiles by default
 - `unforbid`: does not unforbid unreachable items by default anymore.
+- `build-now`: now handles dirt roads and initializes farm plots properly
 
 ## Removed
 


### PR DESCRIPTION
it doesn't handle clearing shrubs yet, though

depends on DFHack/dfhack#2734
related to DFHack/dfhack#2614