### PR TITLE
Fix protect-nick nil crash on new embark

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ that repo.
 
 ## Fixes
 - `gui/unit-syndromes`: allow the window widgets to be interacted with
+- `fix/protect-nicks`: no longer fails after a new embark
 
 ## Misc Improvements
 

--- a/fix/protect-nicks.lua
+++ b/fix/protect-nicks.lua
@@ -26,9 +26,9 @@ end
 local function save_nicks()
     for _,unit in pairs(df.global.world.units.active) do
         local nickname = unit.name.nickname
-        local hfid = unit.id
+        local unit_id = unit.id
         if not nil_or_empty(nickname) then
-            dfhack.persistent.save{key="nicknames/" .. hfid, value=nickname, ints = {hfid}}
+            dfhack.persistent.save{key="nicknames/" .. unit_id, value=nickname, ints = {unit_id}}
         end
     end
 end
@@ -37,10 +37,10 @@ end
 local function restore_nicks()
     for _,entry in pairs(dfhack.persistent.get_all("nicknames", true) or {}) do
         local nickname = entry.value
-        local hfid = entry.ints[1]
+        local unit_id = entry.ints[1]
 
-        local unit = df.unit.find(hfid)
-        if nil_or_empty(unit.name.nickname) then
+        local unit = df.unit.find(unit_id)
+        if unit and nil_or_empty(unit.name.nickname) then
             print("fix/protect-nicks: Restoring removed nickname for " .. nickname)
             unit.name.nickname = nickname
         end


### PR DESCRIPTION
On new embark, all the units from the previous are cleared from the unit list, leading to a nil error in protect-nicks.

Also: rename "hfid" to "unit_id" internally.