### PR TITLE
[gui/gm-editor] print out coordinate values along with the type

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ that repo.
 
 ## Misc Improvements
 - `gui/gm-editor`: now supports multiple independent data inspection windows
+- `gui/gm-editor`: now prints out contents of coordinate vars instead of just the type
 - `rejuvenate`: now takes an --age parameter to choose a desired age.
 
 ## Removed

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -469,11 +469,17 @@ function getStringValue(trg,field)
     local text=tostring(obj[field])
     pcall(function()
     if obj._field ~= nil then
-        local enum=obj:_field(field)._type
+        local f = obj:_field(field)
+        if df.coord:is_instance(f) then
+            text=('(%d, %d, %d) '):format(f.x, f.y, f.z) .. text
+        elseif df.coord2d:is_instance(f) then
+            text=('(%d, %d) '):format(f.x, f.y) .. text
+        end
+        local enum=f._type
         if enum._kind=="enum-type" then
             text=text.." ("..tostring(enum[obj[field]])..")"
         end
-        local ref_target=obj:_field(field).ref_target
+        local ref_target=f.ref_target
         if ref_target then
             text=text.. " (ref-target: "..getmetatable(ref_target)..")"
         end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/977482/218016949-bdd22828-3bcb-415a-9604-8dc758dea1d6.png)

now when a field is of type df::coord or df::coord2d, then actual coordinate values will be printed out along with the type so you can see at a glance what the values are without having to go one level down into the coordinate field.