### PR TITLE
Extends devel/query --job

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ that repo.
 
 ## Misc Improvements
 - `devel/visualize-structure`: now automatically inspects the contents of most pointer fields, rather than inspecting the pointers themselves
+- `devel/query`: will now search for jobs at the map coordinate highlighted, if no explicit job is highlighted and there is a map tile highlighted
 
 ## Removed
 

--- a/devel/query.lua
+++ b/devel/query.lua
@@ -214,6 +214,21 @@ function getSelectionData()
     elseif args.job then
         debugf(0,"job selection")
         selection = dfhack.gui.getSelectedJob()
+        if selection == nil and df.global.cursor.x ~= -30000 then
+            local pos = { x=df.global.cursor.x,
+                          y=df.global.cursor.y,
+                          z=df.global.cursor.z }
+            print("searching for a job at the cursor")
+            for _link, job in utils.listpairs(df.global.world.jobs.list) do
+                local jp = job.pos
+                if jp.x == pos.x and jp.y == pos.y and jp.z == pos.z then
+                    if selection == nil then
+                        selection = {}
+                    end
+                    table.insert(selection, job)
+                end
+            end
+        end
         path_info = "job"
         path_info_pattern = path_info
     elseif args.tile then

--- a/devel/query.lua
+++ b/devel/query.lua
@@ -214,7 +214,7 @@ function getSelectionData()
     elseif args.job then
         debugf(0,"job selection")
         selection = dfhack.gui.getSelectedJob()
-        if selection == nil and df.global.cursor.x ~= -30000 then
+        if selection == nil and df.global.cursor.x >= 0 then
             local pos = { x=df.global.cursor.x,
                           y=df.global.cursor.y,
                           z=df.global.cursor.z }


### PR DESCRIPTION
Adds the ability to scan for jobs corresponding to the highlighted map coordinate, if there is no explicit job selected