### PR TITLE
Dig mirror mode, S-curves, various fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ that repo.
 ## Fixes
 -@ `gui/dig`: Allow placing an extra point (curve) while still placing the second main point
 -@ `gui/dig`: Allow placing n-point shapes, shape rotation/mirroring, various code refactorings
+-@ `gui/dig`: Allow second bezier point, mirror-mode for freeform shapes, fix symmetry issues
 -@ `gui/create-item`: fix generic corpsepiece spawning
 
 ## Misc Improvements

--- a/gui/dig.lua
+++ b/gui/dig.lua
@@ -5,6 +5,9 @@
 
 -- Must Haves
 -----------------------------
+-- Cubic bezier algo
+-- freeform mirror shape
+-- Guidelines
 
 -- Should Haves
 -----------------------------
@@ -1200,7 +1203,6 @@ function Dig:onRenderFrame(dc, rect)
         return self:get_pen(pos.x, pos.y, mouse_pos)
     end
 
-    -- if self.placing_mark.active then
     if self.placing_mark.active and self.placing_mark.index ~= nil then
         self.marks[self.placing_mark.index] = mouse_pos
     end
@@ -1501,6 +1503,7 @@ function Dig:commit()
         self.extra_points = {}
         self.prev_center = nil
     end
+
     self:updateLayout()
 end
 

--- a/gui/dig.lua
+++ b/gui/dig.lua
@@ -12,7 +12,7 @@
 -- Refactor duplicated code into functions
 --  File is getting long... might be time to consider creating additional modules
 -- All the various states are getting hard to keep track of, e.g. placing extra/mirror/mark/etc...
---   Should consolidate the states into a single attribute with enum values
+--   Should consolidate the states into a single state attribute with enum values
 -- Keyboard support
 -- As the number of shapes and designations grow it might be better to have list menus for them instead of cycle
 -- Grid view without slowness (can ignore if next TODO is done, since nrmal mining mode has grid view)
@@ -82,21 +82,21 @@ local function table_to_string(tbl, indent)
     indent = indent or ""
     local result = {}
     for k, v in pairs(tbl) do
-        local key = type(k) == "number" and "[" .. tostring(k) .. "]" or tostring(k)
+        local key = type(k) == "number" and "["..tostring(k).."]" or tostring(k)
         if type(v) == "table" then
-            table.insert(result, indent .. key .. " = {")
-            local subTable = table_to_string(v, indent .. "  ")
+            table.insert(result, indent..key.." = {")
+            local subTable = table_to_string(v, indent.."  ")
             for _, line in ipairs(subTable) do
                 table.insert(result, line)
             end
-            table.insert(result, indent .. "},")
+            table.insert(result, indent.."},")
         elseif type(v) == "function" then
             local res = v()
-            local value = type(res) == "number" and tostring(res) or "\"" .. tostring(res) .. "\""
-            table.insert(result, indent .. key .. " = " .. value .. ",")
+            local value = type(res) == "number" and tostring(res) or "\""..tostring(res).."\""
+            table.insert(result, indent..key.." = "..value..",")
         else
-            local value = type(v) == "number" and tostring(v) or "\"" .. tostring(v) .. "\""
-            table.insert(result, indent .. key .. " = " .. value .. ",")
+            local value = type(v) == "number" and tostring(v) or "\""..tostring(v).."\""
+            table.insert(result, indent..key.." = "..value..",")
         end
     end
     return result
@@ -141,6 +141,7 @@ function DigDebugWindow:init()
     if not self.dig_window then
         return
     end
+
     for i, a in pairs(attrs) do
         local attr = a
         local sizeOnly = string.sub(attr, 1, 1) == "#"
@@ -150,16 +151,16 @@ function DigDebugWindow:init()
         end
 
         self:addviews { widgets.WrappedLabel {
-            view_id = "debug_label_" .. attr,
+            view_id = "debug_label_"..attr,
             text_to_wrap = function()
                 if type(self.dig_window[attr]) ~= "table" then
-                    return tostring(attr) .. ": " .. tostring(self.dig_window[attr])
+                    return tostring(attr)..": "..tostring(self.dig_window[attr])
                 end
 
                 if sizeOnly then
-                    return '#' .. tostring(attr) .. ": " .. tostring(#self.dig_window[attr])
+                    return '#'..tostring(attr)..": "..tostring(#self.dig_window[attr])
                 else
-                    return { tostring(attr) .. ": ", table.unpack(table_to_string(self.dig_window[attr], "  ")) }
+                    return { tostring(attr)..": ", table.unpack(table_to_string(self.dig_window[attr], "  ")) }
                 end
             end,
         } }
@@ -255,20 +256,20 @@ function ActionPanel:get_action_text()
     else
         text = "Select any draggable points"
     end
-    return text .. " with the mouse. Use right-click to dismiss points in order."
+    return text.." with the mouse. Use right-click to dismiss points in order."
 end
 
 function ActionPanel:get_area_text()
     local label = "Area: "
 
     local bounds = self.dig_panel:get_view_bounds()
-    if not bounds then return label .. "N/A" end
+    if not bounds then return label.."N/A" end
     local width = math.abs(bounds.x2 - bounds.x1) + 1
     local height = math.abs(bounds.y2 - bounds.y1) + 1
     local depth = math.abs(bounds.z2 - bounds.z1) + 1
     local tiles = self.dig_panel.shape.num_tiles * depth
     local plural = tiles > 1 and "s" or ""
-    return label .. ("%dx%dx%d (%d tile%s)"):format(
+    return label..("%dx%dx%d (%d tile%s)"):format(
         width,
         height,
         depth,
@@ -283,10 +284,10 @@ function ActionPanel:get_mark_text(num)
     local label = string.format("Mark %d: ", num)
 
     if not mark then
-        return label .. "Not set"
+        return label.."Not set"
     end
 
-    return label .. ("%d, %d, %d"):format(
+    return label..("%d, %d, %d"):format(
         mark.x,
         mark.y,
         mark.z
@@ -502,10 +503,10 @@ function GenericOptionsPanel:init()
             label = function()
                 local msg = "Place extra point: "
                 if #self.dig_panel.extra_points < #self.dig_panel.shape.extra_points then
-                    return msg .. self.dig_panel.shape.extra_points[#self.dig_panel.extra_points + 1].label
+                    return msg..self.dig_panel.shape.extra_points[#self.dig_panel.extra_points + 1].label
                 end
 
-                return msg .. "N/A"
+                return msg.."N/A"
             end,
             active = true,
             visible = function() return self.dig_panel.shape and #self.dig_panel.shape.extra_points > 0 end,
@@ -708,7 +709,7 @@ function GenericOptionsPanel:init()
         widgets.WrappedLabel {
             view_id = "shape_prio_label",
             text_to_wrap = function()
-                return "Priority: " .. tostring(self.dig_panel.prio)
+                return "Priority: "..tostring(self.dig_panel.prio)
             end,
         },
         widgets.HotkeyLabel {
@@ -1041,7 +1042,7 @@ function Dig:add_shape_options()
         if option.type == "bool" then
             self:addviews {
                 widgets.ToggleHotkeyLabel {
-                    view_id = "shape_option_" .. option.name,
+                    view_id = "shape_option_"..option.name,
                     key = option.key,
                     label = option.name,
                     active = true,
@@ -1077,9 +1078,9 @@ function Dig:add_shape_options()
 
             self:addviews {
                 widgets.HotkeyLabel {
-                    view_id = "shape_option_" .. option.name .. "_minus",
+                    view_id = "shape_option_"..option.name.."_minus",
                     key = option.keys[1],
-                    label = "Decrease " .. option.name,
+                    label = "Decrease "..option.name,
                     active = true,
                     enabled = function()
                         if option.enabled then
@@ -1099,9 +1100,9 @@ function Dig:add_shape_options()
                     end,
                 },
                 widgets.HotkeyLabel {
-                    view_id = "shape_option_" .. option.name .. "_plus",
+                    view_id = "shape_option_"..option.name.."_plus",
                     key = option.keys[2],
-                    label = "Increase " .. option.name,
+                    label = "Increase "..option.name,
                     active = true,
                     enabled = function()
                         if option.enabled then
@@ -1631,7 +1632,7 @@ function Dig:commit()
                         local desig = self:get_designation(col, row, zlevel)
                         if desig ~= "`" then
                             data[zlevel][row][col] =
-                            desig .. tostring(self.prio)
+                            desig..tostring(self.prio)
                         end
                     end
                 end

--- a/gui/dig.lua
+++ b/gui/dig.lua
@@ -1761,8 +1761,6 @@ DigScreen.ATTRS {
     focus_path = "dig",
     pass_pause = true,
     pass_movement_keys = true,
-    dig_window = DEFAULT_NIL,
-    debug_window = DEFAULT_NIL
 }
 
 function DigScreen:init()

--- a/gui/dig.lua
+++ b/gui/dig.lua
@@ -5,7 +5,6 @@
 
 -- Must Haves
 -----------------------------
--- Fix rotation of mirror shapes
 -- Reconsider sorting of mirrored points
 -- Better UI, it's starting to get really crowded
 
@@ -139,7 +138,7 @@ function DigDebugWindow:init()
         "show_guides"
     }
 
-    if self.dig_window == nil then
+    if not self.dig_window then
         return
     end
     for i, a in pairs(attrs) do
@@ -163,7 +162,7 @@ function DigDebugWindow:init()
                     return { tostring(attr) .. ": ", table.unpack(table_to_string(self.dig_window[attr], "  ")) }
                 end
             end,
-        }}
+        } }
     end
 end
 
@@ -203,7 +202,7 @@ function MarksPanel:update_mark_labels()
     end
 
     local mirror = self.dig_panel.mirror_point
-    if mirror ~= nil then
+    if mirror then
         table.insert(label_text, string.format("Mirror Point: %d, %d, %d", mirror.x, mirror.y, mirror.z))
     end
 
@@ -247,11 +246,11 @@ function ActionPanel:get_action_text()
         text = "Place the next point"
     elseif not self.dig_panel.marks[1] then
         text = "Place the first point"
-    elseif not self.parent_view.placing_extra.active and self.parent_view.prev_center == nil then
+    elseif not self.parent_view.placing_extra.active and not self.parent_view.prev_center then
         text = "Select any draggable points"
     elseif self.parent_view.placing_extra.active then
         text = "Place any extra points"
-    elseif self.parent_view.prev_center ~= nil then
+    elseif self.parent_view.prev_center then
         text = "Place the center point"
     else
         text = "Select any draggable points"
@@ -305,7 +304,7 @@ GenericOptionsPanel.ATTRS {
 
 function GenericOptionsPanel:init()
     local options = {}
-    for i, shape in pairs(shapes.all_shapes) do
+    for i, shape in ipairs(shapes.all_shapes) do
         options[#options + 1] = {
             label = shape.name,
             value = i,
@@ -402,13 +401,13 @@ function GenericOptionsPanel:init()
                     key = 'CUSTOM_M',
                     view_id = 'mirror_point_panel',
                     visible = function() return self.dig_panel.shape.can_mirror end,
-                    label = function() if self.dig_panel.mirror_point == nil then return 'Place Mirror Point' else return 'Delete Mirror Point' end end,
+                    label = function() if not self.dig_panel.mirror_point then return 'Place Mirror Point' else return 'Delete Mirror Point' end end,
                     active = true,
                     enabled = function() return not self.dig_panel.placing_extra.active and
-                            not self.dig_panel.placing_mark.active and self.prev_center == nil
+                            not self.dig_panel.placing_mark.active and not self.prev_center
                     end,
                     on_activate = function()
-                        if self.dig_panel.mirror_point == nil then
+                        if not self.dig_panel.mirror_point then
                             self.dig_panel.placing_mark.active = false
                             self.dig_panel.placing_extra.active = false
                             self.dig_panel.placing_extra.active = false
@@ -421,7 +420,7 @@ function GenericOptionsPanel:init()
                 },
                 widgets.ResizingPanel {
                     view_id = 'transform_panel_rotate',
-                    visible = function() return self.dig_panel.mirror_point ~= nil end,
+                    visible = function() return self.dig_panel.mirror_point end,
                     subviews = {
                         widgets.CycleHotkeyLabel {
                             view_id = "mirror_horiz_label",
@@ -462,6 +461,21 @@ function GenericOptionsPanel:init()
                             frame = { t = 3, l = 1 }, key_sep = '',
                             on_change = function() self.dig_panel.needs_update = true end
                         },
+                        widgets.HotkeyLabel {
+                            view_id = "mirror_vert_label",
+                            key = "CUSTOM_SHIFT_M",
+                            label = "Save Mirrored Points",
+                            active = true,
+                            enabled = true,
+                            show_tooltip = true,
+                            initial_option = 1,
+                            frame = { t = 4, l = 1 }, key_sep = ': ',
+                            on_activate = function()
+                                local points = self.dig_panel:get_mirrored_points(self.dig_panel.marks)
+                                self.dig_panel.marks = points
+                                self.dig_panel.mirror_point = nil
+                            end
+                        },
                     }
                 }
             }
@@ -494,9 +508,9 @@ function GenericOptionsPanel:init()
                 return msg .. "N/A"
             end,
             active = true,
-            visible = function() return self.dig_panel.shape ~= nil and #self.dig_panel.shape.extra_points > 0 end,
+            visible = function() return self.dig_panel.shape and #self.dig_panel.shape.extra_points > 0 end,
             enabled = function()
-                if self.dig_panel.shape ~= nil then
+                if self.dig_panel.shape then
                     return #self.dig_panel.extra_points < #self.dig_panel.shape.extra_points
                 end
 
@@ -523,10 +537,10 @@ function GenericOptionsPanel:init()
             active = true,
             visible = true,
             enabled = function()
-                if not self.dig_panel.placing_mark.active and self.dig_panel.prev_center == nil then
-                    return self.dig_panel.shape.max_points == nil or
+                if not self.dig_panel.placing_mark.active and not self.dig_panel.prev_center then
+                    return not self.dig_panel.shape.max_points or
                         #self.dig_panel.marks < self.dig_panel.shape.max_points
-                elseif not self.dig_panel.placing_extra.active and self.dig_panel.prev_center == nil then
+                elseif not self.dig_panel.placing_extra.active and not self.dig_panel.prev_centerl then
                     return true
                 end
 
@@ -553,7 +567,7 @@ function GenericOptionsPanel:init()
             active = true,
             enabled = function()
                 if #self.dig_panel.marks > 0 then return true
-                elseif self.dig_panel.shape ~= nil then
+                elseif self.dig_panel.shape then
                     if #self.dig_panel.extra_points < #self.dig_panel.shape.extra_points then
                         return true
                     end
@@ -579,7 +593,7 @@ function GenericOptionsPanel:init()
             label = "Clear extra points",
             active = true,
             enabled = function()
-                if self.dig_panel.shape ~= nil then
+                if self.dig_panel.shape then
                     if #self.dig_panel.extra_points > 0 then
                         return true
                     end
@@ -588,10 +602,10 @@ function GenericOptionsPanel:init()
                 return false
             end,
             disabled = false,
-            visible = function() return self.dig_panel.shape ~= nil and #self.dig_panel.shape.extra_points > 0 end,
+            visible = function() return self.dig_panel.shape and #self.dig_panel.shape.extra_points > 0 end,
             show_tooltip = true,
             on_activate = function()
-                if self.dig_panel.shape ~= nil then
+                if self.dig_panel.shape then
                     self.dig_panel.extra_points = {}
                     self.dig_panel.prev_center = nil
                     self.dig_panel.start_center = nil
@@ -734,7 +748,7 @@ function GenericOptionsPanel:init()
             key = "CUSTOM_C",
             label = "Auto-Commit: ",
             active = true,
-            enabled = function() return self.dig_panel.shape.max_points ~= nil end,
+            enabled = function() return self.dig_panel.shape.max_points end,
             disabled = false,
             show_tooltip = true,
             initial_option = true,
@@ -901,13 +915,13 @@ function Dig:get_pen(x, y, mousePos)
         end
     end
 
-    for i, mark in pairs(self.marks) do
+    for i, mark in ipairs(self.marks) do
         if same_xy(mark, xy2pos(x, y)) then
             drag_point = true
         end
     end
 
-    if self.mirror_point ~= nil and same_xy(self.mirror_point, xy2pos(x, y)) then
+    if self.mirror_point and same_xy(self.mirror_point, xy2pos(x, y)) then
         drag_point = true
     end
 
@@ -967,7 +981,7 @@ function Dig:get_pen(x, y, mousePos)
         else cursor = nil
         end
     end
-    
+
     -- Create the pen if the cursor is set
     if cursor then PENS[pen_key] = self:make_pen(cursor, drag_point, mouse_over, get_point, extra_point) end
 
@@ -1032,7 +1046,7 @@ function Dig:add_shape_options()
                     label = option.name,
                     active = true,
                     enabled = function()
-                        if option.enabled == nil then
+                        if not option.enabled then
                             return true
                         else
                             return self.shape.options[option.enabled[1]].value == option.enabled[2]
@@ -1068,12 +1082,12 @@ function Dig:add_shape_options()
                     label = "Decrease " .. option.name,
                     active = true,
                     enabled = function()
-                        if option.enabled ~= nil then
+                        if option.enabled then
                             if self.shape.options[option.enabled[1]].value ~= option.enabled[2] then
                                 return false
                             end
                         end
-                        return min == nil or
+                        return not min or
                             (self.shape.options[key].value > min)
                     end,
                     disabled = false,
@@ -1090,12 +1104,12 @@ function Dig:add_shape_options()
                     label = "Increase " .. option.name,
                     active = true,
                     enabled = function()
-                        if option.enabled ~= nil then
+                        if option.enabled then
                             if self.shape.options[option.enabled[1]].value ~= option.enabled[2] then
                                 return false
                             end
                         end
-                        return max == nil or
+                        return not max or
                             (self.shape.options[key].value <= max)
                     end,
                     disabled = false,
@@ -1116,6 +1130,13 @@ function Dig:on_transform(val)
     -- if self.mirror_point then
     --     center_x, center_y = self.mirror_point.x, self.mirror_point.y
     -- end
+
+    -- Save mirrored points first
+    if self.mirror_point then
+        local points = self:get_mirrored_points(self.marks)
+        self.marks = points
+        self.mirror_point = nil
+    end
 
     -- Transform marks
     for i, mark in ipairs(self.marks) do
@@ -1256,7 +1277,7 @@ function Dig:onRenderFrame(dc, rect)
 
     Dig.super.onRenderFrame(self, dc, rect)
 
-    if self.shape == nil then
+    if not self.shape then
         self.shape = shapes.all_shapes[self.subviews.shape_name:getOptionValue()]
     end
 
@@ -1268,7 +1289,7 @@ function Dig:onRenderFrame(dc, rect)
         return self:get_pen(pos.x, pos.y, mouse_pos)
     end
 
-    if self.placing_mark.active and self.placing_mark.index ~= nil then
+    if self.placing_mark.active and self.placing_mark.index then
         self.marks[self.placing_mark.index] = mouse_pos
     end
 
@@ -1288,22 +1309,22 @@ function Dig:onRenderFrame(dc, rect)
     end
 
     -- Check if moving center, if so shift the shape by the delta between the previous and current points
-    if self.prev_center ~= nil and
+    if self.prev_center and
         (self.shape.basic_shape and #self.marks == self.shape.max_points
             or not self.shape.basic_shape and not self.placing_mark.active) then
-        if mouse_pos ~= nil and (self.prev_center.x ~= mouse_pos.x or self.prev_center.y ~= mouse_pos.y or
+        if mouse_pos and (self.prev_center.x ~= mouse_pos.x or self.prev_center.y ~= mouse_pos.y or
             self.prev_center.z ~= mouse_pos.z) then
             self.needs_update = true
             local transform = { x = mouse_pos.x - self.prev_center.x, y = mouse_pos.y - self.prev_center.y,
                 z = mouse_pos.z - self.prev_center.z }
 
-            for i, _ in pairs(self.marks) do
+            for i, _ in ipairs(self.marks) do
                 self.marks[i].x = self.marks[i].x + transform.x
                 self.marks[i].y = self.marks[i].y + transform.y
                 self.marks[i].z = self.marks[i].z + transform.z
             end
 
-            for i, point in pairs(self.extra_points) do
+            for i, point in ipairs(self.extra_points) do
                 self.extra_points[i].x = self.extra_points[i].x + transform.x
                 self.extra_points[i].y = self.extra_points[i].y + transform.y
             end
@@ -1317,79 +1338,9 @@ function Dig:onRenderFrame(dc, rect)
         end
     end
 
-    local mirrored_points = {}
     if self.mirror_point then
-        for i, point in pairs(points) do
-            local mirror_horiz_value = self.subviews.mirror_horiz_label:getOptionValue()
-            local mirror_diag_value = self.subviews.mirror_diag_label:getOptionValue()
-            local mirror_vert_value = self.subviews.mirror_vert_label:getOptionValue()
-
-            -- 1 maps to "Off"
-            if mirror_horiz_value ~= 1 then
-                local mirrored_y = self.mirror_point.y + ((self.mirror_point.y - point.y))
-
-                -- if Mirror (even), then increase mirror amount by 1
-                if mirror_horiz_value == 3 then
-                    if mirrored_y > self.mirror_point.y then
-                        mirrored_y = mirrored_y + 1
-                    else
-                        mirrored_y = mirrored_y - 1
-                    end
-                end
-                table.insert(mirrored_points, { z = point.z, x = point.x, y = mirrored_y })
-            end
-            if mirror_diag_value ~= 1 then
-                local mirrored_y = self.mirror_point.y + ((self.mirror_point.y - point.y))
-                local mirrored_x = self.mirror_point.x + ((self.mirror_point.x - point.x))
-
-                -- if Mirror (even), then increase mirror amount by 1
-                if mirror_diag_value == 3 then
-                    if mirrored_y > self.mirror_point.y then
-                        mirrored_y = mirrored_y + 1
-                        mirrored_x = mirrored_x + 1
-                    else
-                        mirrored_y = mirrored_y - 1
-                        mirrored_x = mirrored_x - 1
-                    end
-                end
-                table.insert(mirrored_points, { z = point.z, x = mirrored_x, y = mirrored_y })
-            end
-            if mirror_vert_value ~= 1 then
-                local mirrored_x = self.mirror_point.x + ((self.mirror_point.x - point.x))
-
-                -- if Mirror (even), then increase mirror amount by 1
-                if mirror_vert_value == 3 then
-                    if mirrored_x > self.mirror_point.x then
-                        mirrored_x = mirrored_x + 1
-                    else
-                        mirrored_x = mirrored_x - 1
-                    end
-                end
-                table.insert(mirrored_points, { z = point.z, x = mirrored_x, y = point.y })
-            end
-        end
-
-        for i, point in pairs(mirrored_points) do
-            table.insert(points, mirrored_points[i])
-        end
-
-        -- local center_x, center_y = 0, 0
-        -- for i = 1, #points do
-        --     center_x = center_x + points[i].x
-        --     center_y = center_y + points[i].y
-        -- end
-        -- center_x = center_x / #points
-        -- center_y = center_y / #points
-
-        -- Sorts the points by angle relative to the mirror point to connect points sequentially
-        -- TODO, this whole thing can probably be avoided by connecting the points better beforehand
-        table.sort(points, function(a, b)
-            local atan_a = math.atan(a.y - self.mirror_point.y, a.x - self.mirror_point.x)
-            local atan_b = math.atan(b.y - self.mirror_point.y, b.x - self.mirror_point.x)
-            return atan_a < atan_b
-        end)
+        points = self:get_mirrored_points(points)
     end
-
 
     if self:shape_needs_update() then
         self.shape:update(points, self.extra_points)
@@ -1401,15 +1352,16 @@ function Dig:onRenderFrame(dc, rect)
 
     -- Generate bounds based on the shape's dimensions
     local bounds = self:get_view_bounds()
-    if self.shape ~= nil and bounds ~= nil then
+    if self.shape and bounds then
         local top_left, bot_right = self.shape:get_view_dims(self.extra_points, self.mirror_point)
-        if top_left == nil or bot_right == nil then return end
+        if not top_left or not bot_right then return end
         bounds.x1 = top_left.x
         bounds.x2 = bot_right.x
         bounds.y1 = top_left.y
         bounds.y2 = bot_right.y
     end
 
+    -- Show mouse guidelines
     if self.show_guides and mouse_pos then
         local map_x, map_y, map_z = dfhack.maps.getTileSize()
         local horiz_bounds = { x1 = 0, x2 = map_x, y1 = mouse_pos.y, y2 = mouse_pos.y, z1 = mouse_pos.z, z2 = mouse_pos.z }
@@ -1418,6 +1370,7 @@ function Dig:onRenderFrame(dc, rect)
         guidm.renderMapOverlay(function() return guide_tile_pen end, vert_bounds)
     end
 
+    -- Show Mirror guidelines
     if self.mirror_point then
         local mirror_horiz_value = self.subviews.mirror_horiz_label:getOptionValue()
         local mirror_diag_value = self.subviews.mirror_diag_label:getOptionValue()
@@ -1464,18 +1417,18 @@ function Dig:onInput(keys)
 
     if keys.LEAVESCREEN or keys._MOUSE_R_DOWN then
         -- If center draggin, put the shape back to the original center
-        if self.prev_center ~= nil then
+        if self.prev_center then
             local transform = { x = self.start_center.x - self.prev_center.x,
                 y = self.start_center.y - self.prev_center.y,
                 z = self.start_center.z - self.prev_center.z }
 
-            for i, _ in pairs(self.marks) do
+            for i, _ in ipairs(self.marks) do
                 self.marks[i].x = self.marks[i].x + transform.x
                 self.marks[i].y = self.marks[i].y + transform.y
                 self.marks[i].z = self.marks[i].z + transform.z
             end
 
-            for i, point in pairs(self.extra_points) do
+            for i, point in ipairs(self.extra_points) do
                 self.extra_points[i].x = self.extra_points[i].x + transform.x
                 self.extra_points[i].y = self.extra_points[i].y + transform.y
             end
@@ -1487,7 +1440,7 @@ function Dig:onInput(keys)
         end -- TODO
 
         -- If extra points, clear them and return
-        if self.shape ~= nil then
+        if self.shape then
             if #self.extra_points > 0 or self.placing_extra.active then
                 self.extra_points = {}
                 self.placing_extra.active = false
@@ -1527,7 +1480,7 @@ function Dig:onInput(keys)
 
     if keys._MOUSE_L_DOWN and pos then
         -- TODO Refactor this a bit
-        if self.shape.max_points ~= nil and #self.marks == self.shape.max_points and self.placing_mark.active then
+        if self.shape.max_points and #self.marks == self.shape.max_points and self.placing_mark.active then
             self.marks[self.placing_mark.index] = pos
             self.placing_mark.index = self.placing_mark.index + 1
             self.placing_mark.active = false
@@ -1574,7 +1527,7 @@ function Dig:onInput(keys)
                     end
                 end
             else
-                for i, point in pairs(self.marks) do
+                for i, point in ipairs(self.marks) do
                     if same_xy(pos, point) then
                         self.placing_mark = { active = true, index = i, continue = false }
                     end
@@ -1593,11 +1546,11 @@ function Dig:onInput(keys)
             -- Clicking center point
             if #self.marks > 0 then
                 local center_x, center_y = self.shape:get_center()
-                if same_xy(pos, xy2pos(center_x, center_y)) and self.prev_center == nil then
+                if same_xy(pos, xy2pos(center_x, center_y)) and not self.prev_center then
                     self.start_center = pos
                     self.prev_center = pos
                     return true
-                elseif self.prev_center ~= nil then
+                elseif self.prev_center then
                     self.start_center = nil
                     self.prev_center = nil
                     return true
@@ -1635,13 +1588,13 @@ function Dig:get_designation(x, y, z)
         elseif view_bounds and z == math.abs(view_bounds.z1 - view_bounds.z2) then
             local pos = xyz2pos(view_bounds.x1 + x, view_bounds.y1 + y, view_bounds.z1 + z)
             local tile_type = dfhack.maps.getTileType(pos)
-            local tile_shape = tile_type ~= nil and tile_attrs[tile_type].shape or nil
+            local tile_shape = tile_type and tile_attrs[tile_type].shape or nil
             local designation = dfhack.maps.getTileFlags(pos)
 
             -- If top of the view_bounds is down stair, 'auto' should change it to up/down to match vanilla stair logic
             local up_or_updown_dug = (
                 tile_shape == df.tiletype_shape.STAIR_DOWN or tile_shape == df.tiletype_shape.STAIR_UPDOWN)
-            local up_or_updown_desig = designation ~= nil and (designation.dig == df.tile_dig_designation.UpStair or
+            local up_or_updown_desig = designation and (designation.dig == df.tile_dig_designation.UpStair or
                 designation.dig == df.tile_dig_designation.UpDownStair)
 
             if stairs_top_type == "auto" then
@@ -1725,8 +1678,78 @@ function Dig:commit()
     self:updateLayout()
 end
 
+function Dig:get_mirrored_points(points)
+    local mirrored_points = {}
+    for i, point in ipairs(points) do
+        local mirror_horiz_value = self.subviews.mirror_horiz_label:getOptionValue()
+        local mirror_diag_value = self.subviews.mirror_diag_label:getOptionValue()
+        local mirror_vert_value = self.subviews.mirror_vert_label:getOptionValue()
+
+        -- 1 maps to "Off"
+        if mirror_horiz_value ~= 1 then
+            local mirrored_y = self.mirror_point.y + ((self.mirror_point.y - point.y))
+
+            -- if Mirror (even), then increase mirror amount by 1
+            if mirror_horiz_value == 3 then
+                if mirrored_y > self.mirror_point.y then
+                    mirrored_y = mirrored_y + 1
+                else
+                    mirrored_y = mirrored_y - 1
+                end
+            end
+
+            table.insert(mirrored_points, { z = point.z, x = point.x, y = mirrored_y })
+        end
+        if mirror_diag_value ~= 1 then
+            local mirrored_y = self.mirror_point.y + ((self.mirror_point.y - point.y))
+            local mirrored_x = self.mirror_point.x + ((self.mirror_point.x - point.x))
+
+            -- if Mirror (even), then increase mirror amount by 1
+            if mirror_diag_value == 3 then
+                if mirrored_y > self.mirror_point.y then
+                    mirrored_y = mirrored_y + 1
+                    mirrored_x = mirrored_x + 1
+                else
+                    mirrored_y = mirrored_y - 1
+                    mirrored_x = mirrored_x - 1
+                end
+            end
+
+            table.insert(mirrored_points, { z = point.z, x = mirrored_x, y = mirrored_y })
+        end
+        if mirror_vert_value ~= 1 then
+            local mirrored_x = self.mirror_point.x + ((self.mirror_point.x - point.x))
+
+            -- if Mirror (even), then increase mirror amount by 1
+            if mirror_vert_value == 3 then
+                if mirrored_x > self.mirror_point.x then
+                    mirrored_x = mirrored_x + 1
+                else
+                    mirrored_x = mirrored_x - 1
+                end
+            end
+
+            table.insert(mirrored_points, { z = point.z, x = mirrored_x, y = point.y })
+        end
+    end
+
+    for i, point in ipairs(mirrored_points) do
+        table.insert(points, mirrored_points[i])
+    end
+
+    -- Sorts the points by angle relative to the mirror point to connect points sequentially
+    -- TODO, this whole thing can probably be avoided by connecting the points better beforehand
+    table.sort(points, function(a, b)
+        local atan_a = math.atan(a.y - self.mirror_point.y, a.x - self.mirror_point.x)
+        local atan_b = math.atan(b.y - self.mirror_point.y, b.x - self.mirror_point.x)
+        return atan_a < atan_b
+    end)
+
+    return points
+end
+
 --
--- Dig
+-- DigScreen
 --
 
 DigScreen = defclass(DigScreen, gui.ZScreen)

--- a/gui/dig.lua
+++ b/gui/dig.lua
@@ -5,7 +5,6 @@
 
 -- Must Haves
 -----------------------------
--- Reconsider sorting of mirrored points
 -- Better UI, it's starting to get really crowded
 
 -- Should Haves
@@ -67,6 +66,7 @@ local mirror_guide_pen = to_pen {
 -- Utilities
 
 local function same_xy(pos1, pos2)
+    if not pos1 or not pos2 then return false end
     return pos1.x == pos2.x and pos1.y == pos2.y
 end
 
@@ -76,7 +76,7 @@ end
 
 -- Debug window
 
-SHOW_DEBUG_WINDOW = true
+SHOW_DEBUG_WINDOW = false
 
 local function table_to_string(tbl, indent)
     indent = indent or ""
@@ -836,8 +836,8 @@ Dig.ATTRS {
     name = "dig_window",
     frame_title = "Dig",
     frame = {
-        w = 47,
-        h = 40,
+        w = 40,
+        h = 45,
         r = 2,
         t = 18,
     },
@@ -1679,12 +1679,13 @@ function Dig:commit()
 end
 
 function Dig:get_mirrored_points(points)
-    local mirrored_points = {}
-    for i, point in ipairs(points) do
-        local mirror_horiz_value = self.subviews.mirror_horiz_label:getOptionValue()
-        local mirror_diag_value = self.subviews.mirror_diag_label:getOptionValue()
-        local mirror_vert_value = self.subviews.mirror_vert_label:getOptionValue()
+    local mirror_horiz_value = self.subviews.mirror_horiz_label:getOptionValue()
+    local mirror_diag_value = self.subviews.mirror_diag_label:getOptionValue()
+    local mirror_vert_value = self.subviews.mirror_vert_label:getOptionValue()
 
+    local mirrored_points = {}
+    for i = #points, 1, -1 do
+        local point = points[i]
         -- 1 maps to "Off"
         if mirror_horiz_value ~= 1 then
             local mirrored_y = self.mirror_point.y + ((self.mirror_point.y - point.y))
@@ -1700,6 +1701,9 @@ function Dig:get_mirrored_points(points)
 
             table.insert(mirrored_points, { z = point.z, x = point.x, y = mirrored_y })
         end
+    end
+
+    for i, point in ipairs(points) do
         if mirror_diag_value ~= 1 then
             local mirrored_y = self.mirror_point.y + ((self.mirror_point.y - point.y))
             local mirrored_x = self.mirror_point.x + ((self.mirror_point.x - point.x))
@@ -1717,6 +1721,10 @@ function Dig:get_mirrored_points(points)
 
             table.insert(mirrored_points, { z = point.z, x = mirrored_x, y = mirrored_y })
         end
+    end
+
+    for i = #points, 1, -1 do
+        local point = points[i]
         if mirror_vert_value ~= 1 then
             local mirrored_x = self.mirror_point.x + ((self.mirror_point.x - point.x))
 
@@ -1736,14 +1744,6 @@ function Dig:get_mirrored_points(points)
     for i, point in ipairs(mirrored_points) do
         table.insert(points, mirrored_points[i])
     end
-
-    -- Sorts the points by angle relative to the mirror point to connect points sequentially
-    -- TODO, this whole thing can probably be avoided by connecting the points better beforehand
-    table.sort(points, function(a, b)
-        local atan_a = math.atan(a.y - self.mirror_point.y, a.x - self.mirror_point.x)
-        local atan_b = math.atan(b.y - self.mirror_point.y, b.x - self.mirror_point.x)
-        return atan_a < atan_b
-    end)
 
     return points
 end

--- a/gui/dig.lua
+++ b/gui/dig.lua
@@ -1128,9 +1128,6 @@ end
 
 function Dig:on_transform(val)
     local center_x, center_y = self.shape:get_center()
-    -- if self.mirror_point then
-    --     center_x, center_y = self.mirror_point.x, self.mirror_point.y
-    -- end
 
     -- Save mirrored points first
     if self.mirror_point then
@@ -1182,6 +1179,7 @@ function Dig:on_transform(val)
         self.marks[i].x = self.marks[i].x + delta_x
         self.marks[i].y = self.marks[i].y + delta_y
     end
+
     for i, point in ipairs(self.extra_points) do
         self.extra_points[i].x = self.extra_points[i].x + delta_x
         self.extra_points[i].y = self.extra_points[i].y + delta_y
@@ -1310,33 +1308,38 @@ function Dig:onRenderFrame(dc, rect)
     end
 
     -- Check if moving center, if so shift the shape by the delta between the previous and current points
+    -- TODO clean this up
     if self.prev_center and
-        (self.shape.basic_shape and #self.marks == self.shape.max_points
-            or not self.shape.basic_shape and not self.placing_mark.active) then
-        if mouse_pos and (self.prev_center.x ~= mouse_pos.x or self.prev_center.y ~= mouse_pos.y or
-            self.prev_center.z ~= mouse_pos.z) then
-            self.needs_update = true
-            local transform = { x = mouse_pos.x - self.prev_center.x, y = mouse_pos.y - self.prev_center.y,
-                z = mouse_pos.z - self.prev_center.z }
+        (
+        (self.shape.basic_shape and #self.marks == self.shape.max_points)
+            or (not self.shape.basic_shape and not self.placing_mark.active)
+        )
+        and mouse_pos and (
+        (self.prev_center.x ~= mouse_pos.x)
+            or (self.prev_center.y ~= mouse_pos.y)
+            or (self.prev_center.z ~= mouse_pos.z)
+        ) then
+        self.needs_update = true
+        local transform = { x = mouse_pos.x - self.prev_center.x, y = mouse_pos.y - self.prev_center.y,
+            z = mouse_pos.z - self.prev_center.z }
 
-            for i, _ in ipairs(self.marks) do
-                self.marks[i].x = self.marks[i].x + transform.x
-                self.marks[i].y = self.marks[i].y + transform.y
-                self.marks[i].z = self.marks[i].z + transform.z
-            end
-
-            for i, point in ipairs(self.extra_points) do
-                self.extra_points[i].x = self.extra_points[i].x + transform.x
-                self.extra_points[i].y = self.extra_points[i].y + transform.y
-            end
-
-            if self.mirror_point then
-                self.mirror_point.x = self.mirror_point.x + transform.x
-                self.mirror_point.y = self.mirror_point.y + transform.y
-            end
-
-            self.prev_center = mouse_pos
+        for i, _ in ipairs(self.marks) do
+            self.marks[i].x = self.marks[i].x + transform.x
+            self.marks[i].y = self.marks[i].y + transform.y
+            self.marks[i].z = self.marks[i].z + transform.z
         end
+
+        for i, point in ipairs(self.extra_points) do
+            self.extra_points[i].x = self.extra_points[i].x + transform.x
+            self.extra_points[i].y = self.extra_points[i].y + transform.y
+        end
+
+        if self.mirror_point then
+            self.mirror_point.x = self.mirror_point.x + transform.x
+            self.mirror_point.y = self.mirror_point.y + transform.y
+        end
+
+        self.prev_center = mouse_pos
     end
 
     if self.mirror_point then
@@ -1632,7 +1635,7 @@ function Dig:commit()
                         local desig = self:get_designation(col, row, zlevel)
                         if desig ~= "`" then
                             data[zlevel][row][col] =
-                            desig..tostring(self.prio)
+                            desig .. tostring(self.prio)
                         end
                     end
                 end

--- a/internal/dig/shapes.lua
+++ b/internal/dig/shapes.lua
@@ -173,6 +173,7 @@ function Shape:get_center()
     -- return center_x, center_y
 
     -- Simple way to get the center defined by the point dims
+    if #self.points == 0 then return nil, nil end
     local top_left, bot_right = self:get_point_dims()
     return math.floor((bot_right.x - top_left.x) / 2) + top_left.x,
         math.floor((bot_right.y - top_left.y) / 2) + top_left.y
@@ -184,8 +185,9 @@ end
 function Shape:update(points)
     self.num_tiles = 0
     self.points = copyall(points)
-    local top_left, bot_right = self:get_point_dims()
     self.arr = {}
+    if #points < self.min_points then return end
+    local top_left, bot_right = self:get_point_dims()
     self.height = bot_right.y - top_left.y
     self.width = bot_right.x - top_left.x
 
@@ -543,8 +545,9 @@ end
 function FreeForm:update(points, extra_points)
     self.num_tiles = 0
     self.points = copyall(points)
-    local top_left, bot_right = self:get_point_dims()
     self.arr = {}
+    if #points < self.min_points then return end
+    local top_left, bot_right = self:get_point_dims()
     self.height = bot_right.x - top_left.x
     self.width = bot_right.y - top_left.y
 

--- a/internal/dig/shapes.lua
+++ b/internal/dig/shapes.lua
@@ -88,7 +88,7 @@ end
 -- Get dimensions taking into account, main points, extra points,
 -- and the shape array, anything that needs to be drawn should be
 -- within these bounds
-function Shape:get_view_dims(extra_points)
+function Shape:get_view_dims(extra_points, mirror_point)
     local min_x, min_y, max_x, max_y
     for x, _ in pairs(self.arr) do
         for y, _ in pairs(self.arr[x]) do
@@ -132,6 +132,13 @@ function Shape:get_view_dims(extra_points)
             min_y = math.min(min_y, point.y)
             max_y = math.max(max_y, point.y)
         end
+    end
+
+    if mirror_point then
+        min_x = math.min(min_x, mirror_point.x)
+        max_x = math.max(max_x, mirror_point.x)
+        min_y = math.min(min_y, mirror_point.y)
+        max_y = math.max(max_y, mirror_point.y)
     end
 
     return { x = min_x, y = min_y }, { x = max_x, y = max_y }

--- a/internal/dig/shapes.lua
+++ b/internal/dig/shapes.lua
@@ -147,7 +147,7 @@ function Shape:get_view_dims(extra_points, mirror_point)
 end
 
 function Shape:points_to_string(points)
-    local points = points == nil and self.points or points
+    local points = (not points) and self.points or points
     local output = ""
     local sep = ""
     for _, point in ipairs(points) do

--- a/internal/dig/shapes.lua
+++ b/internal/dig/shapes.lua
@@ -452,13 +452,15 @@ function Line:update(points, extra_points)
         local t = 0
         local x2, y2 = bezier_point.x, bezier_point.y
         while t <= 1 do
-            local x = math.floor((1 - t) ^ 2 * x0 + 2 * (1 - t) * t * x2 + t ^ 2 * x1)
-            local y = math.floor((1 - t) ^ 2 * y0 + 2 * (1 - t) * t * y2 + t ^ 2 * y1)
+            local x = math.floor(((1 - t) ^ 2 * x0 + 2 * (1 - t) * t * x2 + t ^ 2 * x1) + 0.5)
+            local y = math.floor(((1 - t) ^ 2 * y0 + 2 * (1 - t) * t * y2 + t ^ 2 * y1) + 0.5)
             for i = 0, thickness - 1 do
                 for j = -math.floor(thickness / 2), math.ceil(thickness / 2) - 1 do
                     if not self.arr[x + j] then self.arr[x + j] = {} end
-                    self.arr[x + j][y + i] = true
-                    self.num_tiles = self.num_tiles + 1
+                    if not self.arr[x + j][y + i] then
+                        self.arr[x + j][y + i] = true
+                        self.num_tiles = self.num_tiles + 1
+                    end
                 end
             end
             t = t + 0.01

--- a/internal/dig/shapes.lua
+++ b/internal/dig/shapes.lua
@@ -151,7 +151,7 @@ function Shape:points_to_string(points)
     local output = ""
     local sep = ""
     for _, point in ipairs(points) do
-        output = output .. sep .. string.format("(%d, %d)", point.x, point.y)
+        output = output..sep..string.format("(%d, %d)", point.x, point.y)
         sep = ", "
     end
 

--- a/internal/dig/shapes.lua
+++ b/internal/dig/shapes.lua
@@ -89,58 +89,35 @@ end
 -- and the shape array, anything that needs to be drawn should be
 -- within these bounds
 -- TODO this probably belongs in dig.lua at this point
--- TODO also this needs to be cleaned up before seeing the light of day
 function Shape:get_view_dims(extra_points, mirror_point)
+    local function update_minmax(point, min_x, min_y, max_x, max_y)
+        if not min_x then
+            min_x, max_x, min_y, max_y = point.x, point.x, point.y, point.y
+        else
+            min_x, max_x = math.min(min_x, point.x), math.max(max_x, point.x)
+            min_y, max_y = math.min(min_y, point.y), math.max(max_y, point.y)
+        end
+        return min_x, min_y, max_x, max_y
+    end
+
     local min_x, min_y, max_x, max_y
-    for x, _ in pairs(self.arr) do
-        for y, _ in pairs(self.arr[x]) do
-            if not min_x then
-                min_x = x
-                max_x = x
-                min_y = y
-                max_y = y
-            else
-                min_x = math.min(min_x, x)
-                max_x = math.max(max_x, x)
-                min_y = math.min(min_y, y)
-                max_y = math.max(max_y, y)
-            end
+
+    for x, y_vals in pairs(self.arr) do
+        for y, _ in pairs(y_vals) do
+            min_x, min_y, max_x, max_y = update_minmax({ x = x, y = y }, min_x, min_y, max_x, max_y)
         end
     end
 
-    for i, point in pairs(self.points) do
-        if not min_x then
-            min_x = point.x
-            max_x = point.x
-            min_y = point.y
-            max_y = point.y
-        else
-            min_x = math.min(min_x, point.x)
-            max_x = math.max(max_x, point.x)
-            min_y = math.min(min_y, point.y)
-            max_y = math.max(max_y, point.y)
-        end
+    for _, point in pairs(self.points) do
+        min_x, min_y, max_x, max_y = update_minmax(point, min_x, min_y, max_x, max_y)
     end
 
-    for i, point in pairs(extra_points) do
-        if not min_x then
-            min_x = point.x
-            max_x = point.x
-            min_y = point.y
-            max_y = point.y
-        else
-            min_x = math.min(min_x, point.x)
-            max_x = math.max(max_x, point.x)
-            min_y = math.min(min_y, point.y)
-            max_y = math.max(max_y, point.y)
-        end
+    for _, point in pairs(extra_points) do
+        min_x, min_y, max_x, max_y = update_minmax(point, min_x, min_y, max_x, max_y)
     end
 
     if mirror_point then
-        min_x = math.min(min_x, mirror_point.x)
-        max_x = math.max(max_x, mirror_point.x)
-        min_y = math.min(min_y, mirror_point.y)
-        max_y = math.max(max_y, mirror_point.y)
+        min_x, min_y, max_x, max_y = update_minmax(mirror_point, min_x, min_y, max_x, max_y)
     end
 
     return { x = min_x, y = min_y }, { x = max_x, y = max_y }
@@ -151,7 +128,7 @@ function Shape:points_to_string(points)
     local output = ""
     local sep = ""
     for _, point in ipairs(points) do
-        output = output..sep..string.format("(%d, %d)", point.x, point.y)
+        output = output .. sep .. string.format("(%d, %d)", point.x, point.y)
         sep = ", "
     end
 

--- a/internal/dig/shapes.lua
+++ b/internal/dig/shapes.lua
@@ -124,7 +124,7 @@ function Shape:get_view_dims(extra_points, mirror_point)
 end
 
 function Shape:points_to_string(points)
-    local points = (not points) and self.points or points
+    local points = points or self.points
     local output = ""
     local sep = ""
     for _, point in ipairs(points) do


### PR DESCRIPTION
### Added option to place second bezier point for curves
![s_curve](https://user-images.githubusercontent.com/4482627/223886015-39667ba6-8ec2-47bd-9a3a-da9c14273da1.gif)

### Add option to set a 'mirror point' when drawing freeform shapes
Allows setting a point and selecting mirror directions (vertical, horizontal, diagonal). Points will be mirrored across the planes defined by the point. The user can choose to 'save' the mirrored points which makes them into regular draggable points that can be transformed, moved, etc...

This works pretty well, but the interface is maybe a ltitle clunky. Should look in to UI improvements soon.
![freeform_mirror](https://user-images.githubusercontent.com/4482627/223886026-b12ec0f3-1136-45b0-b070-55b8de5101b0.gif)

### Symmetry fixes
- `Line` shapes have been updated to draw the line both ways, this will guarantee creating symmetrical lines in cases where the Bresenham's algorithm has to 'choose' tiles arbitrarily when tie breaking.
- Updated bezier algorithm to fix rounding errors that created asymmetric curves


### Also
- Changed 'Transform' hotkey to `Y` (conflicted with thickness)
- Added optional guide line crosshair for mouse pos to help line things up