### PR TITLE
Combine ammo and body parts

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,7 @@ that repo.
 ## Fixes
 
 ## Misc Improvements
-- `combine`: added seeds and powder types.
+- `combine`: Now supports ammo, powders and seeds, and combines into containers.
 
 ## Removed
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,7 @@ that repo.
 ## Fixes
 
 ## Misc Improvements
-- `combine`: Now supports ammo, powders and seeds, and combines into containers.
+- `combine`: Now supports ammo, parts, powders and seeds, and combines into containers.
 
 ## Removed
 

--- a/combine.lua
+++ b/combine.lua
@@ -296,7 +296,7 @@ local function isRestrictedItem(item)
     local flags = item.flags
     return flags.rotten or flags.trader or flags.hostile or flags.forbid
         or flags.dump or flags.on_fire or flags.garbage_collect or flags.owned
-        or flags.removed or flags.encased or flags.spider_web or flags.melt 
+        or flags.removed or flags.encased or flags.spider_web or flags.melt
         or flags.hidden or #item.specific_refs > 0
 end
 

--- a/combine.lua
+++ b/combine.lua
@@ -506,6 +506,7 @@ end
 local function get_stockpile_all()
     -- attempt to get all the stockpiles for the fort, or exit with error
     -- return the stockpiles as a table
+    log(3, 'get_stockpile_all\n')
     local stockpiles = {}
     for _, building in pairs(df.global.world.buildings.all) do
         if building:getType() == df.building_type.Stockpile then
@@ -521,6 +522,7 @@ end
 local function get_stockpile_here()
     -- attempt to get the selected stockpile, or exit with error
     -- return the stockpile as a table
+    log(3, 'get_stockpile_here\n')
     local stockpiles = {}
     local building = dfhack.gui.getSelectedStockpile()
     if not building then qerror('Please select a stockpile.') end
@@ -535,6 +537,7 @@ end
 local function parse_types_opts(arg)
     -- check the types specified on the command line, or exit with error
     -- return the selected types as a table
+    log(3, 'parse_types_opts\n')
     local types = {}
     local div = ''
     local types_output = ''
@@ -556,19 +559,20 @@ local function parse_types_opts(arg)
                 for k3, v3 in pairs(v2) do
                     types[k2][k3]=v3
                 end
-                types_output = types_output .. div .. types[k2].type_name
+                types_output = types_output .. div .. df.item_type[types[k2].type_id]
                 div=', '
             else
                 qerror(('Expected: only one value for %s'):format(t))
             end
         end
     end
-    dfhack.print(types_output .. '\n')
+    log(0, types_output .. '\n')
     return types
 end
 
 local function parse_commandline(opts, args)
     -- check the command line/exit on error, and set the defaults
+    log(3, 'parse_commandline\n')
     local positionals = argparse.processArgsGetopt(args, {
             {'h', 'help', handler=function() opts.help = true end},
             {'t', 'types', hasArg=true, handler=function(optarg) opts.types=parse_types_opts(optarg) end},

--- a/combine.lua
+++ b/combine.lua
@@ -88,7 +88,7 @@ local function comp_item_new(comp_key, max_size)
                                                         --      before_size, after_size, before_cont_id, after_cont_id,
                                                         --      stockpile_id, stockpile_name,
                                                         --      before_mat_amt {Leather, Bone, Shell, Tooth, Horn, HairWool, Yarn}
-                                                        --      after_mat_amt {Leather, Bone, Shell, Tooth, Horn, HairWool, Yarn} 
+                                                        --      after_mat_amt {Leather, Bone, Shell, Tooth, Horn, HairWool, Yarn}
                                                         --  }
     comp_item.item_qty = 0                              -- total quantity of items
     comp_item.material_amt = 0                          -- total amount of materials

--- a/combine.lua
+++ b/combine.lua
@@ -87,7 +87,7 @@ local function comp_item_new(comp_key, max_size)
     comp_item.description = ''                          -- description of the comp item for output
     comp_item.max_size = max_size or 0                  -- how many of a comp item can be in one stack
     -- item info
-    comp_item.items = CList:new(nil)                    -- key:item.id, val:{ item, before_size, after_size, before_cont_id, after_cont_id, 
+    comp_item.items = CList:new(nil)                    -- key:item.id, val:{ item, before_size, after_size, before_cont_id, after_cont_id,
                                                         --                    before_mat_amt {Leather, Bone, Shell, Tooth, Horn, HairWool, Yarn}
                                                         --                    after_mat_amt {Leather, Bone, Shell, Tooth, Horn, HairWool, Yarn} }
     comp_item.item_qty = 0                              -- total quantity of items
@@ -131,7 +131,7 @@ local function comp_item_add_item(stack_type, comp_item, item, container)
             new_item.before_mat_amt.HairWool = item.material_amount.HairWool
             new_item.before_mat_amt.Yarn     = item.material_amount.Yarn
             for _, v in pairs(new_item.before_mat_amt) do if new_item.before_mat_amt.Qty < v then new_item.before_mat_amt.Qty = v end end
-            
+
             comp_item.material_amt = comp_item.material_amt + new_item.before_mat_amt.Qty
             if new_item.before_mat_amt.Qty > comp_item.max_mat_amt then comp_item.max_mat_amt = new_item.before_mat_amt.Qty end
         end
@@ -387,7 +387,7 @@ local function isValidPart(item)
             item.material_amount.Horn > 0 or
             item.material_amount.HairWool > 0 or
             item.material_amount.Yarn > 0))
-            
+
 end
 
 function stacks_add_items(stacks, items, container, contained_count, ind)
@@ -526,7 +526,7 @@ local function preview_stacks(stacks)
 
                 if stack_remainder > 0 then
                     comp_item.after_stacks = stacks_needed + 1
-                else 
+                else
                     comp_item.after_stacks = stacks_needed
                 end
 

--- a/docs/combine.rst
+++ b/docs/combine.rst
@@ -63,7 +63,7 @@ Options
 
 ``-q``, ``--quiet``
     Only print changes instead of a summary of all processed stockpiles.
-    
+
 ``-v``, ``--verbose n``
     Print verbose output, n from 1 to 4.
 
@@ -72,7 +72,7 @@ Notes
 The following conditions prevent an item from being combined:
 1. An item is not in a stockpile.
 2. An item is sand or plaster.
-3. An item is rotten, forbidden/hidden, marked for dumping/melting, 
+3. An item is rotten, forbidden/hidden, marked for dumping/melting,
 on fire, encased, owned by a trader/hostile/dwarf or is in a spider web.
 
 The following categories are used for combining:

--- a/docs/combine.rst
+++ b/docs/combine.rst
@@ -64,8 +64,8 @@ Options
 ``-q``, ``--quiet``
     Only print changes instead of a summary of all processed stockpiles.
     
-``-v``, ``--verbose [0-3]``
-    Print verbose output, level from 0 to 3.
+``-v``, ``--verbose n``
+    Print verbose output, n from 1 to 4.
 
 Notes
 -----

--- a/docs/combine.rst
+++ b/docs/combine.rst
@@ -55,6 +55,8 @@ Options
 
         ``meat``:  MEAT
 
+        ``parts``: CORPSEPIECE
+
         ``plant``: PLANT and PLANT_GROWTH
 
         ``powders``: POWDERS_MISC
@@ -74,10 +76,12 @@ The following conditions prevent an item from being combined:
 2. An item is sand or plaster.
 3. An item is rotten, forbidden/hidden, marked for dumping/melting,
 on fire, encased, owned by a trader/hostile/dwarf or is in a spider web.
+4. An item is a part and not butchered.
 
 The following categories are used for combining:
-1. Item has a race/caste: category=type + race + caste
-2. Item is ammo, created by for masterwork. category=type + material + quality (+ created by)
-3. Or: category= type + material
+1. Item is a part and has a race: category=type + race
+2. Item has a race/caste: category=type + race + caste
+3. Item is ammo, created by for masterwork. category=type + material + quality (+ created by)
+4. Or: category= type + material
 
 A default stack size of 30 applies to a category, unless a larger stack exists.

--- a/docs/combine.rst
+++ b/docs/combine.rst
@@ -23,21 +23,23 @@ Examples
 ``combine all --types=meat,plant``
     Merge ``meat`` and ``plant`` type stacks in all stockpiles.
 ``combine here``
-    Merge stacks in stockpile located at game cursor.
+    Merge stacks in the selected stockpile.
 
 Commands
 --------
 ``all``
     Search all stockpiles.
 ``here``
-    Search the stockpile under the game cursor.
+    Search the currently selected stockpile.
 
 Options
 -------
 ``-h``, ``--help``
     Prints help text. Default if no options are specified.
+
 ``-d``, ``--dry-run``
     Display the stack changes without applying them.
+
 ``-t``, ``--types <comma separated list of types>``
     Filter item types. Default is ``all``. Valid types are:
 
@@ -72,16 +74,16 @@ Options
 Notes
 -----
 The following conditions prevent an item from being combined:
-1. An item is not in a stockpile.
-2. An item is sand or plaster.
-3. An item is rotten, forbidden/hidden, marked for dumping/melting,
-on fire, encased, owned by a trader/hostile/dwarf or is in a spider web.
-4. An item is a part and not butchered.
+    1. An item is not in a stockpile.
+    2. An item is sand or plaster.
+    3. An item is rotten, forbidden/hidden, marked for dumping/melting, on fire, encased, owned by a trader/hostile/dwarf or is in a spider web.
+    4. An item is part of a corpse and not butchered.
 
-The following categories are used for combining:
-1. Item is a part and has a race: category=type + race
-2. Item has a race/caste: category=type + race + caste
-3. Item is ammo, created by for masterwork. category=type + material + quality (+ created by)
-4. Or: category= type + material
+The following categories are defined:
+    1. Corpse pieces, grouped by piece type and race
+    2. Items that have an associated race/caste, grouped by item type,  race, and caste
+    3. Ammo, grouped by ammo type, material, and quality. If the ammo is a masterwork, it is also grouped by who created it.
+    4. Anything else, grouped by item type and material
 
-A default stack size of 30 applies to a category, unless a larger stack exists.
+Each category has a default stack size of 30 unless a larger stack already exists in your fort.
+In that case the largest existing stack size is used.

--- a/docs/combine.rst
+++ b/docs/combine.rst
@@ -43,6 +43,8 @@ Options
 
         ``all``:   all of the types listed here.
 
+        ``ammo``: AMMO
+
         ``drink``: DRINK
 
         ``fat``:   GLOB and CHEESE
@@ -59,5 +61,8 @@ Options
 
         ``seeds``: SEEDS
 
-``-v``, ``--verbose 1-4``
-    Print verbose output, level from 1 to 4.
+``-q``, ``--quiet``
+    Only print changes instead of a summary of all processed stockpiles.
+
+``-v``, ``--verbose n``
+    Print verbose output, n from 1 to 4.

--- a/docs/combine.rst
+++ b/docs/combine.rst
@@ -63,6 +63,21 @@ Options
 
 ``-q``, ``--quiet``
     Only print changes instead of a summary of all processed stockpiles.
+    
+``-v``, ``--verbose [0-3]``
+    Print verbose output, level from 0 to 3.
 
-``-v``, ``--verbose n``
-    Print verbose output, n from 1 to 4.
+Notes
+-----
+The following conditions prevent an item from being combined:
+1. An item is not in a stockpile.
+2. An item is sand or plaster.
+3. An item is rotten, forbidden/hidden, marked for dumping/melting, 
+on fire, encased, owned by a trader/hostile/dwarf or is in a spider web.
+
+The following categories are used for combining:
+1. Item has a race/caste: category=type + race + caste
+2. Item is ammo, created by for masterwork. category=type + material + quality (+ created by)
+3. Or: category= type + material
+
+A default stack size of 30 applies to a category, unless a larger stack exists.


### PR DESCRIPTION
PR for https://github.com/DFHack/dfhack/issues/3215.

Combine ammo, for bolts and arrows. categories: type + material + quality (+ created by). Created by is used for masterwork items.

Items which are marked for melting, is forbidden or hidden are excluded from being combined. This is in addition to the existing restrictions.

Edit: Added https://github.com/DFHack/dfhack/issues/3220.