### PR TITLE
WIP: autojustice

### DIFF
--- a/autojustice.lua
+++ b/autojustice.lua
@@ -1,0 +1,297 @@
+-- Auto Justice
+--@enable = true
+
+local usage = [[
+Usage
+-----
+enable autojustice
+disable autojustice
+]]
+
+local GLOBAL_KEY = 'autojustice'
+local UNIT_NEW_ACTIVE_DELAY = 100
+local CRIME_REFRESH_DELAY = 120
+
+local json = require('json')
+local persist = require('persist-table')
+local repeatUtil = require('repeat-util')
+local eventful = require('plugins.eventful')
+local justice = reqscript('autojustice/justicetools')
+
+enabled = enabled or false
+
+local lastCrimeCount = 0
+local openCrimes = nil
+local openCrimesWitnessCount = nil
+local undiscoveredCrimes = nil
+local confessedCrimes = nil
+
+function isEnabled()
+    return enabled
+end
+
+function saveState()
+    persist.GlobalTable[GLOBAL_KEY] = json.encode({
+        enabled = enabled or false
+    })
+end
+
+function loadState ()
+    local data = json.decode(persist.GlobalTable[GLOBAL_KEY] or '{}') 
+    enabled = data.enabled or false
+end
+
+function onStateChange (sc)
+    if sc == SC_MAP_UNLOADED then
+        enabled = false
+        return
+    end
+  
+    if sc ~= SC_MAP_LOADED or df.global.gamemode ~= df.game_mode.DWARF then
+        return
+    end
+  
+    loadState()
+    --TODO: make it run here
+end
+
+function serviceToggle ()
+    if dfhack_flags.enable_state then
+        serviceEnable()
+    else
+        serviceDisable()
+    end
+end
+
+function serviceEnable ()
+    saveState()
+    initValues()
+    registerEvents()
+
+    print('autojustice is running')
+end
+
+function serviceDisable ()
+    clearEvents()
+    clearValues()
+
+    print('autojustice has stopped')
+end
+
+function runScript ()
+    if not dfhack.isMapLoaded() then
+        qerror('This script requires a fortress map to be loaded')
+        return
+    end
+
+    -- TODO: Set possible variables here
+end
+
+function registerEvents ()
+    dfhack.onStateChange[GLOBAL_KEY] = onStateChange
+
+    eventful.enableEvent(eventful.eventType.UNIT_NEW_ACTIVE, UNIT_NEW_ACTIVE_DELAY)
+    eventful.onUnitNewActive[GLOBAL_KEY] = onUnitNewActive
+
+    repeatUtil.scheduleEvery(GLOBAL_KEY, CRIME_REFRESH_DELAY, 'ticks', onRefresh)
+end
+
+function clearEvents ()
+    dfhack.onStateChange[GLOBAL_KEY] = nil
+    eventful.onUnitNewActive[GLOBAL_KEY] = nil
+    repeatUtil.cancel(GLOBAL_KEY)
+end
+
+function initValues ()
+    lastCrimeCount = #df.global.world.crimes.all
+
+    openCrimes = {}
+    openCrimesWitnessCount = {}
+    undiscoveredCrimes = {}
+    confessedCrimes = {}
+
+    for i, crime in ipairs (df.global.world.crimes.all) do
+        addNewCrime(crime)
+    end
+end
+
+function clearValues () 
+    lastCrimeCount = 0 
+    
+    openCrimes = nil
+    openCrimesWitnessCount = nil
+    undiscoveredCrimes = nil
+    confessedCrimes = nil
+end
+
+function getSiteId ()
+    return df.global.world.world_data.active_site[0].id
+end
+
+function getInterviewCrime ()
+    return openCrimes[1]    -- Lua starts its index at 1? What?
+end
+
+function addNewCrimes ()
+    local newCount = #df.global.world.crimes.all
+    if lastCrimeCount == newCount then
+        return
+    end
+
+    for i = lastCrimeCount, newCount - 1 do
+        addNewCrime(df.global.world.crimes.all[i])
+    end 
+
+    lastCrimeCount = newCount
+end
+
+function addNewCrime (crime)
+    if justice.isOpenCrime(crime, getSiteId()) then
+        addOpenCrime(crime)
+        return
+    end
+
+    if justice.isUndiscoveredCrime(crime, getSiteId()) then
+        addUndiscoveredCrime(crime)
+        return
+    end 
+end
+
+function addOpenCrime (crime)
+    local confessed = justice.getConfessedUnit(crime)
+    if confessed ~= nil then
+        if not justice.tryConvictUnit(crime, confessed) then
+            table.insert(confessedCrimes, crime)
+        end
+    else
+        table.insert(openCrimes, crime)
+        table.insert(openCrimesWitnessCount, 0)
+    end
+end
+
+function addUndiscoveredCrime (crime, siteId)
+    table.insert(undiscoveredCrimes, crime)
+end
+
+function updateUndiscoveredCrimes ()
+    local siteId = getSiteId()
+
+    for i = #undiscoveredCrimes, 1, -1 do
+        local crime = undiscoveredCrimes[i]
+        
+        if justice.isOpenCrime(crime, siteId) then
+            local confessed = justice.getConfessedUnit(crime)
+            if confessed ~= nil then
+                if not justice.tryConvictUnit(crime, confessed) then
+                    table.insert(confessedCrimes, crime)
+                end
+            else
+                table.insert(openCrimes, crime)
+                table.insert(openCrimesWitnessCount, 0)
+            end
+
+            -- This is not an undiscovered crime anymore
+            table.remove(undiscoveredCrimes, i)
+        end
+    end
+end
+
+function updateOpenCrimes ()
+    --TODO: limit the number of iterations per refresh
+    for i = #openCrimes, 1, -1 do
+        updateOpenCrime(openCrimes[i], i)
+    end
+end
+
+function updateOpenCrime (crime, index)
+    -- Check if the is still open
+    if crime.flags.sentenced then
+        table.remove(openCrimes, index)
+        table.remove(openCrimesWitnessCount, index)
+        return
+    end
+
+    -- Only recheck if we have new witnesses
+    if openCrimesWitnessCount[index] == #crime.witnesses then
+        return
+    end
+    openCrimesWitnessCount[index] = #crime.witnesses
+
+    -- Try to convict confessed or interview accused
+    local confessed = justice.getConfessedUnit(crime)
+    if confessed ~= nil then
+        if not justice.tryConvictUnit(crime, confessed) then
+            table.insert(confessedCrimes, crime)
+        end
+        
+        -- Someone confessed, this is not an open crime anymore
+        table.remove(openCrimes, index)
+        table.remove(openCrimesWitnessCount, index)
+    else
+        local accused = justice.getAccusedUnit(crime)
+        if accused ~= nil then
+            justice.scheduleInterview(crime, accused)
+        end
+    end
+end
+
+function updateConfessedCrimes ()
+    for i = #confessedCrimes, 1, -1 do
+        local crime = confessedCrimes[i]
+        local confessed = justice.getConfessedUnit(crime)
+        if confessed ~= nil and justice.tryConvictUnit(crime, confessed) then
+            table.remove(confessedCrimes, i)
+        end
+    end
+end
+
+function convictConfessed (unit)
+    for i = #confessedCrimes, 1, -1 do
+        local crime = confessedCrimes[i]
+        if justice.hasConfessed(crime, unit) and justice.tryConvictUnit(crime, unit) then
+            table.remove(confessedCrimes, i)
+        end
+    end
+end
+
+function scheduleAccused (unit)
+    for i = #openCrimes, 1, -1 do
+        local crime = openCrimes[i]
+        if justice.isAccused(crime, unit) then
+            justice.scheduleInterview(crime, unit)
+        end
+    end
+end
+
+function onUnitNewActive (unitId)
+    local unit = df.unit.find(unitId)
+    if unit == nil then
+        return
+    end
+
+    local crime = getInterviewCrime()
+    if crime ~= nil then
+        if justice.scheduleInterview(crime, unit) then
+        end
+    end
+
+    convictConfessed(unit)
+    scheduleAccused(unit)
+end
+
+function onRefresh ()
+    addNewCrimes()
+    updateUndiscoveredCrimes()
+    updateOpenCrimes()
+    updateConfessedCrimes()
+end
+
+function main ()
+    if dfhack_flags.enable then
+        serviceToggle()
+    else
+        runScript()
+    end
+end
+
+main()

--- a/autojustice/justicetools.lua
+++ b/autojustice/justicetools.lua
@@ -1,0 +1,176 @@
+--@ module = true
+
+--TODO: map other claim types
+claimType = {
+    accuses = 0,
+    confessed = 5,
+    implicates = 6
+}
+
+function convictUnit (crime, unit)
+    if crime.flags.sentenced then
+        return false
+    end
+
+    crime.convicted_hf = unit.hist_figure_id
+    crime.convicted_hf_2 = unit.hist_figure_id
+    --crime.convicted_hf_3 = unit.hist_figure_id -- this value is not set by the game
+
+    -- TODO: Not sure why the game fill this vector. Need to investigate if the convict and victim is always equal and if it has only one entry
+    if #crime.convict_data.unk_v47_vector_1 > 0 then
+        local convict = crime.convict_data.unk_v47_vector_1[0]
+        crime.victim_data.unk_v47_vector_2:insert(#crime.victim_data.unk_v47_vector_2, convict)
+    end
+
+    crime.convict_data.convicted = unit.id
+    crime.flags.sentenced = false
+
+    return true
+end
+
+function scheduleInterview (crime, unit)
+    if isScheduled(crime, unit.hist_figure_id) or not canInterview(unit) then
+        return false
+    end
+
+    local report = df.crime.T_reports:new()
+    report.accused_id = unit.hist_figure_id
+    report.accused_id_2 = unit.hist_figure_id
+
+    crime.reports:insert(#crime.reports, report)
+
+    return true
+end
+
+function scheduleduleInterviewUnits (crime, units)
+    for i, unit in ipairs (units) do
+        scheduleInterview(crime, unit)
+    end
+end
+
+function skipConviction (unit)
+    --TODO: Not sure how to check long term resident or others that asked to join
+    if dfhack.units.isCitizen(unit, true) then
+        return true -- Always skip citizen crimes
+    end
+
+    return false
+end
+
+function isScheduled (crime, hist_figure_id)
+    for i, report in ipairs (crime.reports) do
+        if report.accused_id == hist_figure_id then
+            return true
+        end
+    end
+    return false
+end
+
+function didInterview (crime, hist_figure_id)
+    for i, report in ipairs (crime.counterintelligence) do
+        if report.identified_hf == hist_figure_id then
+            return true
+        end
+    end
+    return false
+end
+
+function canInterview(unit)
+    return dfhack.units.isActive(unit) and
+        unit.status.current_soul and
+        not dfhack.units.isAnimal(unit)
+end
+
+function isOpenCrime (crime, siteId)
+    return crime.site == siteId and
+        crime.flags.discovered and
+        not crime.flags.sentenced
+end
+
+
+function isUndiscoveredCrime (crime, siteId)
+    return crime.site == siteId and
+        not crime.flags.discovered
+end
+
+function getOpenCrimes (crimes, siteId)
+    local r = {}
+
+    for i, crime in ipairs (crimes) do
+        if isOpenCrime(crime, siteId) then
+            table.insert(r, crime)
+        end
+    end
+    
+    return r
+end
+
+function getConfessedUnit (crime)
+    for i, witness in ipairs (crime.witnesses) do
+        if witness.witness_claim == claimType.confessed then
+            return df.unit.find(witness.witness_id)
+        end
+    end
+    return nil
+end
+
+function getAccusedUnit (crime)
+    for i, witness in ipairs (crime.witnesses) do
+        if witness.witness_claim == claimType.accuses or
+            witness.witness_claim == claimType.implicates then
+            return df.unit.find(witness.accused_id)
+        end
+    end
+    return nil
+end
+
+function hasConfessed (crime, unit)
+    local confessed = getConfessedUnit(crime)
+    return confessed ~= nil and confessed.hist_figure_id == unit.hist_figure_id
+end
+
+function isAccused (crime, unit)
+    local accused = getAccusedUnit(crime)
+    return accused ~= nil and accused.hist_figure_id == unit.hist_figure_id
+end
+
+function findRelatedCrimes (crimes, unit)
+    local r = {}
+
+    for i, crime in ipairs (crimes) do
+        if didInterview(crime, unit.hist_figure_id) then
+            table.insert(r, crime)
+        end
+    end
+    
+    return r
+end
+
+function tryConvictUnit (crime, unit)
+    if crime.flags.sentenced or unit == nil then
+        return false
+    end
+
+    if skipConviction(unit) then
+        return true
+    end
+
+    return convictUnit(crime, unit)
+end
+
+function trySolveCrime (crime)
+    if crime.flags.sentenced or #crime.witnesses == 0 then
+        return false
+    end
+
+    local unit = getConfessedUnit(crime)
+    if (unit == nil) then
+        return false
+    end
+
+    if skipConviction(unit) then
+        return true
+    end
+
+    return convictUnit(crime, unit)
+end


### PR DESCRIPTION
### autojustice

This is a script that automate most of the tedious parts of the justice system.

### Features
- Auto interview visitors.
- Auto interview accused units.
- Auto convict non-citizens confessed crimes.

### Notes
- There are a couple of things listed as TODO, but the core functions seems to be working fine.

- This script was (afk) tested on a running fort for a dozen hours without issues, but since I'm totally new with df/dfhack/lua I can't guarantee that all the modifications made to the crime data are 100% correct.

- "justicetools.lua" file contains helper methods used by the "autojustice.lua". Not sure if I should merge those two scripts or where to even put the "justicetools.lua".

- I'm not sure I've correctly followed all naming conventions, feel free to comment on that.

- There are a couple of options that can be added in case everything is working fine (i.e: auto convict citizens when the punishment is just jail time, add notifications to convictions and confessions).

- Might need to test on worlds with multiple forts as crime reports seems to have a siteId field mapped on them.

### Known Issues
- I had a goblin poet getting convicted even though he did join my fortress. I'm not sure why he is not being considered as a citizen.