### PR TITLE
forbid/unforbid: calculate position for contained items correctly

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,8 @@ that repo.
 - `makeown`: fixes errors caused by using makeown on an invader
 - `gui/blueprint`: correctly use setting presets passed on the commandline
 - `gui/quickfort`: correctly use settings presets passed on the commandline
+-@ `forbid`: fix detection of unreachable items for items in containers
+-@ `unforbid`: fix detection of unreachable items for items in containers
 
 ## Misc Improvements
 - `devel/visualize-structure`: now automatically inspects the contents of most pointer fields, rather than inspecting the pointers themselves

--- a/forbid.lua
+++ b/forbid.lua
@@ -80,7 +80,7 @@ if positionals[1] == "unreachable" then
 
         local reachable = false
         for _, unit in pairs(citizens) do
-            if dfhack.maps.canWalkBetween(item.pos, unit.pos) then
+            if dfhack.maps.canWalkBetween(xyz2pos(dfhack.items.getPosition(item)), unit.pos) then
                 reachable = true
             end
         end

--- a/unforbid.lua
+++ b/unforbid.lua
@@ -13,7 +13,7 @@ local function unforbid_all(include_unreachable, quiet)
                 local reachable = false
 
                 for _, unit in pairs(citizens) do
-                    if dfhack.maps.canWalkBetween(item.pos, unit.pos) then
+                    if dfhack.maps.canWalkBetween(xyz2pos(dfhack.items.getPosition(item)), unit.pos) then
                         reachable = true
                     end
                 end


### PR DESCRIPTION
`item::pos` is usually invalid for items in containers, which was causing `canWalkBetween()` to return false and items in reachable containers to get forbidden by `forbid`, or skipped by `unforbid`.
