### PR TITLE
[prioritize] watch default job types when enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -37,6 +37,7 @@ that repo.
 - `unforbid`: does not unforbid unreachable and underwater items by default
 - `gui/create-item`: added proper corpsepiece spawning from any creature. (under "body part")
 - `gui/create-item`: added search functionality to the creature selection prompt, as well as new the body part, tissue, and creature material selection prompts.
+- `prioritize`: now automatically starts boosting the default list of job types when enabled
 
 ## Removed
 - `show-unit-syndromes`: replaced by `gui/unit-syndromes`. exporting html is no longer supported.

--- a/changelog.txt
+++ b/changelog.txt
@@ -38,6 +38,7 @@ that repo.
 - `gui/create-item`: added proper corpsepiece spawning from any creature. (under "body part")
 - `gui/create-item`: added search functionality to the creature selection prompt, as well as new the body part, tissue, and creature material selection prompts.
 - `prioritize`: now automatically starts boosting the default list of job types when enabled
+- `prioritize`: pushing minecarts is now included in the default priortization list
 
 ## Removed
 - `show-unit-syndromes`: replaced by `gui/unit-syndromes`. exporting html is no longer supported.

--- a/docs/prioritize.rst
+++ b/docs/prioritize.rst
@@ -5,7 +5,7 @@ prioritize
     :summary: Automatically boost the priority of selected job types.
     :tags: fort auto jobs
 
-This tool can force specified types of jobs to get assigned and completed as
+This tool encourages specified types of jobs to get assigned and completed as
 soon as possible. Finally, you can be sure your food will be hauled before
 rotting, your hides will be tanned before going bad, and the corpses of your
 enemies will be cleared from your entranceway expediently.
@@ -18,7 +18,7 @@ jobs don't get ignored indefinitely in busy forts.
 
 It is important to automatically prioritize only the *most* important job types.
 If you add too many job types, or if there are simply too many jobs of those
-types in your fort, the other tasks in your fort can get ignored. This causes
+types in your fort, the *other* tasks in your fort can get ignored. This causes
 the same problem that ``prioritize`` is designed to solve. The script provides
 a good default set of job types to prioritize that have been suggested and
 playtested by the DF community.
@@ -31,8 +31,9 @@ Usage
 
 ::
 
-    prioritize [<options>] [defaults|<job_type> ...]
+    enable prioritize
     disable prioritize
+    prioritize [<options>] [defaults|<job_type> ...]
 
 Examples
 --------
@@ -42,9 +43,9 @@ Examples
     jobs of each type we have prioritized since we started watching them. The
     counts are saved with your game, so they will be accurate even if the game
     has been saved and reloaded since ``prioritize`` was started.
-``prioritize -a defaults``
-    Prioritize the default set of job types that the community has suggested and
-    playtested (see below for details).
+``enable prioritize``, ``prioritize -a defaults``
+    Watch for and prioritize the default set of job types that the community has
+    suggested and playtested (see below for details).
 ``prioritize -j``
     Print out the list of active jobs that you can prioritize right now.
 ``prioritize ConstructBuilding DestroyBuilding``
@@ -96,8 +97,9 @@ forced to let it rot in the butcher shop.
 
 It is also convenient to prioritize tasks that block you (the player) from doing
 other things. When you designate a group of trees for chopping, it's often
-because you want to *do* something with that space. Prioritizing tree chopping
-will get your dwarves on the task and keep you from waiting too long.
+because you want to *do* something with those logs and/or that free space.
+Prioritizing tree chopping will get your dwarves on the task and keep you from
+staring at the screen too long.
 
 You may be tempted to automatically prioritize ``ConstructBuilding`` jobs, but
 beware that if you engage in megaprojects where many constructions must be
@@ -111,16 +113,14 @@ Default list of job types to prioritize
 
 The community has assembled a good default list of job types that most players
 will benefit from. They have been playtested across a wide variety of fort
-types. Add ``on-new-fortress prioritize -aq defaults`` to your
-:file:`dfhack-config/init/onMapLoad.init` file to have them automatically
-prioritized for you in all your forts.
+types. It is a good idea to enable prioritize for all your forts.
 
-They include:
+The default prioritize list includes:
 
-- Handling items that can rot before they rot
+- Handling items that can rot
 - Medical, hygiene, and hospice tasks
 - Putting items in bins/barrels/pots/minecarts
-- Interactions with animals
+- Interactions with animals and prisoners
 - Dumping items, pulling levers, felling trees, and other tasks that you, as a
   player, might stare at and internally scream "why why why isn't this getting
   done??".

--- a/prioritize.lua
+++ b/prioritize.lua
@@ -615,17 +615,19 @@ if df.global.gamemode ~= df.game_mode.DWARF or not dfhack.isMapLoaded() then
     return
 end
 
+local args = {...}
+
 if dfhack_flags.enable then
     if dfhack_flags.enable_state then
-        print('please use "prioritize -a" to add job types to the watch list')
+        args = {'-aq', 'defaults'}
     else
         clear_watched_job_matchers()
         persist_state()
+        return
     end
-    return
 end
 
-local opts = parse_commandline({...})
+local opts = parse_commandline(args)
 if opts.help then print(dfhack.script_help()) return end
 opts.action(opts.job_matchers, opts)
 persist_state()

--- a/prioritize.lua
+++ b/prioritize.lua
@@ -20,7 +20,7 @@ local DEFAULT_JOB_TYPES = {
     'PlaceInTraction', 'SetBone', 'Surgery', 'Suture',
     -- organize items efficiently so new items can be brought to the stockpiles
     'StoreItemInVehicle', 'StoreItemInBag', 'StoreItemInBarrel',
-    'StoreItemInLocation', 'StoreItemInBin',
+    'StoreItemInLocation', 'StoreItemInBin', 'PushTrackVehicle',
     -- ensure prisoners and animals are tended to quickly
     'TameAnimal', 'TrainAnimal', 'TrainHuntingAnimal', 'TrainWarAnimal',
     'PenLargeAnimal', 'PitLargeAnimal', 'SlaughterAnimal',


### PR DESCRIPTION
so it's immediately effective when enabled