### PR TITLE
deep-embark: Update for v50

### DIFF
--- a/deep-embark.lua
+++ b/deep-embark.lua
@@ -391,8 +391,8 @@ dfhack.onStateChange.DeepEmbarkMonitor = function(event)
     if not consoleMode and not args.atReclaim and df.global.gametype == df.game_type.DWARF_RECLAIM then -- it's assumed that a player who chooses to run the script from console whilst reclaiming knows what they're doing, so there's no need to check for -atReclaim in this scenario
       dfhack.onStateChange.DeepEmbarkMonitor = nil -- stop monitoring
       return -- don't deepEmbark if running from onLoad.init and in reclaim mode without -atReclaim
-    elseif view._type == df.viewscreen_choose_start_sitest then -- and view.choosing_embark then
-      if view.choosing_embark or view.choosing_reclaim then
+    elseif view._type == df.viewscreen_choose_start_sitest then -- on embark screen
+      if view.choosing_embark or view.choosing_reclaim then -- on a fresh embark, or on a reclaim
         deepEmbark(args.depth, args.blockDemons)
         dfhack.onStateChange.DeepEmbarkMonitor = nil
       end

--- a/deep-embark.lua
+++ b/deep-embark.lua
@@ -396,7 +396,9 @@ dfhack.onStateChange.DeepEmbarkMonitor = function(event)
         deepEmbark(args.depth, args.blockDemons)
         dfhack.onStateChange.DeepEmbarkMonitor = nil
       end
-    end -- run deepEmbark if we're in choose_start_sitest and the embark has been chosen
+    elseif view._type == df.viewscreen_dwarfmodest then -- we're in game. If we got here then we never got an embark screen, so this is loading a save and we abort.
+      dfhack.onStateChange.DeepEmbarkMonitor = nil
+    end
   elseif event == SC_WORLD_UNLOADED then -- embark aborted
     dfhack.onStateChange.DeepEmbarkMonitor = nil
   end

--- a/deep-embark.lua
+++ b/deep-embark.lua
@@ -197,7 +197,7 @@ end
 function moveEmbarkStuff(selectedBlock, embarkTiles)
   local spawnPosCentre
   for _, hotkey in ipairs(df.global.plotinfo.main.hotkeys) do
-    if hotkey.name == "Gate" then -- the preset hotkey is centred around the spawn point
+    if hotkey.name == "Wagon arrival location" then -- the preset hotkey is centred around the spawn point
       spawnPosCentre = xyz2pos(hotkey.x, hotkey.y, hotkey.z)
       hotkey:assign(embarkTiles[math.random(1, #embarkTiles)]) -- set the hotkey to the new spawn point
       break
@@ -390,13 +390,10 @@ end
 
 dfhack.onStateChange.DeepEmbarkMonitor = function(event)
   if event == SC_VIEWSCREEN_CHANGED then -- I initially tried using SC_MAP_LOADED, but the map appears to be loaded too early when reclaiming sites
-    if dfhack.gui.getCurViewscreen()._type ~= df.viewscreen_textviewerst then -- embark message; map should have been loaded by the time this is presented
-      return
-    end
     if not consoleMode and not args.atReclaim and df.global.gametype == df.game_type.DWARF_RECLAIM then -- it's assumed that a player who chooses to run the script from console whilst reclaiming knows what they're doing, so there's no need to check for -atReclaim in this scenario
       dfhack.onStateChange.DeepEmbarkMonitor = nil -- stop monitoring
       return -- don't deepEmbark if running from onLoad.init and in reclaim mode without -atReclaim
-    else
+    elseif dfhack.gui.getCurViewscreen()._type == df.viewscreen_choose_start_sitest then
       deepEmbark(args.depth, args.blockDemons)
       dfhack.onStateChange.DeepEmbarkMonitor = nil
     end


### PR DESCRIPTION
Change embark hotkey name, and update viewscreen checking code.

Tested and confirmed working when run from DFHack console and from `onLoad.init` - both on a fresh embark, and reclaiming an abandoned fort.