### PR TITLE
Revises query.lua to use df_shortcut_env

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ that repo.
 - `makeown`: fixes errors caused by using makeown on an invader
 - `gui/blueprint`: correctly use setting presets passed on the commandline
 - `gui/quickfort`: correctly use settings presets passed on the commandline
+- `devel/query`: can now properly index vectors in the --table argument
 
 ## Misc Improvements
 - `devel/visualize-structure`: now automatically inspects the contents of most pointer fields, rather than inspecting the pointers themselves

--- a/devel/query.lua
+++ b/devel/query.lua
@@ -169,12 +169,19 @@ function main()
     query(selection, path_info, args.search, path_info)
 end
 
+local eval_env = utils.df_shortcut_env()
+function eval(s)
+    local f, err = load("return " .. s, "expression", "t", eval_env)
+    if err then qerror(err) end
+    return f()
+end
+
 function getSelectionData()
     local selection = nil
     local path_info = nil
     if args.table then
         debugf(0,"table selection")
-        selection = utils.df_expr_to_ref(args.table)
+        selection = eval(args.table)
         path_info = args.table
         path_info_pattern = escapeSpecialChars(path_info)
     elseif args.json then


### PR DESCRIPTION
Table lookups now use `df_shortcut_env` instead of `df_expr_to_ref` This fixes a problem trying to index some vectors (probably all)