### PR TITLE
gm-editor: Add ``g`` shortcut to locate a target or selected value on the map

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ that repo.
 ## Fixes
 
 ## Misc Improvements
+- `gui/gm-editor`: press ``g`` to move the map to the currently selected item/unit/building
 
 ## Removed
 
@@ -34,7 +35,6 @@ that repo.
 ## Misc Improvements
 - `gui/gm-editor`: can now jump to material info objects from a mat_type reference with a mat_index using ``i``
 - `gui/gm-editor`: the key column now auto-fits to the widest key
-- `gui/gm-editor`: press ``g`` to move the map to the currently selected item/unit/building
 - `prioritize`: revise and simplify the default list of prioritized jobs -- be sure to tell us if your forts are running noticeably better (or worse!)
 -@ `gui/control-panel`: add `faststart` to the system services
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,7 +20,8 @@ that repo.
 
 ## Misc Improvements
 - `gui/gm-editor`: can now jump to material info objects from a mat_type reference with a mat_index using ``i``
-- `gui/gm-editor`: they key column now auto-fits to the widest key
+- `gui/gm-editor`: the key column now auto-fits to the widest key
+- `gui/gm-editor`: press ``g`` to move the map to the currently selected item/unit/building
 
 ## Removed
 

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -348,14 +348,22 @@ function GmEditorUi:openOffseted(index,choice)
 end
 function GmEditorUi:locate(t)
     if getmetatable(t) == 'coord' then return t end
+    if df.unit:is_instance(t) then return xyz2pos(dfhack.units.getPosition(t)) end
+    if df.item:is_instance(t) then return xyz2pos(dfhack.items.getPosition(t)) end
+    if df.building:is_instance(t) then return xyz2pos(t.centerx, t.centery, t.z) end
+    -- anything else - look for pos or x/y/z fields
     local ok, pos = pcall(function() return t.pos end)
     if getmetatable(pos) == 'coord' then return pos end
-    local x,y,z -- locate buildings
-    ok, x = pcall(function() return t.centerx end)
-    ok, y = pcall(function() return t.centery end)
+    local x,y,z
+    ok, x = pcall(function() return t.x end)
+    if type(x)~='number' then ok, x = pcall(function() return t.centerx end) end
+    if type(x)~='number' then ok, x = pcall(function() return t.x1 end) end
+    ok, y = pcall(function() return t.y end)
+    if type(y)~='number' then ok, y = pcall(function() return t.centery end) end
+    if type(y)~='number' then ok, y = pcall(function() return t.y1 end) end
     ok, z = pcall(function() return t.z end)
     if type(x)=='number' and type(y)=='number' and type(z)=='number' then
-        return { x=x, y=y, z=z }
+        return xyz2pos(x,y,z)
     end
     return nil
 end

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -29,6 +29,7 @@ local keybindings_raw = {
     {name='delete', key="CUSTOM_ALT_D",desc="Delete selected entry"},
     {name='reinterpret', key="CUSTOM_ALT_R",desc="Open selected entry as something else"},
     {name='start_filter', key="CUSTOM_S",desc="Start typing filter, Enter to finish"},
+    {name='gotopos', key="CUSTOM_G",desc="Move map view to location of target"},
     {name='help', key="STRING_A063",desc="Show this help"},
     {name='displace', key="STRING_A093",desc="Open reference offseted by index"},
     --{name='NOT_USED', key="SEC_SELECT",desc="Edit selected entry as a number (for enums)"}, --not a binding...
@@ -345,6 +346,35 @@ function GmEditorUi:openOffseted(index,choice)
             self:pushTarget(trg.target[trg_key]:_displace(tonumber(choice)))
         end)
 end
+function GmEditorUi:locate(t)
+    if getmetatable(t) == 'coord' then return t end
+    local ok, pos = pcall(function() return t.pos end)
+    if getmetatable(pos) == 'coord' then return pos end
+    local x,y,z -- locate buildings
+    ok, x = pcall(function() return t.centerx end)
+    ok, y = pcall(function() return t.centery end)
+    ok, z = pcall(function() return t.z end)
+    if type(x)=='number' and type(y)=='number' and type(z)=='number' then
+        return { x=x, y=y, z=z }
+    end
+    return nil
+end
+function GmEditorUi:gotoPos()
+    if not dfhack.isMapLoaded() then return end
+    -- if the selected value is a coord then use it
+    local pos = self:getSelectedValue()
+    if getmetatable(pos) ~= 'coord' then
+        -- otherwise locate the current target
+        pos = GmEditorUi:locate(self:currentTarget().target)
+        if not pos then
+            -- otherwise locate the current selected value
+            pos = GmEditorUi:locate(self:getSelectedValue())
+        end
+    end
+    if pos then
+        dfhack.gui.revealInDwarfmodeMap(pos,true)
+    end
+end
 function GmEditorUi:editSelectedRaw(index,choice)
     self:editSelected(index, choice, {raw=true})
 end
@@ -452,6 +482,9 @@ function GmEditorUi:onInput(keys)
         return true
     elseif keys[keybindings.reinterpret.key] then
         self:openReinterpret(self:getSelectedKey())
+        return true
+    elseif keys[keybindings.gotopos.key] then
+        self:gotoPos()
         return true
     elseif keys[keybindings.help.key] then
         self.subviews.pages:setSelected(2)

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -381,6 +381,9 @@ function GmEditorUi:gotoPos()
     end
     if pos then
         dfhack.gui.revealInDwarfmodeMap(pos,true)
+        df.global.game.main_interface.recenter_indicator_m.x = pos.x
+        df.global.game.main_interface.recenter_indicator_m.y = pos.y
+        df.global.game.main_interface.recenter_indicator_m.z = pos.z
     end
 end
 function GmEditorUi:editSelectedRaw(index,choice)


### PR DESCRIPTION
When a fort is loaded jump to the first of:
- the coord if the current target or the selected value is a coord
- the `pos` of the current target
- the `centerx`, `centery`, `z` of the current target
- the `pos` of the selected value
- the `centerx`, `centery`, `z` of the selected value

The last two allow browsing lists like world.units.active or world.buildings.all and pressing g to jump to each item in the list without opening them.
Items in containers/being carried won't be located currently - I can add a (recursive) holder/container ref lookup if there is interest.