### PR TITLE
update gui/mass-remove for v50

### DIFF
--- a/docs/gui/mass-remove.rst
+++ b/docs/gui/mass-remove.rst
@@ -3,7 +3,7 @@ gui/mass-remove
 
 .. dfhack-tool::
     :summary: Mass select buildings and constructions to suspend or remove.
-    :tags: untested fort productivity buildings stockpiles
+    :tags: fort productivity design buildings stockpiles
 
 This tool lets you remove buildings/constructions or suspend/unsuspend
 construction jobs using a mouse-driven box selection.
@@ -12,17 +12,19 @@ The following marking modes are available.
 
 :Suspend: Suspend the construction of a planned building/construction.
 :Unsuspend: Resume the construction of a suspended planned
-    building/construction.
+    building/construction. Note that buildings planned with `buildingplan`
+    that are waiting for items cannot be unsuspended until all pending items
+    are attached.
 :Remove Construction: Designate a construction (wall, floor, etc.) for removal.
-    This is similar to the native Designate->Remove Construction menu in DF.
 :Unremove Construction: Cancel removal of a construction (wall, floor, etc.).
 :Remove Building: Designate a building (door, workshop, etc) for removal.
-    This is similar to the native Set Building Tasks/Prefs->Remove Building menu
-    in DF.
 :Unremove Building: Cancel removal of a building (door, workshop, etc.).
 :Remove All: Designate both constructions and buildings for removal, and deletes
     planned buildings/constructions.
 :Unremove All: Cancel removal designations for both constructions and buildings.
+
+Note: ``Unremove Construction`` and ``Unremove Building`` are not yet available
+for the latest release of Dwarf Fortress.
 
 Usage
 -----

--- a/gui/mass-remove.lua
+++ b/gui/mass-remove.lua
@@ -40,6 +40,8 @@ end
 
 local function suspend(job)
     job.flags.suspend = true
+    job.flags.working = false
+    dfhack.job.removeWorker(job, 0)
 end
 
 local function unsuspend(job)


### PR DESCRIPTION
Fixes DFHack/dfhack#2880
Fixes DFHack/dfhack#2742

significant overhaul of the code to solve a number of bugs and use standard library functionality.

note that `dfhack.job.removeJob` appears to cause crashes when used on DestroyBuilding jobs, so this version of `gui/mass-remove` does not offer "Unremove" functionality. It handles the primary use case of removing buildings, though.

Fixed case of unremoving destroy construction jobs (the previous code only handled the case where jobs were not yet assigned and it was still just a dig designation). unremoving constructions does actually work, but I commented it out in this PR for parity with unremove building.

When a building construction job is suspended, now the entire building is highlighted instead of just the center tile.

![image](https://user-images.githubusercontent.com/977482/218397520-52c008f5-e401-40d9-abc5-329a1e2a0cb1.png)
