### PR TITLE
Update dig to allow dropping an extra point before placing second point.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ that repo.
 - `devel/query`: can now properly index vectors in the --table argument
 -@ `forbid`: fix detection of unreachable items for items in containers
 -@ `unforbid`: fix detection of unreachable items for items in containers
+- `gui/dig`: Allow placing an extra point (curve) while still placing thesecond main point
 
 ## Misc Improvements
 - `troubleshoot-item`: output as bullet point list with indenting, with item description and ID at top

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ that repo.
 ## New Scripts
 
 ## Fixes
+-@ `gui/dig`: Allow placing an extra point (curve) while still placing thesecond main point
 
 ## Misc Improvements
 
@@ -34,7 +35,6 @@ that repo.
 - `devel/query`: can now properly index vectors in the --table argument
 -@ `forbid`: fix detection of unreachable items for items in containers
 -@ `unforbid`: fix detection of unreachable items for items in containers
--@ `gui/dig`: Allow placing an extra point (curve) while still placing thesecond main point
 
 ## Misc Improvements
 - `troubleshoot-item`: output as bullet point list with indenting, with item description and ID at top

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,7 +24,7 @@ that repo.
 - `devel/query`: can now properly index vectors in the --table argument
 -@ `forbid`: fix detection of unreachable items for items in containers
 -@ `unforbid`: fix detection of unreachable items for items in containers
-- `gui/dig`: Allow placing an extra point (curve) while still placing thesecond main point
+-@ `gui/dig`: Allow placing an extra point (curve) while still placing thesecond main point
 
 ## Misc Improvements
 - `troubleshoot-item`: output as bullet point list with indenting, with item description and ID at top

--- a/gui/dig.lua
+++ b/gui/dig.lua
@@ -247,8 +247,13 @@ function GenericOptionsPanel:init()
             end,
             show_tooltip = true,
             on_activate = function()
-                self.dig_panel.placing_extra.active = true
-                self.dig_panel.placing_extra.index = #self.dig_panel.extra_points + 1
+                if self.dig_panel.mark1 and self.dig_panel.mark2 then
+                    self.dig_panel.placing_extra.active = true
+                    self.dig_panel.placing_extra.index = #self.dig_panel.extra_points + 1
+                elseif self.dig_panel.mark1 and not self.dig_panel.mark2 then
+                    local mouse_pos = dfhack.gui.getMousePos()
+                    self.dig_panel.extra_points[#self.dig_panel.extra_points + 1] = { x = mouse_pos.x, y = mouse_pos.y }
+                end
                 self.dig_panel.needs_update = true
             end,
         },
@@ -518,7 +523,6 @@ Dig.ATTRS {
     prio = 4,
     autocommit = true,
     cur_shape = 1,
-    -- extra_marks = {},
     placing_extra = { active = false, index = nil },
     prev_center = DEFAULT_NIL,
     extra_points = {},

--- a/gui/dig.lua
+++ b/gui/dig.lua
@@ -252,7 +252,7 @@ function GenericOptionsPanel:init()
                     self.dig_panel.placing_extra.index = #self.dig_panel.extra_points + 1
                 elseif self.dig_panel.mark1 and not self.dig_panel.mark2 then
                     local mouse_pos = dfhack.gui.getMousePos()
-                    self.dig_panel.extra_points[#self.dig_panel.extra_points + 1] = { x = mouse_pos.x, y = mouse_pos.y }
+                    if mouse_pos then table.insert(self.dig_panel.extra_points, { x = mouse_pos.x, y = mouse_pos.y }) end
                 end
                 self.dig_panel.needs_update = true
             end,


### PR DESCRIPTION
![Demo3](https://user-images.githubusercontent.com/4482627/221363498-c5cdc9a4-e878-41e5-b946-5c6f5e8d9eb5.gif)

A reddit comment got me thinking and I realized a nice UX feature is being able to use the `v` shortcut to drop an extra point for a curve whil placing the second point of a line. 

It actually works really well and I think is really intuitive.
