### PR TITLE
[warn-starving] no reports for non-fort-controlled units

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ that repo.
 - `prioritize`: fixed all watched job type names showing as ``nil``
 - `suspendmanager`: does not suspend non blocking jobs such as floor bars or bridges anymore
 - `suspendmanager`: fix occasional bad identification of buildingplan jobs
+- `warn-starving`: no longer warns for enemy and neutral units
 
 ## Misc Improvements
 - `gui/control-panel`: Now detects overlays from scripts named with capital letters

--- a/docs/warn-starving.rst
+++ b/docs/warn-starving.rst
@@ -10,6 +10,8 @@ pause and you'll get a warning dialog telling you which units are in danger.
 This gives you a chance to rescue them (or take them out of their cages) before
 they die.
 
+You can enable ``warn-starving`` notifications in `gui/control-panel` on the "Maintenance" tab.
+
 Usage
 -----
 
@@ -23,9 +25,6 @@ Examples
 ``warn-starving all sane``
     Report on all currently distressed units, excluding insane units that you
     wouldn't be able to save anyway.
-``repeat --time 10 --timeUnits days --command [ warn-starving sane ]``
-    Every 10 days, report any (sane) distressed units that haven't already been
-    reported.
 
 Options
 -------

--- a/warn-starving.lua
+++ b/warn-starving.lua
@@ -34,7 +34,7 @@ warning.ATTRS = {
     pass_mouse_clicks=false,
 }
 
-function warning:init(args)
+function warning:init(info)
     local main = widgets.Window{
         frame={w=80, h=18},
         frame_title='Warning',
@@ -44,7 +44,7 @@ function warning:init(args)
 
     main:addviews{
         widgets.WrappedLabel{
-            text_to_wrap=table.concat(args.messages, NEWLINE),
+            text_to_wrap=table.concat(info.messages, NEWLINE),
         }
     }
 
@@ -98,13 +98,12 @@ function doCheck()
     for i=#units-1, 0, -1 do
         local unit = units[i]
         local rraw = findRaceCaste(unit)
-        if rraw and dfhack.units.isActive(unit) and not dfhack.units.isOpposedToLife(unit) then
-            if not checkOnlySane or dfhack.units.isSane(unit) then
-                table.insert(messages, checkVariable(unit.counters2.hunger_timer, 75000, 'starving', starvingUnits, unit))
-                table.insert(messages, checkVariable(unit.counters2.thirst_timer, 50000, 'dehydrated', dehydratedUnits, unit))
-                table.insert(messages, checkVariable(unit.counters2.sleepiness_timer, 150000, 'very drowsy', sleepyUnits, unit))
-            end
-        end
+        if not rraw or not dfhack.units.isFortControlled(unit) then goto continue end
+        if checkOnlySane and not dfhack.units.isSane(unit) then goto continue end
+        table.insert(messages, checkVariable(unit.counters2.hunger_timer, 75000, 'starving', starvingUnits, unit))
+        table.insert(messages, checkVariable(unit.counters2.thirst_timer, 50000, 'dehydrated', dehydratedUnits, unit))
+        table.insert(messages, checkVariable(unit.counters2.sleepiness_timer, 150000, 'very drowsy', sleepyUnits, unit))
+        ::continue::
     end
     if #messages > 0 then
         dfhack.color(COLOR_LIGHTMAGENTA)


### PR DESCRIPTION
this also skips reports for residents, which is debatable. should we report on residents? Moreover, should isFortControlled be returning false for residents?

Fixes DFHack/dfhack#3117