### PR TITLE
[exterminate] add vaporize kill method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ that repo.
 - `gui/control-panel`: Now detects overlays from scripts named with capital letters
 - `gui/cp437-table`: now has larger key buttons and clickable backspace/submit/cancel buttons, making it fully usable on the Steam Deck and other systems that don't have an accessible keyboard
 - `gui/design`: Now supports placing constructions using 'Building' mode. Inner and Outer tile constructions are configurable. Uses buildingplan filters set up with the regular buildingplan interface.
+- `exterminate`: add support for ``vaporize`` kill method for when you don't want to leave a corpse
 - `combine`: you can select a target stockpile in the UI instead of having to use the keyboard cursor
 - `combine`: added ``--quiet`` option for no output when there are no changes
 - `gui/control-panel`: added ``combine all`` maintenance option for automatic combining of partial stacks in stockpiles

--- a/docs/exterminate.rst
+++ b/docs/exterminate.rst
@@ -2,29 +2,22 @@ exterminate
 ===========
 
 .. dfhack-tool::
-    :summary: Kills creatures.
+    :summary: Kill things.
     :tags: fort armok units
 
-Kills any unit, or all units of a given race. You can target any unit on a
-revealed tile of the map, including ambushers, but caged/chained creatures are
-ignored.
-
-If ``method`` is specified, ``exterminate`` will kill the selected units
-using the provided method. ``Instant`` will instantly kill the units.
-``Butcher`` will mark the units for butchering, not kill them, useful for pets
-and not for armed enemies. ``Drown`` and ``Magma`` will spawn a 7/7 column of
-water or magma on the units respectively, cleaning up the liquid as they move
-and die. Magma not recommended for magma-safe creatures...
+Kills any unit, or all undead, or all units of a given race. You can target any
+unit on a revealed tile of the map, including ambushers, but caged/chained
+creatures cannot be killed with this tool.
 
 Usage
 -----
 
-``exterminate``
-    List the available targets.
-``exterminate this [<options>]``
-    Kills the selected unit, instantly by default.
-``exterminate <race>[:<caste>] [<options>]``
-    Kills all available units of the specified race, or all undead units.
+::
+
+    exterminate
+    exterminate this [<options>]
+    exterminate undead [<options>]
+    exterminate <race>[:<caste>] [<options>]
 
 Examples
 --------
@@ -35,27 +28,43 @@ Examples
     List the targets on your map.
 ``exterminate BIRD_RAVEN:MALE``
     Kill the ravens flying around the map (but only the male ones).
-``exterminate GOBLIN --method MAGMA --only-visible --only-hostile``
-    Kill all visible, hostile goblins on the map by drowning them in magma.
+``exterminate GOBLIN --method magma --only-visible``
+    Kill all visible, hostile goblins on the map by boiling them in magma.
 
 Options
 -------
 
 ``-m``, ``--method <method>``
-    Specifies the "method" of killing units.
+    Specifies the "method" of killing units. See below for details.
 ``-o``, ``--only-visible``
-    Specifies the tool should only kill units visible to the player
+    Specifies the tool should only kill units visible to the player.
     on the map.
 ``-f``, ``--include-friendly``
     Specifies the tool should also kill units friendly to the player.
+
+Methods
+-------
+
+`exterminate` can kill units using any of the following methods:
+
+:instant: Kill by blood loss, and if this is ineffective, then kill by
+    vaporization (default).
+:vaporize: Make the unit disappear in a puff of smoke. Note that units killed
+    this way will not leave a corpse behind, but any items they were carrying
+    will still drop.
+:drown: Drown the unit in water.
+:magma: Boil the unit in magma (not recommended for magma-safe creatures).
+:butcher: Will mark the units for butchering instead of killing them. This is
+    more useful for pets than armed enemies.
 
 Technical details
 -----------------
 
 This tool kills by setting a unit's ``blood_count`` to 0, which means
 immediate death at the next game tick. For creatures where this is not enough,
-such as vampires, it also sets animal.vanish_countdown to 2.
+such as vampires, it also sets ``animal.vanish_countdown``, allowing the unit
+to vanish in a puff of smoke if the blood loss doesn't kill them.
 
-The script drowns units in the liquid of choice by modifying the tile with a
-liquid level of 7 every tick. If the unit moves, the liquid moves along with
+If the method of choice involves liquids, the tile is filled with a liquid
+level of 7 every tick. If the target unit moves, the liquid moves along with
 it, leaving the vacated tiles clean.

--- a/exterminate.lua
+++ b/exterminate.lua
@@ -1,5 +1,3 @@
--- Exterminate creatures based on criteria
-
 local argparse = require('argparse')
 
 local function spawnLiquid(position, liquid_level, liquid_type, update_liquids)
@@ -38,12 +36,20 @@ local killMethod = {
     BUTCHER = 1,
     MAGMA = 2,
     DROWN = 3,
+    VAPORIZE = 4,
 }
 
--- Kills a unit by removing blood and vanishing them.
-local function killUnit(unit)
+-- removes the unit from existence, leaving no corpse if the unit hasn't died
+-- by the time the vanish countdown expires
+local function vaporizeUnit(unit, target_value)
+    target_value = target_value or 1
+    unit.animal.vanish_countdown = target_value
+end
+
+-- Kills a unit by removing blood and also setting a vanish countdown as a failsafe.
+local function destroyUnit(unit)
     unit.body.blood_count = 0
-    unit.animal.vanish_countdown = 2
+    vaporizeUnit(unit, 2)
 end
 
 --  Marks a unit for slaughter at the butcher's shop.
@@ -57,44 +63,50 @@ local function drownUnit(unit, liquid_type)
 
     local function createLiquid()
         spawnLiquid(unit.pos, 7, liquid_type)
-
         if not same_xyz(previousPositions[unit.id], unit.pos) then
             spawnLiquid(previousPositions[unit.id], 0, nil, false)
             previousPositions[unit.id] = copyall(unit.pos)
         end
-
         if unit.flags2.killed then
             spawnLiquid(previousPositions[unit.id], 0, nil, false)
         else
             dfhack.timeout(1, 'ticks', createLiquid)
         end
     end
-
     createLiquid()
+end
+
+local function killUnit(unit, method)
+    if method == killMethod.BUTCHER then
+        butcherUnit(unit)
+    elseif method == killMethod.MAGMA then
+        drownUnit(unit, df.tile_liquid.Magma)
+    elseif method == killMethod.DROWN then
+        drownUnit(unit, df.tile_liquid.Water)
+    elseif method == killMethod.VAPORIZE then
+        vaporizeUnit(unit)
+    else
+        destroyUnit(unit)
+    end
 end
 
 local function getRaceCastes(race_id)
     local unit_castes = {}
-
     for _, caste in pairs(df.creature_raw.find(race_id).caste) do
         unit_castes[caste.caste_id] = {}
     end
-
     return unit_castes
 end
 
 local function getMapRaces(only_visible, include_friendly)
     local map_races = {}
-
     for _, unit in pairs(df.global.world.units.active) do
         if only_visible and not dfhack.units.isVisible(unit) then
             goto skipunit
         end
-
         if not include_friendly and isUnitFriendly(unit) then
             goto skipunit
         end
-
         if dfhack.units.isActive(unit) and checkUnit(unit) then
             local unit_race_name = dfhack.units.isUndead(unit) and "UNDEAD" or df.creature_raw.find(unit.race).creature_id
 
@@ -103,7 +115,6 @@ local function getMapRaces(only_visible, include_friendly)
             race.name = unit_race_name
             race.count = (race.count or 0) + 1
         end
-
         :: skipunit ::
     end
 
@@ -119,7 +130,7 @@ local options, args = {
 
 local positionals = argparse.processArgsGetopt(args, {
     {'h', 'help', handler = function() options.help = true end},
-    {'m', 'method', handler = function(arg) options.method = killMethod[arg] end, hasArg = true},
+    {'m', 'method', handler = function(arg) options.method = killMethod[arg:upper()] end, hasArg = true},
     {'o', 'only-visible', handler = function() options.only_visible = true end},
     {'f', 'include-friendly', handler = function() options.include_friendly = true end},
 })
@@ -130,49 +141,45 @@ end
 
 if positionals[1] == "help" or options.help then
     print(dfhack.script_help())
+    return
 end
 
 if positionals[1] == "this" then
     local selected_unit = dfhack.gui.getSelectedUnit()
-
     if not selected_unit then
         qerror("Select a unit and run the script again.")
     end
-
-    killUnit(selected_unit)
-    return
-end
-
-if positionals[1] == nil then
-    local map_races = getMapRaces(options.only_visible, options.include_friendly)
-
-    local sorted_races = {}
-    for race, value in pairs(map_races) do
-        table.insert(sorted_races, { name = race, count = value.count })
-    end
-
-    table.sort(sorted_races, function(a, b)
-        return a.count > b.count
-    end)
-
-    for _, race in pairs(sorted_races) do
-        print(([[%4s %s]]):format(race.count, race.name))
-    end
-
+    killUnit(selected_unit, options.method)
+    print('Unit exterminated.')
     return
 end
 
 local map_races = getMapRaces(options.only_visible, options.include_friendly)
 
-if string.find(positionals[1], "UNDEAD") then
-    if map_races.UNDEAD then
-        for _, unit in pairs(df.global.world.units.active) do
-            if dfhack.units.isUndead(unit) and checkUnit(unit) then
-                killUnit(unit)
-            end
-        end
-    else
+if not positionals[1] then
+    local sorted_races = {}
+    for race, value in pairs(map_races) do
+        table.insert(sorted_races, { name = race, count = value.count })
+    end
+    table.sort(sorted_races, function(a, b)
+        return a.count > b.count
+    end)
+    for _, race in ipairs(sorted_races) do
+        print(([[%4s %s]]):format(race.count, race.name))
+    end
+    return
+end
+
+local count = 0
+if positionals[1]:lower() == 'undead' then
+    if not map_races.UNDEAD then
         qerror("No undead found on the map.")
+    end
+    for _, unit in pairs(df.global.world.units.active) do
+        if dfhack.units.isUndead(unit) and checkUnit(unit) then
+            killUnit(unit, options.method)
+            count = count + 1
+        end
     end
 else
     local selected_race, selected_caste = positionals[1], nil
@@ -192,40 +199,27 @@ else
         qerror("Invalid caste.")
     end
 
-    local count = 0
     for _, unit in pairs(df.global.world.units.active) do
-        if not dfhack.units.isActive(unit) or not checkUnit(unit) then
+        if not checkUnit(unit) then
             goto skipunit
         end
-
         if options.only_visible and not dfhack.units.isVisible(unit) then
             goto skipunit
         end
-
         if not options.include_friendly and isUnitFriendly(unit) then
             goto skipunit
         end
-
         if selected_caste and selected_caste ~= df.creature_raw.find(unit.race).caste[unit.caste].caste_id then
             goto skipunit
         end
 
         if selected_race == df.creature_raw.find(unit.race).creature_id then
-            if options.method == killMethod.BUTCHER then
-                butcherUnit(unit)
-            elseif options.method == killMethod.MAGMA then
-                drownUnit(unit, df.tile_liquid.Magma)
-            elseif options.method == killMethod.DROWN then
-                drownUnit(unit, df.tile_liquid.Water)
-            else
-                killUnit(unit)
-            end
-
+            killUnit(unit, options.method)
             count = count + 1
         end
 
         :: skipunit ::
     end
-
-    print(([[Exterminated %s creatures.]]):format(count))
 end
+
+print(([[Exterminated %d creatures.]]):format(count))


### PR DESCRIPTION
Fixes DFHack/dfhack#3107

also update docs and respect kill method for `this` and `undead` targets. also print out how many units were killed for `undead`