### PR TITLE
[suspendmanager] Detect and protect dead end constructions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ that repo.
 
 ## Misc Improvements
 - `gui/create-item`: ask for number of items to spawn by default
+- `suspendmanager`: improve detection of potentially blocking jobs
 
 ## Removed
 

--- a/suspend.lua
+++ b/suspend.lua
@@ -16,8 +16,14 @@ if help then
     return
 end
 
+local manager = suspendmanager.SuspendManager.new()
+
+if onlyblocking then
+    manager:computeBlockingJobs()
+end
+
 suspendmanager.foreach_construction_job(function (job)
-    if not onlyblocking or suspendmanager.isBlocking(job) then
+    if not onlyblocking or manager:shouldBeSuspended(job) then
         suspendmanager.suspend(job)
     end
 end)

--- a/unsuspend.lua
+++ b/unsuspend.lua
@@ -185,11 +185,15 @@ argparse.processArgsGetopt({...}, {
 
 local skipped_counts = {}
 local unsuspended_count = 0
+local manager = suspendmanager.SuspendManager.new()
+if skipblocking then
+    manager:computeBlockingJobs()
+end
 
 suspendmanager.foreach_construction_job(function(job)
     if not job.flags.suspend then return end
 
-    local skip,reason=suspendmanager.shouldStaySuspended(job, skipblocking)
+    local skip,reason=manager:shouldStaySuspended(job)
     if skip then
         skipped_counts[reason] = (skipped_counts[reason] or 0) + 1
         return


### PR DESCRIPTION
Fixes DFHack/dfhack#3049 and DFHack/dfhack#3157

Replace the suspendmanager blocking detection. This new approach explore groups of connected construction jobs, and suspend corridors that would prevent accessing a deadend or the cluster entirely.

This approach handles many more situations, the most important being the issues linked above. It also behaves better for filling area, which was mentioned on discord.

It still have some short-coming, such as interior corridors in a big cluster not being suspended, and the general algorithm feeling more complicated than it should be but all my attempt to simplify the general logic lead to many blocking points...

Two situations where the previous approach would mostly fail, but are now well handled:

Two-z walls where dwarves must build the walls one by one:

![suspendmanager-1](https://user-images.githubusercontent.com/630159/236639877-a1de121a-48c9-48af-9472-2632e739631c.gif)

Area filling:

![suspendmanager-2](https://user-images.githubusercontent.com/630159/236640305-d48c5046-ce2d-46ab-a9e6-9621a57b93ef.gif)

