### PR TITLE
gm-editor: Small usability tweaks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,8 +16,11 @@ that repo.
 ## New Scripts
 
 ## Fixes
+- `gui/gm-editor`: no longer nudges last open window when opening a new one
 
 ## Misc Improvements
+- `gui/gm-editor`: can now jump to material info objects from a mat_type reference with a mat_index using ``i``
+- `gui/gm-editor`: they key column now auto-fits to the widest key
 
 ## Removed
 
@@ -34,7 +37,6 @@ that repo.
 - `suspendmanager`: does not suspend non-blocking jobs such as floor bars or bridges anymore
 - `suspendmanager`: fix occasional bad identification of buildingplan jobs
 - `warn-starving`: no longer warns for enemy and neutral units
-- `gui/gm-editor`: no longer nudges last open window when opening a new one
 
 ## Misc Improvements
 - `gui/control-panel`: Now detects overlays from scripts named with capital letters
@@ -48,8 +50,6 @@ that repo.
 - `gui/control-panel`: added ``combine all`` maintenance option for automatic combining of partial stacks in stockpiles
 - `gui/control-panel`: added ``general-strike`` maintenance option for automatic fixing of (at least one cause of) the general strike bug
 - `gui/cp437-table`: dialog is now fully controllable with the mouse, including highlighting which key you are hovering over and adding a clickable backspace button
-- `gui/gm-editor`: can now jump to material info objects from a mat_type reference with a mat_index using ``i``
-- `gui/gm-editor`: they key column now auto-fits to the widest key
 
 ## Removed
 - `autounsuspend`: replaced by `suspendmanager`

--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ that repo.
 - `suspendmanager`: does not suspend non blocking jobs such as floor bars or bridges anymore
 - `suspendmanager`: fix occasional bad identification of buildingplan jobs
 - `warn-starving`: no longer warns for enemy and neutral units
+- `gui/gm-editor`: no longer nudges last open window when opening a new one
 
 ## Misc Improvements
 - `gui/control-panel`: Now detects overlays from scripts named with capital letters
@@ -35,6 +36,8 @@ that repo.
 - `stripcaged`: items that are marked for dumping are now automatically unforbidden (unless ``--skip-forbidden`` is set)
 - `gui/control-panel`: added ``combine all`` maintenance option for automatic combining of partial stacks in stockpiles
 - `gui/cp437-table`: dialog is now fully controllable with the mouse, including highlighting which key you are hovering over and adding a clickable backspace button
+- `gui/gm-editor`: can now jump to material info objects from a mat_type reference with a mat_index using ``i``
+- `gui/gm-editor`: they key column now auto-fits to the widest key
 
 ## Removed
 - `autounsuspend`: replaced by `suspendmanager`

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -72,7 +72,7 @@ end
 
 GmEditorUi = defclass(GmEditorUi, widgets.Window)
 GmEditorUi.ATTRS{
-    frame=config.data,
+    frame={ w=config.data.w, h=config.data.h, l=config.data.l, r=config.data.r, t=config.data.t, b=config.data.b },
     frame_title="GameMaster's editor",
     frame_inset=0,
     resizable=true,

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -488,7 +488,9 @@ function GmEditorUi:updateTarget(preserve_pos,reindex)
 
     if reindex then
         trg.keys={}
+        trg.kw=10
         for k,v in pairs(trg.target) do
+            if #tostring(k)>trg.kw then trg.kw=#tostring(k) end
             if filter~= "" then
                 local ok,ret=dfhack.pcall(string.match,tostring(k):lower(),filter)
                 if not ok then
@@ -504,7 +506,7 @@ function GmEditorUi:updateTarget(preserve_pos,reindex)
     self.subviews.lbl_current_item:itemById('name').text=tostring(trg.target)
     local t={}
     for k,v in pairs(trg.keys) do
-            table.insert(t,{text={{text=string.format("%-25s",tostring(v))},{gap=1,text=getStringValue(trg,v)}}})
+        table.insert(t,{text={{text=string.format("%-"..trg.kw.."s",tostring(v))},{gap=1,text=getStringValue(trg,v)}}})
     end
     local last_pos
     if preserve_pos then
@@ -521,6 +523,7 @@ function GmEditorUi:pushTarget(target_to_push)
     local new_tbl={}
     new_tbl.target=target_to_push
     new_tbl.keys={}
+    new_tbl.kw=10
     new_tbl.selected=1
     new_tbl.filter=""
     if self:currentTarget()~=nil then
@@ -528,6 +531,7 @@ function GmEditorUi:pushTarget(target_to_push)
         self.stack[#self.stack].filter=self.subviews.filter_input.text
     end
     for k,v in pairs(target_to_push) do
+        if #tostring(k)>new_tbl.kw then new_tbl.kw=#tostring(k) end
         table.insert(new_tbl.keys,k)
     end
     new_tbl.item_count=#new_tbl.keys

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -72,7 +72,7 @@ end
 
 GmEditorUi = defclass(GmEditorUi, widgets.Window)
 GmEditorUi.ATTRS{
-    frame={ w=config.data.w, h=config.data.h, l=config.data.l, r=config.data.r, t=config.data.t, b=config.data.b },
+    frame=copyall(config.data),
     frame_title="GameMaster's editor",
     frame_inset=0,
     resizable=true,

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -181,11 +181,22 @@ function GmEditorUi:find_id(force_dialog)
         ref_target = field.ref_target
     end
     if ref_target and not force_dialog then
+        local obj
         if not ref_target.find then
-            dialog.showMessage("Error!", ("Cannot look up %s by ID"):format(getmetatable(ref_target)), COLOR_LIGHTRED)
-            return
+            if key == 'mat_type' then
+                local ok, mi = pcall(function()
+                    return self:currentTarget().target['mat_index']
+                end)
+                if ok then
+                    obj = dfhack.matinfo.decode(id, mi)
+                end
+            end
+            if not obj then
+                dialog.showMessage("Error!", ("Cannot look up %s by ID"):format(getmetatable(ref_target)), COLOR_LIGHTRED)
+                return
+            end
         end
-        local obj = ref_target.find(id)
+        obj = obj or ref_target.find(id)
         if obj then
             self:pushTarget(obj)
         else


### PR DESCRIPTION
Three small inprovements:
- Don't clobber previous window frame when opening a new one
- Enable jumping to matinfos
- Auto-fit the key column