### PR TITLE
Reindex pathfinding on liquids spawn

### DIFF
--- a/gui/liquids.lua
+++ b/gui/liquids.lua
@@ -149,6 +149,10 @@ function SpawnLiquid:spawn(pos)
         else
             liquids.spawnLiquid(pos, self:getLiquidLevel(pos), self.type)
         end
+
+        -- Regardless of spawning or removing liquids, we need to reindex to
+        -- ensure pathability is up to date.
+        df.global.world.reindex_pathfinding = true
     end
 end
 


### PR DESCRIPTION
This fixes the pathing issues with gui/liquids. Specifically when spawning or removing magma.