### PR TITLE
devel/visualize-structure: dereference primitive double-pointers

### DIFF
--- a/devel/visualize-structure.lua
+++ b/devel/visualize-structure.lua
@@ -26,7 +26,7 @@ local ok, ref = pcall(function() return utils.df_expr_to_ref(args[1]) end)
 if not ok then
     qerror(ref)
 end
-if type(ref._type) == 'string' and ref._type:endswith('*') then
+if ref._kind == 'primitive' and type(ref._type) == 'string' and ref._type:endswith('*') then
     ref = ref.value
 end
 

--- a/devel/visualize-structure.lua
+++ b/devel/visualize-structure.lua
@@ -26,6 +26,9 @@ local ok, ref = pcall(function() return utils.df_expr_to_ref(args[1]) end)
 if not ok then
     qerror(ref)
 end
+if type(ref._type) == 'string' and ref._type:endswith('*') then
+    ref = ref.value
+end
 
 local size, baseaddr = ref:sizeof()
 local actual_size = -1

--- a/devel/visualize-structure.lua
+++ b/devel/visualize-structure.lua
@@ -26,7 +26,8 @@ local ok, ref = pcall(function() return utils.df_expr_to_ref(args[1]) end)
 if not ok then
     qerror(ref)
 end
-if ref._kind == 'primitive' and type(ref._type) == 'string' and ref._type:endswith('*') then
+if ref._kind == 'primitive' and type(ref._type) == 'string' and ref._type:endswith('*') and ref.value ~= nil then
+    -- dereference primitive pointer fields, since we usually care more about their contents
     ref = ref.value
 end
 


### PR DESCRIPTION
For instance, passing `screen.parent` to this script is equivalent to `screen:_field('parent')`, which effectively yields a `viewscreen**`. This is represented in Lua as an object with a single `value` field containing the actual viewscreen pointer. However, there is no way to dereference this pointer via `utils.df_expr_to_ref()`. That behavior is fine for non-pointer primitives, since there is nothing to dereference, so this change introduces a special case for pointer primitives only.