### PR TITLE
Refactor gui/dig a bit, support 'stamping' shapes and lines/curves

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -41,6 +41,7 @@ that repo.
 - `gui/gm-editor`: now supports multiple independent data inspection windows
 - `gui/gm-editor`: now prints out contents of coordinate vars instead of just the type
 - `rejuvenate`: now takes an --age parameter to choose a desired age.
+- `gui/dig` : Added 'Line' shape that also can draw curves, added draggable center handle
 
 # 50.05-alpha3.1
 

--- a/gui/dig.lua
+++ b/gui/dig.lua
@@ -930,8 +930,6 @@ function Dig:onInput(keys)
         return true
     end
 
-    if keys.CUSTOM_M then self.parent_view:dismiss() end
-
     if keys.LEAVESCREEN or keys._MOUSE_R_DOWN then
         if self.shape ~= nil then
             -- if extra points have been set

--- a/gui/dig.lua
+++ b/gui/dig.lua
@@ -397,9 +397,9 @@ function Dig:get_pen(x, y, mousePos)
     end
 
     local n, w, e, s = false, false, false, false
-    if y == 0 or not self.shape.arr[x][y - 1] then n = true end
-    if x == 0 or not self.shape.arr[x - 1][y] then w = true end
-    if x == #self.shape.arr or not self.shape.arr[x + 1][y] then e = true end
+    if y == 0 or not self.shape.arr[x] or not self.shape.arr[x][y - 1] then n = true end
+    if x == 0 or not self.shape.arr[x - 1] or not self.shape.arr[x - 1][y] then w = true end
+    if x == #self.shape.arr or not self.shape.arr[x + 1] or not self.shape.arr[x + 1][y] then e = true end
     if y == #self.shape.arr[x] or not self.shape.arr[x][y + 1] then s = true end
 
     -- Get the bit field to use as a key for the PENS map
@@ -408,39 +408,56 @@ function Dig:get_pen(x, y, mousePos)
     -- If key doesn't exist in the map, set it
     if pen_key and not PENS[pen_key] then
         if not n and not w and not e and not s then
-            PENS[pen_key] = self:make_pen(CURSORS.INSIDE, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.INSIDE, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif self.shape.arr[x][y] and n and w and not e and not s then
-            PENS[pen_key] = self:make_pen(CURSORS.NW, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.NW, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif self.shape.arr[x][y] and n and not w and not e and not s then
-            PENS[pen_key] = self:make_pen(CURSORS.NORTH, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.NORTH, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif self.shape.arr[x][y] and n and e and not w and not s then
-            PENS[pen_key] = self:make_pen(CURSORS.NE, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.NE, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif self.shape.arr[x][y] and not n and w and not e and not s then
-            PENS[pen_key] = self:make_pen(CURSORS.WEST, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.WEST, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif self.shape.arr[x][y] and not n and not w and e and not s then
-            PENS[pen_key] = self:make_pen(CURSORS.EAST, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.EAST, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif self.shape.arr[x][y] and not n and w and not e and s then
-            PENS[pen_key] = self:make_pen(CURSORS.SW, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.SW, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif self.shape.arr[x][y] and not n and not w and not e and s then
-            PENS[pen_key] = self:make_pen(CURSORS.SOUTH, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.SOUTH, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif self.shape.arr[x][y] and not n and not w and e and s then
-            PENS[pen_key] = self:make_pen(CURSORS.SE, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.SE, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif self.shape.arr[x][y] and n and w and e and not s then
-            PENS[pen_key] = self:make_pen(CURSORS.N_NUB, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.N_NUB, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif self.shape.arr[x][y] and n and not w and e and s then
-            PENS[pen_key] = self:make_pen(CURSORS.E_NUB, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.E_NUB, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif self.shape.arr[x][y] and n and w and not e and s then
-            PENS[pen_key] = self:make_pen(CURSORS.W_NUB, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.W_NUB, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif self.shape.arr[x][y] and not n and w and e and s then
-            PENS[pen_key] = self:make_pen(CURSORS.S_NUB, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.S_NUB, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif self.shape.arr[x][y] and not n and w and e and not s then
-            PENS[pen_key] = self:make_pen(CURSORS.VERT_NS, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.VERT_NS, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif self.shape.arr[x][y] and n and not w and not e and s then
-            PENS[pen_key] = self:make_pen(CURSORS.VERT_EW, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.VERT_EW, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif self.shape.arr[x][y] and n and w and e and s then
-            PENS[pen_key] = self:make_pen(CURSORS.POINT, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.POINT, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         elseif is_corner(x, y) and not self.shape.arr[x][y] then
-            PENS[pen_key] = self:make_pen(CURSORS.INSIDE, is_corner(x, y), is_mouse_over(x, y, mousePos), self.shape.arr[x][y])
+            PENS[pen_key] = self:make_pen(CURSORS.INSIDE, is_corner(x, y), is_mouse_over(x, y, mousePos),
+                self.shape.arr[x][y])
         else
             PENS[pen_key] = nil
         end
@@ -449,7 +466,6 @@ function Dig:get_pen(x, y, mousePos)
     -- Return the pen for the caller
     return PENS[pen_key]
 end
-
 
 function Dig:init()
     self:addviews { ActionPanel {
@@ -640,9 +656,34 @@ function Dig:onRenderFrame(dc, rect)
             if self.dirty or (pos.x >= bounds.x1 and pos.x <= bounds.x2 and pos.y >= bounds.y1 and pos.y <= bounds.y2) then
                 if not self.shape or self.dirty or
                     (bounds.x2 - bounds.x1 ~= self.shape.width or bounds.y2 - bounds.y1 ~= self.shape.height) then
+                    local points = {}
+                    local second_point = dfhack.gui.getMousePos()
+                    if self.saved_cursor then
+                        second_point = self.saved_cursor
+                    end
+
+                    if self.mark.x >= second_point.x and self.mark.y >= second_point.y then
+                        print("down right")
+                        -- down right
+                        points = { { 0, 0 }, { math.abs(bounds.x2 - bounds.x1), math.abs(bounds.y2 - bounds.y1) } }
+                    elseif self.mark.x <= second_point.x and self.mark.y >= second_point.y then
+                        print("down left")
+                        -- down left
+                        points = { { math.abs(bounds.x2 - bounds.x1), 0 }, { 0, math.abs(bounds.y2 - bounds.y1) } }
+                    elseif self.mark.x >= second_point.x and self.mark.y <= second_point.y then
+                        print("up right")
+                        -- up right
+                        points = { { 0, math.abs(bounds.y2 - bounds.y1) }, { math.abs(bounds.x2 - bounds.x1), 0 } }
+                    elseif self.mark.x <= second_point.x and self.mark.y <= second_point.y then
+                        print("up left")
+                        -- up left
+                        points = { { math.abs(bounds.x2 - bounds.x1), math.abs(bounds.y2 - bounds.y1) }, { 0, 0 } }
+                    end
+
                     self.shape:update(
                         bounds.x2 - bounds.x1,
-                        bounds.y2 - bounds.y1
+                        bounds.y2 - bounds.y1,
+                        points
                     )
                     self:add_shape_options()
                     self:updateLayout()
@@ -667,7 +708,7 @@ function Dig:onRenderFrame(dc, rect)
             end
         end
 
-        guidm.renderMapOverlay(get_overlay_pen, bounds)
+        guidm.renderMapOverlay(get_overlay_pen, nil)
     end
 end
 
@@ -763,14 +804,17 @@ function Dig:getDesignation(x, y, z)
         if z == 0 then
             return stairs_bottom_type == "auto" and "u" or stairs_bottom_type
         elseif z == math.abs(self:get_bounds().z1 - self:get_bounds().z2) then
-            local tile_type = dfhack.maps.getTileType(self:get_bounds().x1 + x, self:get_bounds().y1 + y, self:get_bounds().z1 + z)
+            local tile_type = dfhack.maps.getTileType(self:get_bounds().x1 + x, self:get_bounds().y1 + y,
+                self:get_bounds().z1 + z)
             local tile_shape = tile_type ~= nil and tile_attrs[tile_type].shape or nil
-            local designation = dfhack.maps.getTileFlags(xyz2pos(self:get_bounds().x1 + x, self:get_bounds().y1 + y, self:get_bounds().z1 + z))
+            local designation = dfhack.maps.getTileFlags(xyz2pos(self:get_bounds().x1 + x, self:get_bounds().y1 + y,
+                self:get_bounds().z1 + z))
 
             -- If top of the bounds is down stair, 'auto' should change it to up/down to match vanilla stair logic
-            local up_or_updown_dug = (tile_shape == df.tiletype_shape.STAIR_DOWN or tile_shape == df.tiletype_shape.STAIR_UPDOWN)
+            local up_or_updown_dug = (
+                tile_shape == df.tiletype_shape.STAIR_DOWN or tile_shape == df.tiletype_shape.STAIR_UPDOWN)
             local up_or_updown_desig = designation ~= nil and (designation.dig == df.tile_dig_designation.UpStair or
-                    designation.dig == df.tile_dig_designation.UpDownStair)
+                designation.dig == df.tile_dig_designation.UpDownStair)
 
             if stairs_top_type == "auto" then
                 return (up_or_updown_desig or up_or_updown_dug) and "i" or "j"

--- a/gui/dig.lua
+++ b/gui/dig.lua
@@ -813,11 +813,11 @@ function Dig:commit()
         for zlevel = 0, math.abs(view_bounds.z1 - view_bounds.z2) do
             data[zlevel] = {}
             for row = 0, math.abs(
-                view_bounds.y1 - view_bounds.y2
+                view_bounds.y1 - view_bounds.y2 -- this is the prob
             ) do
                 data[zlevel][row] = {}
                 for col = 0, math.abs(
-                    view_bounds.x1 - view_bounds.x2
+                    view_bounds.x1 - view_bounds.x2 -- this is the prob
                 ) do
                     if grid[col] and grid[col][row] then
                         local desig = self:get_designation(col, row, zlevel)

--- a/internal/dig/shapes.lua
+++ b/internal/dig/shapes.lua
@@ -355,7 +355,6 @@ function Line:init()
 end
 
 function Line:update(points)
-
     if #self.points == #points and not self.needs_update then
         local same = true
         for i, point in ipairs(self.points) do
@@ -378,75 +377,44 @@ function Line:update(points)
     local x0, y0 = self.points[1].x, self.points[1].y
     local x1, y1 = self.points[2].x, self.points[2].y
     local dx = math.abs(x1 - x0)
+    local dy = math.abs(y1 - y0)
     local sx = x0 < x1 and 1 or -1
-    local dy = -math.abs(y1 - y0)
     local sy = y0 < y1 and 1 or -1
-    local err = dx + dy
-    local e2
-
-    -- self.offsets = {n = self.options.thickness.value - 1, s = self.options.thickness.value - 1, e = self.options.thickness.value - 1, w = self.options.thickness.value - 1}
-
-    while true do
-        self.arr[x0] = self.arr[x0] or {}
-        self.arr[x0][y0] = true
-
-        -- Add line thickness
-        if (math.abs(dx) > math.abs(dy)) then
-            local i = 1
-            while i < self.options.thickness.value do
-                local offset = math.ceil(i / 2)
-                if y0 >= i then
-                    if not self.arr[x0] then self.arr[x0] = {} end
-                    self.arr[x0][y0 - offset] = true
-                end
-                i = i + 1
-                self.offsets.n = offset
-
-                if y0 + i - 1 <= self.height and self.options.thickness.value > i then
-                    if not self.arr[x0] then self.arr[x0] = {} end
-                    self.arr[x0][y0 + offset] = true
-                    i = i + 1
-                    self.offsets.s = offset
-                end
-            end
-        elseif (math.abs(dx) <= math.abs(dy)) then
-            local i = 1
-            while i < self.options.thickness.value do
-                local offset = math.ceil(i / 2)
-                if x0 >= i then
-                    if not self.arr[x0 - offset] then self.arr[x0 - offset] = {} end
-                    self.arr[x0 - offset][y0] = true
-                end
-                i = i + 1
-                self.offsets.w = offset
-
-                if x0 + i - 1 <= self.width and self.options.thickness.value > i then
-                    if not self.arr[x0 - offset] then self.arr[x0 - offset] = {} end
-                    self.arr[x0 + offset][y0] = true
-                    i = i + 1
-                    -- print(offset)
-                    self.offsets.e = offset
-                end
-            end
+    local err = dx - dy
+    local e2, x, y
+    local thickness = self.options.thickness.value or 1
+  
+    for i = 0, thickness - 1 do
+      x = x0
+      y = y0 + i
+      while true do
+        -- Plot the point at (x, y)
+        for j = -math.floor(thickness / 2), math.ceil(thickness / 2) - 1 do
+          if not self.arr[x + j] then self.arr[x + j] = {} end
+          self.arr[x + j][y] = true
         end
-
-        if x0 == x1 and y0 == y1 then
-            break
+  
+        if x == x1 and y == y1 + i then
+          break
         end
-
+  
         e2 = 2 * err
-
-        if e2 >= dy then
-            err = err + dy
-            x0 = x0 + sx
+  
+        if e2 > -dy then
+          err = err - dy
+          x = x + sx
         end
 
-        if e2 <= dx then
-            err = err + dx
-            y0 = y0 + sy
+        if e2 < dx then
+          err = err + dx
+          y = y + sy
         end
+      end
     end
 end
+
+
+
 
 -- persist in these as long as the module is loaded
 -- idk enough lua to know if this is okay to do or not

--- a/internal/dig/shapes.lua
+++ b/internal/dig/shapes.lua
@@ -151,7 +151,7 @@ function Shape:get_center()
     -- local num_points = 0
     -- local sum_x = 0
     -- local sum_y = 0
-    
+
     -- for x, row in pairs(self.arr) do
     --   for y, value in pairs(row) do
     --     if value then
@@ -161,10 +161,10 @@ function Shape:get_center()
     --     end
     --   end
     -- end
-    
+
     -- local center_x = math.floor(sum_x / num_points)
     -- local center_y = math.floor(sum_y / num_points)
-    
+
     -- return center_x, center_y
 
     -- Simple way to get the center defined by the point dims

--- a/internal/dig/shapes.lua
+++ b/internal/dig/shapes.lua
@@ -152,23 +152,35 @@ function Shape:clear_extra_points()
     end
 end
 
+function Shape:get_center()
+    -- TODO revisit
+    -- local num_points = 0
+    -- local sum_x = 0
+    -- local sum_y = 0
+    
+    -- for x, row in pairs(self.arr) do
+    --   for y, value in pairs(row) do
+    --     if value then
+    --       num_points = num_points + 1
+    --       sum_x = sum_x + x
+    --       sum_y = sum_y + y
+    --     end
+    --   end
+    -- end
+    
+    -- local center_x = math.floor(sum_x / num_points)
+    -- local center_y = math.floor(sum_y / num_points)
+    
+    -- return center_x, center_y
+
+    local top_left, bot_right = self:get_point_dims()
+    return math.floor((bot_right.x - top_left.x) / 2) + top_left.x, math.floor((bot_right.y - top_left.y) / 2) + top_left.y
+
+end
+
 -- Basic update function that loops over a rectangle from top left to bottom right
 -- Can be overridden for more complex shapes
 function Shape:update(points)
-
-    -- If doesn't need update
-    if #self.points == #points then
-        local same = true
-        for i, point in ipairs(self.points) do
-            if points[i].x ~= point.x or points[i].y ~= point.y then
-                same = false
-                break
-            end
-        end
-
-        if same then return end -- No need to update
-    end
-
 
     self.points = copyall(points)
     local top_left, bot_right = self:get_point_dims()

--- a/internal/dig/shapes.lua
+++ b/internal/dig/shapes.lua
@@ -344,7 +344,7 @@ Line = defclass(Line, Shape)
 Line.ATTRS {
     name = "Line Segments",
     -- todo extra corners
-    extra_points = {{label = "Curve", name = "bezier_point", pos = nil }}
+    extra_points = {{label = "Curve"}}
 }
 
 function Line:init()
@@ -367,30 +367,37 @@ function Line:init()
 end
 
 function Line:update(points, extra_points)
-    if #self.points == #points and not self.needs_update then
-        local same = true
-        for i, point in ipairs(self.points) do
-            if points[i].x ~= point.x or points[i].y ~= point.y then
-                same = false
-                break
-            end
-        end
-        if same == true then
-            for i, point in ipairs(self.extra_points) do
-                if extra_points[i].x ~= point.x or extra_points[i].y ~= point.y then
-                    same = false
-                    break
-                end
-            end
-        end
+    -- if #self.points == #points and #self.extra_points == #extra_points and not self.needs_update then
+    --     local same = true
+    --     for i, point in ipairs(self.points) do
+    --         if points[i].x ~= point.x or points[i].y ~= point.y then
+    --             same = false
+    --             break
+    --         end
+    --     end
+    --     if same == true then
+    --         for i, point in ipairs(self.extra_points) do
+    --             print("checking point " ..
+    --                 i ..
+    --                 string.format(" is %d, %d       OR     %d, %d",
+    --                     extra_points[i] ~= nil and extra_points[i].x or -1,
+    --                     extra_points[i] ~= nil and extra_points[i].y or -1,
+    --                 )
+    --                 )
+    --             if extra_points[i].x ~= point.x or extra_points[i].y ~= point.y then
+    --                 same = false
+    --                 break
+    --             end
+    --         end
+    --     end
 
-        if same then return end -- No need to update
-    end
+    --     if same then return end -- No need to update
+    -- end
 
     print("updating")
 
     self.points = copyall(points)
-    if extra_points then self.extra_points = copyall(extra_points) end
+    -- if extra_points then self.extra_points = copyall(extra_points) end
     local top_left, bot_right = self:get_point_dims()
     self.arr = {}
     self.height = bot_right.x - top_left.x
@@ -399,7 +406,7 @@ function Line:update(points, extra_points)
     local x0, y0 = self.points[1].x, self.points[1].y
     local x1, y1 = self.points[2].x, self.points[2].y
     local thickness = self.options.thickness.value or 1
-    local bezier_point = extra_points[1].pos
+    local bezier_point = (#extra_points > 0) and {x = extra_points[1].x, y = extra_points[1].y} or nil
     if bezier_point then -- Use Bezier curve
         local t = 0
         local x2, y2 = bezier_point.x, bezier_point.y


### PR DESCRIPTION
[Demo.webm](https://user-images.githubusercontent.com/4482627/220819399-771243e2-503d-44fd-b7ef-e6a26b20bc10.webm)


### Refactors `gui/dig`

**Points Driven**

Previously, shapes would be defined by the bounds of the 'view rectangle' marked by the user's mouse. Now, shapes are defined by points (currently just 2, although this paves the way for n-point shapes), and the view rectangle is defined by the bounds of the shape (and any extra points).

This allows for shapes 'bigger' than the rectangle defined by the initial points, which allows for thicc lines despite the user marking an e.g. 1x10 shape.

**Real Lines have Curves**

New shape type: Line Segment, also introduces the new concept for `gui/dig` "extra points", these points are for modifying the shape that's defined by the 'main' points. Currently this is used to define the 'bezier point' to make a curved line. This has a lot of potential for creating some really cool stuff.

**Center Point Dragging**

Now creates a special 'center' point that can be dragged to move the shape around,

**Also**

- Adjusted the non auto-commit behavior, now when the users Control-C's to place a shape, it leaves the shape so the user can drag and re-designate it, to quickly designate multiple areas of a given shape.


**Notes**

IMO there's still some grey area about what exactly should be in `dig.lua` vs. `shapes.lua`, so I'll keep thinking about that... I'd like `shapes.lua` to be able to be used in other scripts if possible. There's a lot in `dig.lua` that would potentially be useful elsewhere as well, e.g. drawing nice borders around designations, so it's still a little in flux.