### PR TITLE
Fix suspendmanager building identification sometimes being wrong

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ that repo.
 
 ## Fixes
 - `suspendmanager`: does not suspend non blocking jobs such as floor bars or bridges anymore
+- `suspendmanager`: fix occasional bad identification of buildingplan jobs
 
 ## Misc Improvements
 - `gui/control-panel`: Now detects overlays from scripts named with capital letters

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -196,7 +196,7 @@ function shouldBeSuspended(job, accountblocking)
         return true, 'underwater'
     end
 
-    local bld = dfhack.buildings.findAtTile(job.pos)
+    local bld = dfhack.job.getHolder(job)
     if bld and buildingplan and buildingplan.isPlannedBuilding(bld) then
         return true, 'buildingplan'
     end


### PR DESCRIPTION
When trying to determine if a job was suspended by `buildingplan`, suspendmanager was retrieving the job using `dfhack.buildings.findAtTile(job.pos)` instead `dfhack.job.getHolder(job)`. It's likely inefficient, but can also be wrong as `job.pos` is sometimes off by one.

This PR switches to `dfhack.job.getHolder` to fix this.