### PR TITLE
Check for tile_type being nil to avoid out of bounds index error, and also respect stair designations

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -35,6 +35,7 @@ that repo.
 -@ `gui/unit-syndromes`: allow the window widgets to be interacted with
 -@ `fix/protect-nicks`: now works by setting the historical figure nickname
 -@ `gui/liquids`: fixed issues with unit pathing after adding/removing liquids
+-@ `gui/dig`: Fix for 'continuing' auto-stair designation. Avoid nil index issue for tile_type
 
 ## Misc Improvements
 - `gui/gm-editor`: now supports multiple independent data inspection windows

--- a/gui/dig.lua
+++ b/gui/dig.lua
@@ -764,7 +764,7 @@ function Dig:getDesignation(x, y, z)
             return stairs_bottom_type == "auto" and "u" or stairs_bottom_type
         elseif z == math.abs(self:get_bounds().z1 - self:get_bounds().z2) then
             local tile_type = dfhack.maps.getTileType(self:get_bounds().x1 + x, self:get_bounds().y1 + y, z)
-            local tile_shape = tile_attrs[tile_type].shape
+            local tile_shape = tile_type ~= nil and tile_attrs[tile_type].shape or nil
 
             -- If top of the bounds is down stair, 'auto' should change it to up/down to match vanilla stair logic
             return stairs_top_type == "auto" and (tile_shape == df.tiletype_shape.STAIR_DOWN and "i" or "j") or

--- a/gui/dig.lua
+++ b/gui/dig.lua
@@ -763,12 +763,20 @@ function Dig:getDesignation(x, y, z)
         if z == 0 then
             return stairs_bottom_type == "auto" and "u" or stairs_bottom_type
         elseif z == math.abs(self:get_bounds().z1 - self:get_bounds().z2) then
-            local tile_type = dfhack.maps.getTileType(self:get_bounds().x1 + x, self:get_bounds().y1 + y, z)
+            local tile_type = dfhack.maps.getTileType(self:get_bounds().x1 + x, self:get_bounds().y1 + y, self:get_bounds().z1 + z)
             local tile_shape = tile_type ~= nil and tile_attrs[tile_type].shape or nil
+            local designation = dfhack.maps.getTileFlags(xyz2pos(self:get_bounds().x1 + x, self:get_bounds().y1 + y, self:get_bounds().z1 + z))
 
             -- If top of the bounds is down stair, 'auto' should change it to up/down to match vanilla stair logic
-            return stairs_top_type == "auto" and (tile_shape == df.tiletype_shape.STAIR_DOWN and "i" or "j") or
-                stairs_top_type
+            local up_or_updown_dug = (tile_shape == df.tiletype_shape.STAIR_DOWN or tile_shape == df.tiletype_shape.STAIR_UPDOWN)
+            local up_or_updown_desig = designation ~= nil and (designation.dig == df.tile_dig_designation.UpStair or
+                    designation.dig == df.tile_dig_designation.UpDownStair)
+
+            if stairs_top_type == "auto" then
+                return (up_or_updown_desig or up_or_updown_dug) and "i" or "j"
+            else
+                return stairs_top_type
+            end
         else
             return stairs_middle_type == "auto" and 'i' or stairs_middle_type
         end

--- a/gui/dig.lua
+++ b/gui/dig.lua
@@ -763,9 +763,10 @@ function Dig:getDesignation(x, y, z)
         if z == 0 then
             return stairs_bottom_type == "auto" and "u" or stairs_bottom_type
         elseif z == math.abs(self:get_bounds().z1 - self:get_bounds().z2) then
-            local tile_type = dfhack.maps.getTileType(self:get_bounds().x1 + x, self:get_bounds().y1 + y, self:get_bounds().z1 + z)
+            local pos = xyz2pos(self:get_bounds().x1 + x, self:get_bounds().y1 + y, self:get_bounds().z1 + z)
+            local tile_type = dfhack.maps.getTileType(pos)
             local tile_shape = tile_type ~= nil and tile_attrs[tile_type].shape or nil
-            local designation = dfhack.maps.getTileFlags(xyz2pos(self:get_bounds().x1 + x, self:get_bounds().y1 + y, self:get_bounds().z1 + z))
+            local designation = dfhack.maps.getTileFlags(pos)
 
             -- If top of the bounds is down stair, 'auto' should change it to up/down to match vanilla stair logic
             local up_or_updown_dug = (tile_shape == df.tiletype_shape.STAIR_DOWN or tile_shape == df.tiletype_shape.STAIR_UPDOWN)


### PR DESCRIPTION
Add check for `nil` `tile_type` to try to avoid whatever is happening in https://github.com/DFHack/dfhack/issues/2893

I still couldn't reproduce the original bug but this should avoid it.

Also updated the `getDesignation` code to auto matically convert downstair designations at the top of the stairs to updown. 
