### PR TITLE
Enable confirm

### DIFF
--- a/docs/gui/confirm.rst
+++ b/docs/gui/confirm.rst
@@ -1,4 +1,4 @@
-gui/confirm-opts
+gui/confirm
 ================
 
 .. dfhack-tool::
@@ -14,4 +14,4 @@ Usage
 
 ::
 
-    gui/confirm-opts
+    gui/confirm

--- a/docs/gui/confirm.rst
+++ b/docs/gui/confirm.rst
@@ -1,5 +1,5 @@
 gui/confirm
-================
+===========
 
 .. dfhack-tool::
     :summary: Configure which confirmation dialogs are enabled.

--- a/docs/gui/confirm.rst
+++ b/docs/gui/confirm.rst
@@ -3,7 +3,7 @@ gui/confirm
 
 .. dfhack-tool::
     :summary: Configure which confirmation dialogs are enabled.
-    :tags: untested fort productivity interface
+    :tags: fort productivity interface
 
 This tool is a basic configuration interface for the `confirm` plugin. You can
 see current state, and you can interactively choose which confirmation dialogs

--- a/gui/confirm.lua
+++ b/gui/confirm.lua
@@ -18,27 +18,26 @@ function Opts:init()
             text_pen = COLOR_GREY,
             cursor_pen = COLOR_WHITE,
             choices = {},
-            on_submit = self:callback('toggle'),
-        },
-        widgets.HotkeyLabel{
-            frame = {b=1, l=0},
-            label='Toggle all',
-            key='CUSTOM_ALT_E',
-            on_activate=function() self:toggle_all(self.subviews.list:setSelected(i)) self:refresh() end,
+            on_submit = function() self:toggle(self.subviews.list:getSelected()) self:refresh() end,
         },
         widgets.HotkeyLabel{
             frame = {b=2, l=0},
+            label='Toggle all',
+            key='CUSTOM_ALT_E',
+            on_activate=function() self:toggle_all(self.subviews.list:getSelected()) self:refresh() end,
+        },
+        widgets.HotkeyLabel{
+            frame = {b=1, l=0},
             label='Resume paused confirmations',
             key='CUSTOM_P',
             on_activate=function() self:unpause_all() self:refresh() end,
             enabled=function() return self.any_paused end
         },
-        widgets.Label{
-            view_id = 'controls',
-            frame = {b = 0, l = 0},
-            text = {
-                {key = 'SELECT', text = ': Toggle'},
-            },
+        widgets.HotkeyLabel{
+            frame = {b=0, l=0},
+            label='Toggle',
+            key='SELECT',
+            on_activate=function() self:toggle(self.subviews.list:getSelected()) self:refresh() end,
         },
     }
     self:refresh()
@@ -86,7 +85,8 @@ function Opts:choice_pen(index, enabled)
     return (enabled and COLOR_GREEN or COLOR_RED) + (index == self.subviews.list:getSelected() and 8 or 0)
 end
 
-function Opts:toggle(_, choice)
+function Opts:toggle(choice)
+    choice = self.data[choice]
     confirm.set_conf_state(choice.id, not choice.enabled)
     self:refresh()
 end
@@ -98,7 +98,7 @@ function Opts:toggle_all(choice)
     self:refresh()
 end
 
-function Opts:unpause_all(_, choice)
+function Opts:unpause_all()
     for _, c in pairs(self.data) do
          confirm.set_conf_paused(c.id, false)
     end

--- a/gui/confirm.lua
+++ b/gui/confirm.lua
@@ -1,12 +1,4 @@
--- confirm plugin options
---[====[
-
-gui/confirm
-================
-A basic configuration interface for the `confirm` plugin.
-
-]====]
-
+-- config ui for confirm
 
 confirm = require 'plugins.confirm'
 gui = require 'gui'
@@ -14,7 +6,6 @@ widgets = require 'gui.widgets'
 
 Opts = defclass(Opts, widgets.Window)
 Opts.ATTRS = {
-    frame_style = gui.GREY_LINE_FRAME,
     frame_title = 'Confirmation dialogs',
     frame={w=36, h=17},
 }

--- a/gui/confirm.lua
+++ b/gui/confirm.lua
@@ -85,8 +85,8 @@ function Opts:choice_pen(index, enabled)
     return (enabled and COLOR_GREEN or COLOR_RED) + (index == self.subviews.list:getSelected() and 8 or 0)
 end
 
-function Opts:toggle(choice)
-    choice = self.data[choice]
+function Opts:toggle(idx)
+    local choice = self.data[idx]
     confirm.set_conf_state(choice.id, not choice.enabled)
     self:refresh()
 end

--- a/gui/confirm.lua
+++ b/gui/confirm.lua
@@ -18,7 +18,7 @@ function Opts:init()
             text_pen = COLOR_GREY,
             cursor_pen = COLOR_WHITE,
             choices = {},
-            on_submit = function() self:toggle(self.subviews.list:getSelected()) self:refresh() end,
+            on_submit = function(idx) self:toggle(idx) self:refresh() end,
         },
         widgets.HotkeyLabel{
             frame = {b=2, l=0},

--- a/gui/control-panel.lua
+++ b/gui/control-panel.lua
@@ -44,6 +44,7 @@ table.sort(FORT_AUTOSTART)
 local SYSTEM_SERVICES = {
     'automelt', -- TODO needs dynamic detection of configurability
     'buildingplan',
+    'confirm',
     'overlay',
 }
 


### PR DESCRIPTION
Sister PR to [#2721](https://github.com/DFHack/dfhack/pull/2721) to enable confirm

- Rename `gui/confirm-opts` to `gui/confirm`
- Use a Window/ZScreen in `gui/confirm`
- Add `confirm` to System Services in control-panep