### PR TITLE
gm-editor: add read-only mode with persistent state

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,7 +20,7 @@ that repo.
 ## Misc Improvements
 - `combine`: added seeds and powder types.
 - `gui/gm-editor`: press ``g`` to move the map to the currently selected item/unit/building
-- `gui/gm-editor`: press Ctrl-D to toggle read-only mode to protect from accidental changes; this state persists across sessions
+- `gui/gm-editor`: press ``Ctrl-D`` to toggle read-only mode to protect from accidental changes; this state persists across sessions
 
 ## Removed
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,7 +20,8 @@ that repo.
 
 ## Misc Improvements
 - `gui/gm-editor`: can now jump to material info objects from a mat_type reference with a mat_index using ``i``
-- `gui/gm-editor`: they key column now auto-fits to the widest key
+- `gui/gm-editor`: the key column now auto-fits to the widest key
+- `gui/gm-editor`: Now starts in read-only mode.  Press Ctrl-D to switch to editing mode.  This state persists across sessions
 
 ## Removed
 

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -10,9 +10,7 @@ local utils = require 'utils'
 config = config or json.open('dfhack-config/gm-editor.json')
 
 function save_config(data)
-    for k,v in pairs(data) do
-        config.data[k] = v
-    end
+    utils.assign(config.data, data)
     config:write()
 end
 

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -16,11 +16,6 @@ function save_config(data)
     config:write()
 end
 
-read_only = true
-if config.data.read_only ~= nil then
-    read_only = config.data.read_only
-end
-
 find_funcs = find_funcs or (function()
     local t = {}
     for k in pairs(df) do
@@ -90,6 +85,7 @@ GmEditorUi.ATTRS{
     frame_inset=0,
     resizable=true,
     resize_min={w=30, h=20},
+    read_only=(config.data.read_only or false)
 }
 
 function burning_red(input) -- todo does not work! bug angavrilov that so that he would add this, very important!!
@@ -255,7 +251,7 @@ function GmEditorUi:find_id(force_dialog)
     end)
 end
 function GmEditorUi:insertNew(typename)
-    if read_only then return end
+    if self.read_only then return end
     local tp=typename
     if typename == nil then
         dialog.showInputPrompt("Class type","You can:\n * Enter type name (without 'df.')\n * Leave empty for default type and 'nil' value\n * Enter '*' for default type and 'new' constructed pointer value",COLOR_WHITE,"",self:callback("insertNew"))
@@ -280,7 +276,7 @@ function GmEditorUi:insertNew(typename)
     end
 end
 function GmEditorUi:deleteSelected(key)
-    if read_only then return end
+    if self.read_only then return end
     local trg=self:currentTarget()
     if trg.target and trg.target._kind and trg.target._kind=="container" then
         trg.target:erase(key)
@@ -368,17 +364,17 @@ function GmEditorUi:editSelected(index,choice,opts)
     local trg=self:currentTarget()
     local trg_key=trg.keys[index]
     if trg.target and trg.target._kind and trg.target._kind=="bitfield" then
-        if read_only then return end
+        if self.read_only then return end
         trg.target[trg_key]= not trg.target[trg_key]
         self:updateTarget(true)
     else
         --print(type(trg.target[trg.keys[trg.selected]]),trg.target[trg.keys[trg.selected]]._kind or "")
         local trg_type=type(trg.target[trg_key])
         if self:getSelectedEnumType() and not opts.raw then
-            if read_only then return end
+            if self.read_only then return end
             self:editSelectedEnum()
         elseif trg_type=='number' or trg_type=='string' then --ugly TODO: add metatable get selected
-            if read_only then return end
+            if self.read_only then return end
             local prompt = "Enter new value:"
             if self:getSelectedEnumType() then
                 prompt = "Enter new " .. getTypeName(trg.target:_field(trg_key)._type) .. " value"
@@ -387,7 +383,7 @@ function GmEditorUi:editSelected(index,choice,opts)
                 tostring(trg.target[trg_key]), self:callback("commitEdit",trg_key))
 
         elseif trg_type == 'boolean' then
-            if read_only then return end
+            if self.read_only then return end
             trg.target[trg_key] = not trg.target[trg_key]
             self:updateTarget(true)
         elseif trg_type == 'userdata' or trg_type == 'table' then
@@ -402,7 +398,7 @@ function GmEditorUi:editSelected(index,choice,opts)
 end
 
 function GmEditorUi:commitEdit(key,value)
-    if read_only then return end
+    if self.read_only then return end
     local trg=self:currentTarget()
     if type(trg.target[key])=='number' then
         trg.target[key]=tonumber(value)
@@ -413,7 +409,7 @@ function GmEditorUi:commitEdit(key,value)
 end
 
 function GmEditorUi:set(key,input)
-    if read_only then return end
+    if self.read_only then return end
     local trg=self:currentTarget()
 
     if input== nil then
@@ -445,7 +441,7 @@ function GmEditorUi:onInput(keys)
     end
 
     if keys[keybindings.toggle_ro.key] then
-        read_only = not read_only
+        self.read_only = not self.read_only
         self:updateTitles()
         return true
     elseif keys[keybindings.offset.key] then
@@ -510,14 +506,14 @@ end
 
 function GmEditorUi:updateTitles()
     local title = "GameMaster's Editor"
-    if read_only then
+    if self.read_only then
         title = title.." (Read Only)"
     end
     for view,_ in pairs(views) do
         view.subviews[1].frame_title = title
     end
     self.frame_title = title
-    save_config({read_only = read_only})
+    save_config({read_only = self.read_only})
 end
 function GmEditorUi:updateTarget(preserve_pos,reindex)
     local trg=self:currentTarget()
@@ -615,14 +611,6 @@ end
 
 local function get_editor(args)
     if #args~=0 then
-        if args[1]=='dev' or args[1]=='edit' then
-            read_only = false
-            table.remove(args,1)
-        end
-        if args[1]=='safe' or args[1]=='read' then
-            read_only = true
-            table.remove(args,1)
-        end
         if args[1]=="dialog" then
             dialog.showInputPrompt("Gm Editor", "Object to edit:", COLOR_GRAY,
                     "", function(entry)


### PR DESCRIPTION
Fixes DFHack/dfhack#3171

- new global `read_only` var
- read only state is saved in `config.data.read_only`
- frame position now saved in `config.data.frame`
- config saving moved to `save_config` fn
- keybinding `Ctrl-D` added to toggle `read_only`
- titles of all views updated on change
- added `dev`/`edit` and `safe`/`read` args to clear/set `read_only` on start
- insert/delete/set fns do nothing when `read_only` set
- `editSelected` allows only navigation when `read_only` set

One outstanding issue is that views opened using the `dialog` argument are not added to the `views` global array, so cannot have their `frame_title` updated by other views. I think to fix this I'd need to open the main view before showing the input dialog, which may mean moving the dialog code up into GmEditorUi somewhere.

By default I set `read_only` to true, so it's a bit safer for new users, but it can easily be changed on line 19.
Either way, pressing `Ctrl-D` once, will go back to full read-write access, which will be remembered for future sessions.