### PR TITLE
[gui/create-item] refactor and fix up

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ that repo.
 
 ## New Scripts
 - `exportlegends`: export extended legends information for external browsing
+- `modtools/create-item`: commandline and API interface for creating items
 
 ## Fixes
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ that repo.
 ## Fixes
 
 ## Misc Improvements
+- `gui/create-item`: ask for number of items to spawn by default
 
 ## Removed
 

--- a/docs/gui/create-item.rst
+++ b/docs/gui/create-item.rst
@@ -33,12 +33,12 @@ Examples
 Options
 -------
 
-``--count <num>``
+``-c``, ``--count <num>``
     Set the quantity of items to create instead of prompting for it.
-``--unit <id>``
+``-u``, ``--unit <id>``
     Use the specified unit as the "creator" of the generated item instead of the
     selected unit or the first citizen.
-``--unrestricted``
+``-f``, ``--unrestricted``
     Don't restrict the material options to only those that are normally
     appropriate for the selected item type.
 ``--startup``

--- a/docs/gui/create-item.rst
+++ b/docs/gui/create-item.rst
@@ -2,19 +2,16 @@ gui/create-item
 ===============
 
 .. dfhack-tool::
-    :summary: Magically summon any item.
+    :summary: Summon items from the aether.
     :tags: fort armok items
 
 This tool provides a graphical interface for creating items of your choice. It
 walks you through the creation process with a series of prompts, asking you
-for the type of item, the material, the quality, and (if ``--multi`` is passed
-on the commandline) the quantity.
+for the type of item, the material, the quality, and the quantity.
 
-Be sure to select a unit before running this tool so the created item can have
-a valid "creator" assigned.
-
-See also `createitem` or `modtools/create-item` for different interfaces for
-creating items.
+If a unit is selected, that unit will be designated the creator of the summoned
+items. The items will appear at that unit's feet. If no unit is selected, the
+first citizen unit will be used as the creator.
 
 Usage
 -----
@@ -26,27 +23,27 @@ Usage
 Examples
 --------
 
-``gui/create-item --multi``
-    Only provide options for creating items that normally exist in the game.
-    Also include the prompt for quantity so you can create more than just one
-    item at a time.
-``gui/create-item --unrestricted``
+``gui/create-item``
+    Walk player through the creation of an item that can normally exist in the
+    game.
+``gui/create-item --unrestricted --count 1``
     Create one item made of anything in the game. For example, you can create
     a bar of vomit, if you please.
 
 Options
 -------
 
-``--multi``
-    Also prompt for the quantity of items to create.
+``--count <num>``
+    Set the quantity of items to create instead of prompting for it.
 ``--unit <id>``
     Use the specified unit as the "creator" of the generated item instead of the
-    selected unit.
+    selected unit or the first citizen.
 ``--unrestricted``
     Don't restrict the material options to only those that are normally
     appropriate for the selected item type.
 ``--startup``
-    Instead of showing the item creation interface, start monitoring reactions
-    for a modded reaction with a code of ``DFHACK_WISH``. When a reaction with
-    that code is completed, show the item creation gui. This allows you to mod
-    in "wands of wishing" that can let your adventurer make wishes for items.
+    Instead of showing the item creation interface, start monitoring for a
+    modded reaction with a code of ``DFHACK_WISH``. When a reaction with that
+    code is completed, show the item creation gui (with ``--count 1``). This
+    allows you to mod in "wands of wishing" that can let your adventurer make
+    wishes for an item.

--- a/docs/modtools/create-item.rst
+++ b/docs/modtools/create-item.rst
@@ -14,30 +14,30 @@ Usage
 
     modtools/create-item <options>
 
+Examples
+--------
+
+``modtools/create-item -u 23145 -i WEAPON:ITEM_WEAPON_PICK -m INORGANIC:IRON -q4``
+    Have unit 23145 create an exceptionally crafted iron pick.
+``modtools/create-item -u 323 -i CORPSEPIECE:NONE -m CREATURE_MAT:DWARF:BRAIN``
+    Have unit 323 produce a lump of brain.
+``modtools/create-item -i BOULDER:NONE -m INORGANIC:ADAMANTINE -c 5``
+``modtools/create-item -i BOULDER:NONE -m PLANT_MAT:MUSHROOM_HELMET_PLUMP:DRINK``
+
 Options
 -------
 
-    -creator id
-        specify the id of the unit who will create the item,
-        or \\LAST to indicate the unit with id df.global.unit_next_id-1
-        examples:
-            0
-            2
-            \\LAST
-    -material matstring
-        specify the material of the item to be created
-        examples:
-            INORGANIC:IRON
-            CREATURE_MAT:DWARF:BRAIN
-            PLANT_MAT:MUSHROOM_HELMET_PLUMP:DRINK
-    -item itemstr
-        specify the itemdef of the item to be created
-        examples:
-            WEAPON:ITEM_WEAPON_PICK
-    -quality qualitystr
-        specify the quality level of the item to be created (df.item_quality)
-        examples: Ordinary, WellCrafted, FinelyCrafted, Masterful, or 0-5
-    -matchingShoes
-        create two of this item
-    -matchingGloves
-        create two of this item, and set handedness appropriately
+``-u``, ``--unit <id>`` (default: first citizen)
+    The ID of the unit to use as the item's creator. You can also pass the
+    string "\\LAST" to use the most recently created unit.
+``-i``, ``--item <itemdef>`` (required)
+    The def string of the item you want to create.
+``-m``, ``--material`` (required)
+    That def string of the material you want the item to be made out of.
+``-q``, ``--quality`` (default: ``0``, which is ``df.item_quality.Ordinary``)
+    The quality of the created item.
+``-d``, ``--description`` (required if you are creating a slab)
+    The text that will be engraved on the created slab.
+``-c``, ``--count`` (default: ``1``)
+    The number of items to create. If the item is stackable, this will be the
+    stack size.

--- a/docs/modtools/create-item.rst
+++ b/docs/modtools/create-item.rst
@@ -3,7 +3,7 @@ modtools/create-item
 
 .. dfhack-tool::
     :summary: Create arbitrary items.
-    :tags: unavailable dev
+    :tags: dev
 
 This tool provides a commandline interface for creating items of your choice.
 
@@ -21,8 +21,10 @@ Examples
     Have unit 23145 create an exceptionally crafted iron pick.
 ``modtools/create-item -u 323 -i CORPSEPIECE:NONE -m CREATURE_MAT:DWARF:BRAIN``
     Have unit 323 produce a lump of brain.
-``modtools/create-item -i BOULDER:NONE -m INORGANIC:ADAMANTINE -c 5``
-``modtools/create-item -i BOULDER:NONE -m PLANT_MAT:MUSHROOM_HELMET_PLUMP:DRINK``
+``modtools/create-item -i BOULDER:NONE -m INORGANIC:RAW_ADAMANTINE -c 5``
+    Spawn 5 raw adamantine boulders.
+``modtools/create-item -i DRINK:NONE -m PLANT:MUSHROOM_HELMET_PLUMP:DRINK``
+    Spawn a barrel of dwarven ale.
 
 Options
 -------

--- a/docs/modtools/create-item.rst
+++ b/docs/modtools/create-item.rst
@@ -19,8 +19,8 @@ Examples
 
 ``modtools/create-item -u 23145 -i WEAPON:ITEM_WEAPON_PICK -m INORGANIC:IRON -q4``
     Have unit 23145 create an exceptionally crafted iron pick.
-``modtools/create-item -u 323 -i CORPSEPIECE:NONE -m CREATURE_MAT:DWARF:BRAIN``
-    Have unit 323 produce a lump of brain.
+``modtools/create-item -u 323 -i MEAT:NONE -m CREATURE_MAT:DWARF:BRAIN``
+    Have unit 323 produce a lump of (prepared) brain.
 ``modtools/create-item -i BOULDER:NONE -m INORGANIC:RAW_ADAMANTINE -c 5``
     Spawn 5 raw adamantine boulders.
 ``modtools/create-item -i DRINK:NONE -m PLANT:MUSHROOM_HELMET_PLUMP:DRINK``

--- a/docs/modtools/create-item.rst
+++ b/docs/modtools/create-item.rst
@@ -19,7 +19,7 @@ Examples
 
 ``modtools/create-item -u 23145 -i WEAPON:ITEM_WEAPON_PICK -m INORGANIC:IRON -q4``
     Have unit 23145 create an exceptionally crafted iron pick.
-``modtools/create-item -u 323 -i MEAT:NONE -m CREATURE_MAT:DWARF:BRAIN``
+``modtools/create-item -u 323 -i MEAT:NONE -m CREATURE:DWARF:BRAIN``
     Have unit 323 produce a lump of (prepared) brain.
 ``modtools/create-item -i BOULDER:NONE -m INORGANIC:RAW_ADAMANTINE -c 5``
     Spawn 5 raw adamantine boulders.
@@ -34,12 +34,18 @@ Options
     string "\\LAST" to use the most recently created unit.
 ``-i``, ``--item <itemdef>`` (required)
     The def string of the item you want to create.
-``-m``, ``--material`` (required)
+``-m``, ``--material <matdef>`` (required)
     That def string of the material you want the item to be made out of.
-``-q``, ``--quality`` (default: ``0``, which is ``df.item_quality.Ordinary``)
+``-q``, ``--quality <num>`` (default: ``0``, equal to ``df.item_quality.Ordinary``)
     The quality of the created item.
-``-d``, ``--description`` (required if you are creating a slab)
+``-d``, ``--description <string>`` (required if you are creating a slab)
     The text that will be engraved on the created slab.
-``-c``, ``--count`` (default: ``1``)
+``-c``, ``--count <num>`` (default: ``1``)
     The number of items to create. If the item is stackable, this will be the
     stack size.
+``-t``, ``--caste <name or num>`` (default: ``0``)
+    Used if producing a corpse or other creature-based item that could have a
+    caste associated with it.
+``-p``, ``--pos <x>,<y>,<z>``
+    If specified, items will be spawned at the given coordinates instead of at
+    the creator unit's feet.

--- a/docs/modtools/create-item.rst
+++ b/docs/modtools/create-item.rst
@@ -5,10 +5,17 @@ modtools/create-item
     :summary: Create arbitrary items.
     :tags: unavailable dev
 
-Replaces the `createitem` plugin, with standard
-arguments. The other versions will be phased out in a later version.
+This tool provides a commandline interface for creating items of your choice.
 
-Arguments::
+Usage
+-----
+
+::
+
+    modtools/create-item <options>
+
+Options
+-------
 
     -creator id
         specify the id of the unit who will create the item,

--- a/gui/create-item.lua
+++ b/gui/create-item.lua
@@ -241,7 +241,7 @@ local default_accessors = {
         return script.showInputPrompt('Slab', 'What should the slab say?', COLOR_WHITE)
     end,
     get_count = function()
-        return script.showInputPrompt('Wish', 'How many do you want? (numbers only!)',
+        return script.showInputPrompt('Wish', 'How many do you want?',
             COLOR_LIGHTGREEN)
     end,
 }

--- a/gui/create-item.lua
+++ b/gui/create-item.lua
@@ -210,28 +210,28 @@ local default_accessors = {
         local creatureok, _, creatureTable = script.showListPrompt('Wish', 'What creature should it be?',
             COLOR_LIGHTGREEN, getCreatureList(), 1, true)
         if not creatureok then return false end
-        local mattype, matindex = getCreatureRaceAndCaste(creatureTable[3])
+        local raceId, casteId = getCreatureRaceAndCaste(creatureTable[3])
         if df.item_type[itype] ~= 'CORPSEPIECE' then
-            return true, mattype, matindex, -1
+            return true, -1, raceId, casteId, -1
         end
         local bodpartok, bodypart = script.showListPrompt('Wish', 'What body part should it be?',
-            COLOR_LIGHTGREEN, getCreaturePartList(mattype, matindex), 1, true)
+            COLOR_LIGHTGREEN, getCreaturePartList(raceId, casteId), 1, true)
         if not bodpartok then return false end
         local corpsepieceGeneric = false
         local partlayerok, partlayerID
         if bodypart == 1 then
             corpsepieceGeneric = true
             partlayerok, partlayerID = script.showListPrompt('Wish', 'What creature material should it be?',
-                COLOR_LIGHTGREEN, getCreatureMaterialList(mattype, matindex), 1, true)
+                COLOR_LIGHTGREEN, getCreatureMaterialList(raceId, casteId), 1, true)
         else
             --the offsets here are because indexes in lua are wonky (some start at 0, some start at 1), so we adjust for that, as well as the index offset created by inserting the "generic" option at the start of the body part selection prompt
             bodypart = bodypart - 2
             partlayerok, partlayerID = script.showListPrompt('Wish', 'What tissue layer should it be?',
-                COLOR_LIGHTGREEN, getCreaturePartLayerList(mattype, matindex, bodypart), 1, true)
+                COLOR_LIGHTGREEN, getCreaturePartLayerList(raceId, casteId, bodypart), 1, true)
             partlayerID = partlayerID - 1
         end
         if not partlayerok then return end
-        return true, mattype, matindex, bodypart, partlayerID - 1, corpsepieceGeneric
+        return true, -1, raceId, bodypart, partlayerID - 1, corpsepieceGeneric
     end,
     get_quality = function()
         return script.showListPrompt('Wish', 'What quality should it be?',

--- a/gui/create-item.lua
+++ b/gui/create-item.lua
@@ -118,7 +118,8 @@ local function getMatFilter(itemtype, opts)
             return (mat.flags.CHEESE_PLANT or mat.flags.CHEESE_CREATURE)
         end,
         LIQUID_MISC = function(mat, parent, typ, idx)
-            return (mat.flags.LIQUID_MISC_PLANT or mat.flags.LIQUID_MISC_CREATURE or mat.flags.LIQUID_MISC_OTHER)
+            return mat.id == 'WATER' or mat.id == 'LYE' or mat.flags.LIQUID_MISC_PLANT or
+                    mat.flags.LIQUID_MISC_CREATURE or mat.flags.LIQUID_MISC_OTHER
         end,
         POWDER_MISC = function(mat, parent, typ, idx)
             return (mat.flags.POWDER_MISC_PLANT or mat.flags.POWDER_MISC_CREATURE)

--- a/gui/create-item.lua
+++ b/gui/create-item.lua
@@ -80,7 +80,11 @@ local function getRestrictiveMatFilter(itemType, opts)
             return (mat.flags.IS_STONE)
         end,
         BAR = function(mat, parent, typ, idx)
-            return (mat.flags.IS_METAL or mat.flags.SOAP or mat.id == 'COAL')
+            return (mat.flags.IS_METAL or mat.flags.SOAP or mat.id == 'COAL' or
+                    mat.id == 'POTASH' or mat.id == 'ASH' or mat.id == 'PEARLASH')
+        end,
+        BLOCKS = function(mat, parent, typ, idx)
+            return mat.flags.IS_STONE or mat.flags.IS_METAL or mat.flags.IS_GLASS
         end,
     }
     for k,v in ipairs{'GOBLET', 'FLASK', 'TOY', 'RING', 'CROWN', 'SCEPTER', 'FIGURINE', 'TOOL'} do

--- a/gui/create-item.lua
+++ b/gui/create-item.lua
@@ -280,9 +280,9 @@ if opts.startup then
         if not reaction.code:find('DFHACK_WISH') then return end
         local accessors = copyall(default_accessors)
         accessors.get_unit = function() return unit end
-        createitem.hackWish(accessors, { count = 1 })
+        script.start(createitem.hackWish, accessors, { count = 1 })
     end
     return
 end
 
-createitem.hackWish(default_accessors, opts)
+script.start(createitem.hackWish, default_accessors, opts)

--- a/gui/create-item.lua
+++ b/gui/create-item.lua
@@ -231,7 +231,7 @@ local default_accessors = {
             partlayerID = partlayerID - 1
         end
         if not partlayerok then return end
-        return true, -1, raceId, bodypart, partlayerID - 1, corpsepieceGeneric
+        return true, -1, raceId, casteId, bodypart, partlayerID - 1, corpsepieceGeneric
     end,
     get_quality = function()
         return script.showListPrompt('Wish', 'What quality should it be?',

--- a/gui/create-item.lua
+++ b/gui/create-item.lua
@@ -3,523 +3,549 @@
 -- edited by expwnent
 --@module = true
 
-local utils = require 'utils'
+local eventful = require('plugins.eventful')
 local guidm = require('gui.dwarfmode')
+local script = require('gui.script')
+local utils = require('utils')
+
+local args
 
 function getGenderString(gender)
-  local sym = df.pronoun_type.attrs[gender].symbol
-  if not sym then
-    return ""
-  end
-  return "("..sym..")"
+    local sym = df.pronoun_type.attrs[gender].symbol
+    if not sym then return '' end
+    return '(' .. sym .. ')'
 end
 
 function getCreatureList()
- local crList={}
- for k,cr in ipairs(df.global.world.raws.creatures.alphabetic) do
-  for kk,ca in ipairs(cr.caste) do
-   local str=ca.caste_name[0]
-   str=str..' '..getGenderString(ca.sex)
-   table.insert(crList,{str,nil,ca})
-  end
- end
- return crList
+    local crList = {}
+    for k,cr in ipairs(df.global.world.raws.creatures.alphabetic) do
+        for kk,ca in ipairs(cr.caste) do
+            local str = ca.caste_name[0]
+            str = str .. ' ' .. getGenderString(ca.sex)
+            table.insert(crList, {str, nil, ca})
+        end
+    end
+    return crList
 end
 
 function getCreaturePartList(creatureID, casteID)
- local crpList={{"generic"}}
- for k,crp in ipairs(df.global.world.raws.creatures.all[creatureID].caste[casteID].body_info.body_parts) do
-  local str = crp.name_singular[0][0]
-  table.insert(crpList,{str})
- end
- return crpList
+    local crpList = {{'generic'}}
+    for k,crp in ipairs(df.global.world.raws.creatures.all[creatureID].caste[casteID].body_info.body_parts) do
+        local str = crp.name_singular[0][0]
+        table.insert(crpList, {str})
+    end
+    return crpList
 end
 
 function getCreaturePartLayerList(creatureID, casteID, partID)
- local crplList={{"whole"}}
- for k,crpl in ipairs(df.global.world.raws.creatures.all[creatureID].caste[casteID].body_info.body_parts[partID].layers) do
-  local str = crpl.layer_name
-  table.insert(crplList,{str})
- end
- return crplList
+    local crplList = {{'whole'}}
+    for k,crpl in ipairs(df.global.world.raws.creatures.all[creatureID].caste[casteID].body_info.body_parts[partID].layers) do
+        local str = crpl.layer_name
+        table.insert(crplList, {str})
+    end
+    return crplList
 end
 
 function getCreatureMaterialList(creatureID, casteID)
- local crmList={}
- for k,crm in ipairs(df.global.world.raws.creatures.all[creatureID].material) do
-  local str = crm.id
-  table.insert(crmList,{str})
- end
- return crmList
+    local crmList = {}
+    for k,crm in ipairs(df.global.world.raws.creatures.all[creatureID].material) do
+        local str = crm.id
+        table.insert(crmList, {str})
+    end
+    return crmList
 end
 
 function getRestrictiveMatFilter(itemType)
- if args.unrestricted then return nil end
- local itemTypes={
-   WEAPON=function(mat,parent,typ,idx)
-    return (mat.flags.ITEMS_WEAPON or mat.flags.ITEMS_WEAPON_RANGED)
-   end,
-   AMMO=function(mat,parent,typ,idx)
-    return (mat.flags.ITEMS_AMMO)
-   end,
-   ARMOR=function(mat,parent,typ,idx)
-    return (mat.flags.ITEMS_ARMOR)
-   end,
-   INSTRUMENT=function(mat,parent,typ,idx)
-    return (mat.flags.ITEMS_HARD)
-   end,
-   AMULET=function(mat,parent,typ,idx)
-    return (mat.flags.ITEMS_SOFT or mat.flags.ITEMS_HARD)
-   end,
-   ROCK=function(mat,parent,typ,idx)
-    return (mat.flags.IS_STONE)
-   end,
-   BOULDER=ROCK,
-   BAR=function(mat,parent,typ,idx)
-    return (mat.flags.IS_METAL or mat.flags.SOAP or mat.id==COAL)
-   end
-
-  }
- for k,v in ipairs({'GOBLET','FLASK','TOY','RING','CROWN','SCEPTER','FIGURINE','TOOL'}) do
-  itemTypes[v]=itemTypes.INSTRUMENT
- end
- for k,v in ipairs({'SHOES','SHIELD','HELM','GLOVES'}) do
-    itemTypes[v]=itemTypes.ARMOR
- end
- for k,v in ipairs({'EARRING','BRACELET'}) do
-    itemTypes[v]=itemTypes.AMULET
- end
- itemTypes.BOULDER=itemTypes.ROCK
- return itemTypes[df.item_type[itemType]]
+    if args.unrestricted then return nil end
+    local rock = function(mat, parent, typ, idx)
+        return (mat.flags.IS_STONE)
+    end
+    local itemTypes = {
+        WEAPON = function(mat, parent, typ, idx)
+            return (mat.flags.ITEMS_WEAPON or mat.flags.ITEMS_WEAPON_RANGED)
+        end,
+        AMMO = function(mat, parent, typ, idx)
+            return (mat.flags.ITEMS_AMMO)
+        end,
+        ARMOR = function(mat, parent, typ, idx)
+            return (mat.flags.ITEMS_ARMOR)
+        end,
+        INSTRUMENT = function(mat, parent, typ, idx)
+            return (mat.flags.ITEMS_HARD)
+        end,
+        AMULET = function(mat, parent, typ, idx)
+            return (mat.flags.ITEMS_SOFT or mat.flags.ITEMS_HARD)
+        end,
+        ROCK = rock,
+        BOULDER = rock,
+        BAR = function(mat, parent, typ, idx)
+            return (mat.flags.IS_METAL or mat.flags.SOAP or mat.id == 'COAL')
+        end,
+    }
+    for k,v in ipairs{'GOBLET', 'FLASK', 'TOY', 'RING', 'CROWN', 'SCEPTER', 'FIGURINE', 'TOOL'} do
+        itemTypes[v] = itemTypes.INSTRUMENT
+    end
+    for k,v in ipairs{'SHOES', 'SHIELD', 'HELM', 'GLOVES'} do
+        itemTypes[v] = itemTypes.ARMOR
+    end
+    for k,v in ipairs{'EARRING', 'BRACELET'} do
+        itemTypes[v] = itemTypes.AMULET
+    end
+    itemTypes.BOULDER = itemTypes.ROCK
+    return itemTypes[df.item_type[itemType]]
 end
 
 function getMatFilter(itemtype)
-  local itemTypes={
-   SEEDS=function(mat,parent,typ,idx)
-    return mat.flags.SEED_MAT
-   end,
-   PLANT=function(mat,parent,typ,idx)
-    return mat.flags.STRUCTURAL_PLANT_MAT
-   end,
-   LEAVES=function(mat,parent,typ,idx)
-    return mat.flags.LEAF_MAT
-   end,
-   MEAT=function(mat,parent,typ,idx)
-    return mat.flags.MEAT
-   end,
-   CHEESE=function(mat,parent,typ,idx)
-    return (mat.flags.CHEESE_PLANT or mat.flags.CHEESE_CREATURE)
-   end,
-   LIQUID_MISC=function(mat,parent,typ,idx)
-    return (mat.flags.LIQUID_MISC_PLANT or mat.flags.LIQUID_MISC_CREATURE or mat.flags.LIQUID_MISC_OTHER)
-   end,
-   POWDER_MISC=function(mat,parent,typ,idx)
-    return (mat.flags.POWDER_MISC_PLANT or mat.flags.POWDER_MISC_CREATURE)
-   end,
-   DRINK=function(mat,parent,typ,idx)
-    return (mat.flags.ALCOHOL_PLANT or mat.flags.ALCOHOL_CREATURE)
-   end,
-   GLOB=function(mat,parent,typ,idx)
-    return (mat.flags.STOCKPILE_GLOB)
-   end,
-   WOOD=function(mat,parent,typ,idx)
-    return (mat.flags.WOOD)
-   end,
-   THREAD=function(mat,parent,typ,idx)
-    return (mat.flags.THREAD_PLANT)
-   end,
-   LEATHER=function(mat,parent,typ,idx)
-    return (mat.flags.LEATHER)
-   end
-  }
-  return itemTypes[df.item_type[itemtype]] or getRestrictiveMatFilter(itemtype)
+    local itemTypes = {
+        SEEDS = function(mat, parent, typ, idx)
+            return mat.flags.SEED_MAT
+        end,
+        PLANT = function(mat, parent, typ, idx)
+            return mat.flags.STRUCTURAL_PLANT_MAT
+        end,
+        LEAVES = function(mat, parent, typ, idx)
+            return mat.flags.LEAF_MAT
+        end,
+        MEAT = function(mat, parent, typ, idx)
+            return mat.flags.MEAT
+        end,
+        CHEESE = function(mat, parent, typ, idx)
+            return (mat.flags.CHEESE_PLANT or mat.flags.CHEESE_CREATURE)
+        end,
+        LIQUID_MISC = function(mat, parent, typ, idx)
+            return (mat.flags.LIQUID_MISC_PLANT or mat.flags.LIQUID_MISC_CREATURE or mat.flags.LIQUID_MISC_OTHER)
+        end,
+        POWDER_MISC = function(mat, parent, typ, idx)
+            return (mat.flags.POWDER_MISC_PLANT or mat.flags.POWDER_MISC_CREATURE)
+        end,
+        DRINK = function(mat, parent, typ, idx)
+            return (mat.flags.ALCOHOL_PLANT or mat.flags.ALCOHOL_CREATURE)
+        end,
+        GLOB = function(mat, parent, typ, idx)
+            return (mat.flags.STOCKPILE_GLOB)
+        end,
+        WOOD = function(mat, parent, typ, idx)
+            return (mat.flags.WOOD)
+        end,
+        THREAD = function(mat, parent, typ, idx)
+            return (mat.flags.THREAD_PLANT)
+        end,
+        LEATHER = function(mat, parent, typ, idx)
+            return (mat.flags.LEATHER)
+        end,
+    }
+    return itemTypes[df.item_type[itemtype]] or getRestrictiveMatFilter(itemtype)
 end
 
-function createItem(mat,itemType,quality,creator,description,amount)
- local item=df.item.find(dfhack.items.createItem(itemType[1], itemType[2], mat[1], mat[2], creator))
- local item2=nil
- assert(item, 'failed to create item')
- quality = math.max(0, math.min(5, quality - 1))
- item:setQuality(quality)
- if df.item_type[itemType[1]]=='SLAB' then
-  item.description=description
- end
- if df.item_type[itemType[1]]=='GLOVES' then
-  --create matching gloves
-  item:setGloveHandedness(1)
-  item2=df.item.find(dfhack.items.createItem(itemType[1], itemType[2], mat[1], mat[2], creator))
-  assert(item2, 'failed to create item')
-  item2:setQuality(quality)
-  item2:setGloveHandedness(2)
- end
- if df.item_type[itemType[1]]=='SHOES' then
-  --create matching shoes
-  item2=df.item.find(dfhack.items.createItem(itemType[1], itemType[2], mat[1], mat[2], creator))
-  assert(item2, 'failed to create item')
-  item2:setQuality(quality)
- end
- if tonumber(amount) > 1 then
-  item:setStackSize(amount)
-  if item2 then item2:setStackSize(amount) end
- end
+function createItem(mat, itemType, quality, creator, description, amount)
+    local item = df.item.find(dfhack.items.createItem(itemType[1], itemType[2], mat[1], mat[2], creator))
+    local item2 = nil
+    assert(item, 'failed to create item')
+    quality = math.max(0, math.min(5, quality - 1))
+    item:setQuality(quality)
+    if df.item_type[itemType[1]] == 'SLAB' then
+        item.description = description
+    end
+    if df.item_type[itemType[1]] == 'GLOVES' then
+        --create matching gloves
+        item:setGloveHandedness(1)
+        item2 = df.item.find(dfhack.items.createItem(itemType[1], itemType[2], mat[1], mat[2], creator))
+        assert(item2, 'failed to create item')
+        item2:setQuality(quality)
+        item2:setGloveHandedness(2)
+    end
+    if df.item_type[itemType[1]] == 'SHOES' then
+        --create matching shoes
+        item2 = df.item.find(dfhack.items.createItem(itemType[1], itemType[2], mat[1], mat[2], creator))
+        assert(item2, 'failed to create item')
+        item2:setQuality(quality)
+    end
+    if tonumber(amount) > 1 then
+        item:setStackSize(amount)
+        if item2 then item2:setStackSize(amount) end
+    end
 end
 
 function qualityTable()
- return {{'None'},
- {'-Well-crafted-'},
- {'+Finely-crafted+'},
- {'*Superior*'},
- {string.char(240)..'Exceptional'..string.char(240)},
- {string.char(15)..'Masterwork'..string.char(15)}
- }
+    return {{'None'},
+        {'-Well-crafted-'},
+        {'+Finely-crafted+'},
+        {'*Superior*'},
+        {string.char(240) .. 'Exceptional' .. string.char(240)},
+        {string.char(15) .. 'Masterwork' .. string.char(15)},
+    }
 end
 
-local script=require('gui.script')
+function showItemPrompt(text, item_filter, hide_none)
+    require('gui.materials').ItemTypeDialog{
+        prompt = text,
+        item_filter = item_filter,
+        hide_none = hide_none,
+        on_select = script.mkresume(true),
+        on_cancel = script.mkresume(false),
+        on_close = script.qresume(nil),
+    }:show()
 
-function showItemPrompt(text,item_filter,hide_none)
- require('gui.materials').ItemTypeDialog{
-  prompt=text,
-  item_filter=item_filter,
-  hide_none=hide_none,
-  on_select=script.mkresume(true),
-  on_cancel=script.mkresume(false),
-  on_close=script.qresume(nil)
- }:show()
-
- return script.wait()
+    return script.wait()
 end
 
 function showMaterialPrompt(title, prompt, filter, inorganic, creature, plant) --the one included with DFHack doesn't have a filter or the inorganic, creature, plant things available
- require('gui.materials').MaterialDialog{
-  frame_title = title,
-  prompt = prompt,
-  mat_filter = filter,
-  use_inorganic = inorganic,
-  use_creature = creature,
-  use_plant = plant,
-  on_select = script.mkresume(true),
-  on_cancel = script.mkresume(false),
-  on_close = script.qresume(nil)
- }:show()
+    require('gui.materials').MaterialDialog{
+        frame_title = title,
+        prompt = prompt,
+        mat_filter = filter,
+        use_inorganic = inorganic,
+        use_creature = creature,
+        use_plant = plant,
+        on_select = script.mkresume(true),
+        on_cancel = script.mkresume(false),
+        on_close = script.qresume(nil),
+    }:show()
 
- return script.wait()
+    return script.wait()
 end
 
 function usesCreature(itemtype)
- typesThatUseCreatures={REMAINS=true,FISH=true,FISH_RAW=true,VERMIN=true,PET=true,EGG=true,CORPSE=true,CORPSEPIECE=true}
- return typesThatUseCreatures[df.item_type[itemtype]]
+    typesThatUseCreatures = {
+        REMAINS = true,
+        FISH = true,
+        FISH_RAW = true,
+        VERMIN = true,
+        PET = true,
+        EGG = true,
+        CORPSE = true,
+        CORPSEPIECE = true,
+    }
+    return typesThatUseCreatures[df.item_type[itemtype]]
 end
 
 local function getCreatureRaceAndCaste(caste)
- return df.global.world.raws.creatures.list_creature[caste.index],df.global.world.raws.creatures.list_caste[caste.index]
+    return df.global.world.raws.creatures.list_creature[caste.index],
+            df.global.world.raws.creatures.list_caste[caste.index]
 end
 
-local CORPSE_PIECES = utils.invert{'BONE', 'SKIN', 'CARTILAGE', 'TOOTH', 'NERVE', 'NAIL', 'HORN', 'HOOF', 'CHITIN', 'SHELL', 'IVORY', 'SCALE' }
-local HAIR_PIECES = utils.invert{'HAIR', 'EYEBROW', 'EYELASH', 'MOUSTACHE', 'CHIN_WHISKERS', 'SIDEBURNS' }
-local LIQUID_PIECES = utils.invert{'BLOOD', 'PUS', 'VENOM', 'SWEAT', 'TEARS', 'SPIT', 'MILK' }
+local CORPSE_PIECES = utils.invert{'BONE', 'SKIN', 'CARTILAGE', 'TOOTH', 'NERVE', 'NAIL', 'HORN', 'HOOF', 'CHITIN',
+    'SHELL', 'IVORY', 'SCALE'}
+local HAIR_PIECES = utils.invert{'HAIR', 'EYEBROW', 'EYELASH', 'MOUSTACHE', 'CHIN_WHISKERS', 'SIDEBURNS'}
+local LIQUID_PIECES = utils.invert{'BLOOD', 'PUS', 'VENOM', 'SWEAT', 'TEARS', 'SPIT', 'MILK'}
 
-function createCorpsePiece(creator, bodypart, partlayer, creatureID, casteID, generic, quality) -- this part was written by four rabbits in a trenchcoat (ppaawwll)
- -- (partlayer is also used to determine the material if we're spawning a "generic" body part (i'm just lazy lol))
- quality = math.max(0, math.min(5, quality - 1))
- creatureID = tonumber(creatureID)
- -- get the actual raws of the target creature
- local creatorRaceRaw = df.creature_raw.find(creatureID)
- local wholePart = false
- casteID = tonumber(casteID)
- bodypart = tonumber(bodypart)
- partlayer = tonumber(partlayer)
- if partlayer == -1 and not generic then -- somewhat similar to the bodypart variable below, a value of -1 here means that the user wants to spawn a whole body part. we set the partlayer to 0 (outermost) because the specific layer isn't important, and we're spawning them all anyway. if it's a generic corpsepiece we ignore it, as it gets added to anyway below (we can't do it below because between here and there there's lines that reference the part layer
-    partlayer = 0
-    wholePart = true
- end
- -- get body info for easy reference
- local creatorBody = creatorRaceRaw.caste[casteID].body_info
- local layerName
- local layerMat = "BONE"
- local tissueID
- local liquid = false
- local isCorpse = bodypart == -1 and not generic -- in the hackWish function, the bodypart variable is initialized to -1, which isn't changed if the spawned item is a corpse
- if not generic and not isCorpse then -- if we have a specified body part and layer, figure all the stuff out about that
- -- store the tissue id of the specific layer we selected
-  tissueID = tonumber(creatorBody.body_parts[bodypart].layers[partlayer].tissue_id)
-  layerMat = {}
-  -- get the material name from the material itself
-  for i in string.gmatch(dfhack.matinfo.getToken(creatorRaceRaw.tissue[tissueID].mat_type,creatureID), "([^:]+)") do
-   table.insert(layerMat,i)
-  end
-  layerMat = layerMat[3]
-  layerName = creatorBody.body_parts[bodypart].layers[partlayer].layer_name
- elseif not isCorpse then -- otherwise, figure out the mat name from the dual-use partlayer argument
-  partlayer = partlayer + 1 -- no "whole" option at the start of the generic creature material selection prompt means that the value we get is actually further along than intended
-  layerMat = creatorRaceRaw.material[partlayer].id
-  layerName = layerMat
- end
- -- default is MEAT, so if anything else fails to change it to something else, we know that the body layer is a meat item
- local item_type = "MEAT"
- -- get race name and layer name, both for finding the item material, and the latter for determining the corpsepiece flags to set
- local raceName = string.upper(creatorRaceRaw.creature_id)
- -- every key is a valid non-hair corpsepiece, so if we try to index a key that's not on the table, we don't have a non-hair corpsepiece
- -- we do the same as above but with hair
- -- if the layer is fat, spawn a glob of fat and DON'T check for other layer types
- if layerName == "FAT" then
-  item_type = "GLOB"
- elseif CORPSE_PIECES[layerName] or HAIR_PIECES[layerName] then -- check if hair
-  item_type = "CORPSEPIECE"
- elseif LIQUID_PIECES[layerName] then
-  item_type = "LIQUID_MISC"
-  liquid = true
- end
- if isCorpse then
-  item_type = "CORPSE"
-  generic = true
- end
- local itemType = dfhack.items.findType(item_type..":NONE")
- local itemSubtype = dfhack.items.findSubtype(item_type..":NONE")
- local material = "CREATURE_MAT:"..raceName..":"..layerMat
- local materialInfo = dfhack.matinfo.find(material)
- local item_id = dfhack.items.createItem(itemType, itemSubtype, materialInfo['type'], materialInfo.index, creator)
- local item = df.item.find(item_id)
- if liquid then
-  local bucketMat = dfhack.matinfo.find("PLANT_MAT:NETHER_CAP:WOOD")
-  if not bucketMat then
-   for i,n in ipairs(df.global.world.raws.plants.all) do
-    if n.flags.TREE then
-     bucketMat = dfhack.matinfo.find("PLANT_MAT:"..n.id..":WOOD")
+-- this part was written by four rabbits in a trenchcoat (ppaawwll)
+function createCorpsePiece(creator, bodypart, partlayer, creatureID, casteID, generic, quality)
+    -- (partlayer is also used to determine the material if we're spawning a "generic" body part (i'm just lazy lol))
+    quality = math.max(0, math.min(5, quality - 1))
+    creatureID = tonumber(creatureID)
+    -- get the actual raws of the target creature
+    local creatorRaceRaw = df.creature_raw.find(creatureID)
+    local wholePart = false
+    casteID = tonumber(casteID)
+    bodypart = tonumber(bodypart)
+    partlayer = tonumber(partlayer)
+    -- somewhat similar to the bodypart variable below, a value of -1 here means that the user wants to spawn a whole body part. we set the partlayer to 0 (outermost) because the specific layer isn't important, and we're spawning them all anyway. if it's a generic corpsepiece we ignore it, as it gets added to anyway below (we can't do it below because between here and there there's lines that reference the part layer
+    if partlayer == -1 and not generic then
+        partlayer = 0
+        wholePart = true
     end
-    if bucketMat then break end
-   end
-  end
-  local prevCursorPos = guidm.getCursorPos()
-  local bucketType = dfhack.items.findType("BUCKET:NONE")
-  local bucket = df.item.find(dfhack.items.createItem(bucketType, -1, bucketMat.type, bucketMat.index, creator))
-  dfhack.items.moveToContainer(item, bucket)
-  guidm.setCursorPos(creator.pos)
-  dfhack.run_command("spotclean")
-  guidm.setCursorPos(prevCursorPos)
- end
+    -- get body info for easy reference
+    local creatorBody = creatorRaceRaw.caste[casteID].body_info
+    local layerName
+    local layerMat = 'BONE'
+    local tissueID
+    local liquid = false
+    -- in the hackWish function, the bodypart variable is initialized to -1, which isn't changed if the spawned item is a corpse
+    local isCorpse = bodypart == -1 and not generic
+    if not generic and not isCorpse then -- if we have a specified body part and layer, figure all the stuff out about that
+        -- store the tissue id of the specific layer we selected
+        tissueID = tonumber(creatorBody.body_parts[bodypart].layers[partlayer].tissue_id)
+        layerMat = {}
+        -- get the material name from the material itself
+        for i in string.gmatch(dfhack.matinfo.getToken(creatorRaceRaw.tissue[tissueID].mat_type, creatureID), '([^:]+)') do
+            table.insert(layerMat, i)
+        end
+        layerMat = layerMat[3]
+        layerName = creatorBody.body_parts[bodypart].layers[partlayer].layer_name
+    elseif not isCorpse then -- otherwise, figure out the mat name from the dual-use partlayer argument
+        -- no "whole" option at the start of the generic creature material selection prompt means that the value we get is actually further along than intended
+        partlayer = partlayer + 1
+        layerMat = creatorRaceRaw.material[partlayer].id
+        layerName = layerMat
+    end
+    -- default is MEAT, so if anything else fails to change it to something else, we know that the body layer is a meat item
+    local item_type = 'MEAT'
+    -- get race name and layer name, both for finding the item material, and the latter for determining the corpsepiece flags to set
+    local raceName = string.upper(creatorRaceRaw.creature_id)
+    -- every key is a valid non-hair corpsepiece, so if we try to index a key that's not on the table, we don't have a non-hair corpsepiece
+    -- we do the same as above but with hair
+    -- if the layer is fat, spawn a glob of fat and DON'T check for other layer types
+    if layerName == 'FAT' then
+        item_type = 'GLOB'
+    elseif CORPSE_PIECES[layerName] or HAIR_PIECES[layerName] then -- check if hair
+        item_type = 'CORPSEPIECE'
+    elseif LIQUID_PIECES[layerName] then
+        item_type = 'LIQUID_MISC'
+        liquid = true
+    end
+    if isCorpse then
+        item_type = 'CORPSE'
+        generic = true
+    end
+    local itemType = dfhack.items.findType(item_type .. ':NONE')
+    local itemSubtype = dfhack.items.findSubtype(item_type .. ':NONE')
+    local material = 'CREATURE_MAT:' .. raceName .. ':' .. layerMat
+    local materialInfo = dfhack.matinfo.find(material)
+    local item_id = dfhack.items.createItem(itemType, itemSubtype, materialInfo['type'], materialInfo.index, creator)
+    local item = df.item.find(item_id)
+    if liquid then
+        local bucketMat = dfhack.matinfo.find('PLANT_MAT:NETHER_CAP:WOOD')
+        if not bucketMat then
+            for i,n in ipairs(df.global.world.raws.plants.all) do
+                if n.flags.TREE then
+                    bucketMat = dfhack.matinfo.find('PLANT_MAT:' .. n.id .. ':WOOD')
+                end
+                if bucketMat then break end
+            end
+        end
+        local prevCursorPos = guidm.getCursorPos()
+        local bucketType = dfhack.items.findType('BUCKET:NONE')
+        local bucket = df.item.find(dfhack.items.createItem(bucketType, -1, bucketMat.type, bucketMat.index, creator))
+        dfhack.items.moveToContainer(item, bucket)
+        guidm.setCursorPos(creator.pos)
+        dfhack.run_command('spotclean')
+        guidm.setCursorPos(prevCursorPos)
+    end
 
- -- if the item type is a corpsepiece, we know we have one, and then go on to set the appropriate flags
- if item_type == "CORPSEPIECE" then
-  if layerName == "BONE" then -- check if bones
-   item.corpse_flags.bone = true
-   item.material_amount.Bone = 1
-  elseif layerName == "SKIN" then -- check if skin/leather
-   item.corpse_flags.leather = true
-   item.material_amount.Leather = 1
-   -- elseif layerName == "CARTILAGE" then -- check if cartilage (NO SPECIAL FLAGS)
-  elseif layerName == "HAIR" then -- check if hair (simplified from before)
-   item.corpse_flags.hair_wool = true
-   item.material_amount.HairWool = 1
-   if materialInfo.material.flags.YARN then
-    item.corpse_flags.yarn = true
-    item.material_amount.Yarn = 1
-   end
-  elseif layerName == "TOOTH" or layerName == "IVORY" then -- check if tooth
-   item.corpse_flags.tooth = true
-   item.material_amount.Tooth = 1
-  elseif layerName == "NERVE" then -- check if nervous tissue
-   item.corpse_flags.skull1 = true -- apparently "skull1" is supposed to be named "rots/can_rot"
-   item.corpse_flags.separated_part = true
-   -- elseif layerName == "NAIL" then -- check if nail (NO SPECIAL FLAGS)
-  elseif layerName == "HORN" or layerName == "HOOF" then -- check if nail
-   item.corpse_flags.horn = true
-   item.material_amount.Horn = 1
-  elseif layerName == "SHELL" then
-   item.corpse_flags.shell = true
-   item.material_amount.Shell = 1
-  end
-  -- checking for skull
-  if not generic and not isCorpse and creatorBody.body_parts[bodypart].token == "SKULL" then
-   item.corpse_flags.skull2 = true
-  end
- end
- local matType
- -- figure out which material type the material is (probably a better way of doing this but whatever)
- for i in pairs(creatorRaceRaw.tissue) do
-  if creatorRaceRaw.tissue[i].tissue_material_str[1] == layerMat then
-   matType = creatorRaceRaw.tissue[i].mat_type
-  end
- end
- if item_type == "CORPSEPIECE" or item_type == "CORPSE" then
-  --referencing the source unit for, material, relation purposes???
-  item.race = creatureID
-  item.normal_race = creatureID
-  item.normal_caste = casteID
-  if casteID < 2 and #(creatorRaceRaw.caste) > 1 then -- usually the first two castes are for the creature's sex, so we set the item's sex to the caste if both the creature has one and it's a valid sex id (0 or 1)
-   item.sex = casteID
-  else
-   item.sex = -1 -- it
-  end
-  -- on a dwarf tissue index 3 (bone) is 22, but this is not always the case for all creatures, so we get the mat_type of index 3 instead
-  -- here we also set the actual referenced creature material of the corpsepiece
-  item.bone1.mat_type = matType
-  item.bone1.mat_index = creatureID
-  item.bone2.mat_type = matType
-  item.bone2.mat_index = creatureID
-  -- skin (and presumably other parts) use body part modifiers for size or amount
-  for i=0,200 do -- fuck it this works
-   -- inserts
-   item.body.bp_modifiers:insert('#',1) --jus,t, set a lot of it to one who cares
-  end
-  -- copy target creature's relsizes to the item's's body relsizes thing
-  for i,n in pairs(creatorBody.body_parts) do
-   -- inserts
-   item.body.body_part_relsize:insert('#',n.relsize)
-   item.body.components.body_part_status:insert(i,creator.body.components.body_part_status[0]) --copy the status of the creator's first part to every body_part_status of the desired creature
-   item.body.components.body_part_status[i].missing = true
-  end
-  for i in pairs(creatorBody.layer_part) do
-   -- inserts
-   item.body.components.layer_status:insert(i,creator.body.components.layer_status[0]) --copy the layer status of the creator's first layer to every layer_status of the desired creature
-   item.body.components.layer_status[i].gone = true
-  end
-  if item_type == "CORPSE" then
-   item.corpse_flags.unbutchered = true
-  end
-  if not generic then
-   -- keeps the body part that the user selected to spawn the item from
-   item.body.components.body_part_status[bodypart].missing = false
-   -- restores the selected layer of the selected body part
-   item.body.components.layer_status[creatorBody.body_parts[bodypart].layers[partlayer].layer_id].gone = false
-  elseif generic then
-   for i in pairs(creatorBody.body_parts) do
-     for n in pairs(creatorBody.body_parts[i].layers) do
-      if item_type == "CORPSE" then
-       item.body.components.body_part_status[i].missing = false
-       item.body.components.layer_status[creatorBody.body_parts[i].layers[n].layer_id].gone = false
-      else
-       -- search through the target creature's body parts and bring back every one which has the desired material
-       if creatorRaceRaw.tissue[creatorBody.body_parts[i].layers[n].tissue_id].tissue_material_str[1] == layerMat and creatorBody.body_parts[i].token ~= "SKULL" and not creatorBody.body_parts[i].flags.SMALL then
-        item.body.components.body_part_status[i].missing = false
-        item.body.components.layer_status[creatorBody.body_parts[i].layers[n].layer_id].gone = false
-        -- save the index of the bone layer to a variable
-       end
-      end
-     end
+    -- if the item type is a corpsepiece, we know we have one, and then go on to set the appropriate flags
+    if item_type == 'CORPSEPIECE' then
+        if layerName == 'BONE' then -- check if bones
+            item.corpse_flags.bone = true
+            item.material_amount.Bone = 1
+        elseif layerName == 'SKIN' then -- check if skin/leather
+            item.corpse_flags.leather = true
+            item.material_amount.Leather = 1
+            -- elseif layerName == "CARTILAGE" then -- check if cartilage (NO SPECIAL FLAGS)
+        elseif layerName == 'HAIR' then -- check if hair (simplified from before)
+            item.corpse_flags.hair_wool = true
+            item.material_amount.HairWool = 1
+            if materialInfo.material.flags.YARN then
+                item.corpse_flags.yarn = true
+                item.material_amount.Yarn = 1
+            end
+        elseif layerName == 'TOOTH' or layerName == 'IVORY' then -- check if tooth
+            item.corpse_flags.tooth = true
+            item.material_amount.Tooth = 1
+        elseif layerName == 'NERVE' then    -- check if nervous tissue
+            item.corpse_flags.skull1 = true -- apparently "skull1" is supposed to be named "rots/can_rot"
+            item.corpse_flags.separated_part = true
+            -- elseif layerName == "NAIL" then -- check if nail (NO SPECIAL FLAGS)
+        elseif layerName == 'HORN' or layerName == 'HOOF' then -- check if nail
+            item.corpse_flags.horn = true
+            item.material_amount.Horn = 1
+        elseif layerName == 'SHELL' then
+            item.corpse_flags.shell = true
+            item.material_amount.Shell = 1
+        end
+        -- checking for skull
+        if not generic and not isCorpse and creatorBody.body_parts[bodypart].token == 'SKULL' then
+            item.corpse_flags.skull2 = true
+        end
     end
-  end
-  if wholePart then -- brings back every tissue layer associated with a body part if we're spawning the entire thing
-    for i in pairs(creatorBody.body_parts[bodypart].layers) do
-     item.body.components.layer_status[creatorBody.body_parts[bodypart].layers[i].layer_id].gone = false
-     item.corpse_flags.separated_part = true
-     item.corpse_flags.unbutchered = true
+    local matType
+    -- figure out which material type the material is (probably a better way of doing this but whatever)
+    for i in pairs(creatorRaceRaw.tissue) do
+        if creatorRaceRaw.tissue[i].tissue_material_str[1] == layerMat then
+            matType = creatorRaceRaw.tissue[i].mat_type
+        end
     end
-  end
-  -- DO THIS LAST or else the game crashes for some reason
-  item.caste = casteID
- end
+    if item_type == 'CORPSEPIECE' or item_type == 'CORPSE' then
+        --referencing the source unit for, material, relation purposes???
+        item.race = creatureID
+        item.normal_race = creatureID
+        item.normal_caste = casteID
+        -- usually the first two castes are for the creature's sex, so we set the item's sex to the caste if both the creature has one and it's a valid sex id (0 or 1)
+        if casteID < 2 and #(creatorRaceRaw.caste) > 1 then
+            item.sex = casteID
+        else
+            item.sex = -1 -- it
+        end
+        -- on a dwarf tissue index 3 (bone) is 22, but this is not always the case for all creatures, so we get the mat_type of index 3 instead
+        -- here we also set the actual referenced creature material of the corpsepiece
+        item.bone1.mat_type = matType
+        item.bone1.mat_index = creatureID
+        item.bone2.mat_type = matType
+        item.bone2.mat_index = creatureID
+        -- skin (and presumably other parts) use body part modifiers for size or amount
+        for i = 0,200 do                          -- fuck it this works
+            -- inserts
+            item.body.bp_modifiers:insert('#', 1) --jus,t, set a lot of it to one who cares
+        end
+        -- copy target creature's relsizes to the item's's body relsizes thing
+        for i,n in pairs(creatorBody.body_parts) do
+            -- inserts
+            item.body.body_part_relsize:insert('#', n.relsize)
+            item.body.components.body_part_status:insert(i, creator.body.components.body_part_status[0]) --copy the status of the creator's first part to every body_part_status of the desired creature
+            item.body.components.body_part_status[i].missing = true
+        end
+        for i in pairs(creatorBody.layer_part) do
+            -- inserts
+            item.body.components.layer_status:insert(i, creator.body.components.layer_status[0]) --copy the layer status of the creator's first layer to every layer_status of the desired creature
+            item.body.components.layer_status[i].gone = true
+        end
+        if item_type == 'CORPSE' then
+            item.corpse_flags.unbutchered = true
+        end
+        if not generic then
+            -- keeps the body part that the user selected to spawn the item from
+            item.body.components.body_part_status[bodypart].missing = false
+            -- restores the selected layer of the selected body part
+            item.body.components.layer_status[creatorBody.body_parts[bodypart].layers[partlayer].layer_id].gone = false
+        elseif generic then
+            for i in pairs(creatorBody.body_parts) do
+                for n in pairs(creatorBody.body_parts[i].layers) do
+                    if item_type == 'CORPSE' then
+                        item.body.components.body_part_status[i].missing = false
+                        item.body.components.layer_status[creatorBody.body_parts[i].layers[n].layer_id].gone = false
+                    else
+                        -- search through the target creature's body parts and bring back every one which has the desired material
+                        if creatorRaceRaw.tissue[creatorBody.body_parts[i].layers[n].tissue_id].tissue_material_str[1] == layerMat and creatorBody.body_parts[i].token ~= 'SKULL' and not creatorBody.body_parts[i].flags.SMALL then
+                            item.body.components.body_part_status[i].missing = false
+                            item.body.components.layer_status[creatorBody.body_parts[i].layers[n].layer_id].gone = false
+                            -- save the index of the bone layer to a variable
+                        end
+                    end
+                end
+            end
+        end
+        -- brings back every tissue layer associated with a body part if we're spawning the entire thing
+        if wholePart then
+            for i in pairs(creatorBody.body_parts[bodypart].layers) do
+                item.body.components.layer_status[creatorBody.body_parts[bodypart].layers[i].layer_id].gone = false
+                item.corpse_flags.separated_part = true
+                item.corpse_flags.unbutchered = true
+            end
+        end
+        -- DO THIS LAST or else the game crashes for some reason
+        item.caste = casteID
+    end
 end
 
 function hackWish(unit)
- script.start(function()
-  local amountok, amount
-  local matok,mattype,matindex,matFilter
-  local partlayerok, partlayerID = false, 0
-  local qualityok, quality = false, 0
-  local itemok,itemtype,itemsubtype=showItemPrompt('What item do you want?',function(itype) return df.item_type[itype]~='FOOD' end ,true)
-  local corpsepieceGeneric
-  local bodypart = -1
-  if not itemok then return end
-  if not args.notRestrictive then
-   matFilter=getMatFilter(itemtype)
-  end
-  if not usesCreature(itemtype) then
-   matok,mattype,matindex=showMaterialPrompt('Wish','And what material should it be made of?',matFilter)
-   if not matok then return end
-  else
-   local creatureok,useless,creatureTable=script.showListPrompt('Wish','What creature should it be?',COLOR_LIGHTGREEN,getCreatureList(),1,true)
-   if not creatureok then return end
-   mattype,matindex=getCreatureRaceAndCaste(creatureTable[3])
-  end
-  if df.item_type[itemtype]=='CORPSEPIECE' then
-   local bodpartok,bodypartLocal=script.showListPrompt('Wish','What body part should it be?',COLOR_LIGHTGREEN,getCreaturePartList(mattype,matindex),1,true)
-   -- createCorpsePiece() references the bodypart variable so it can't be local to here
-   bodypart = bodypartLocal
-   if bodypart == 1 then
-     corpsepieceGeneric = true
-   end
-   if not bodpartok then return end
-   if not corpsepieceGeneric then -- probably a better way of doing this tbh
-    partlayerok,partlayerID=script.showListPrompt('Wish','What tissue layer should it be?',COLOR_LIGHTGREEN,getCreaturePartLayerList(mattype,matindex,bodypart-2),1,true)
-   else
-    partlayerok,partlayerID=script.showListPrompt('Wish','What creature material should it be?',COLOR_LIGHTGREEN,getCreatureMaterialList(mattype,matindex),1,true)
-   end
-    if not partlayerok then return end
-  elseif df.item_type[itemtype]~='CORPSE' then
-   qualityok,quality=script.showListPrompt('Wish','What quality should it be?',COLOR_LIGHTGREEN,qualityTable())
-   if not qualityok then return end
-  end
-  local description
-  if df.item_type[itemtype]=='SLAB' then
-   local descriptionok
-   descriptionok,description=script.showInputPrompt('Slab','What should the slab say?',COLOR_WHITE)
-   if not descriptionok then return end
-  end
-  if bodypart ~= -1 then
-   bodypart = bodypart - 2 --the offsets here are cause indexes in lua are wonky (some start at 0, some start at 1), so we adjust for that, as well as the index offset created by inserting the "generic" option at the start of the body part selection prompt
-  end
-  if args.multi then
-   repeat amountok,amount=script.showInputPrompt('Wish','How many do you want? (numbers only!)',COLOR_LIGHTGREEN) until tonumber(amount) or not amountok
-   if not amountok then return end
-   if mattype and itemtype then
-    if df.item_type.attrs[itemtype].is_stackable then
-     createItem({mattype,matindex},{itemtype,itemsubtype},quality,unit,description,amount)
-    else
-     local isCorpsePiece = itemtype == df.item_type.CORPSEPIECE or itemtype == df.item_type.CORPSE
-     for i=1,amount do
-      if not isCorpsePiece then
-       createItem({mattype,matindex},{itemtype,itemsubtype},quality,unit,description,1)
-      else
-       createCorpsePiece(unit,bodypart,partlayerID-2,mattype,matindex,corpsepieceGeneric,quality)
-      end
-     end
-    end
-    return true
-   end
-   return false
-  else
-   if mattype and itemtype then
-      if itemtype ~= df.item_type.CORPSEPIECE and itemtype ~= df.item_type.CORPSE then
-       createItem({mattype,matindex},{itemtype,itemsubtype},quality,unit,description,1)
-      else
-       createCorpsePiece(unit,bodypart,partlayerID-2,mattype,matindex,corpsepieceGeneric,quality)
-      end
-    return true
-   end
-   return false
-  end
- end)
+    script.start(function()
+        local amountok, amount
+        local matok, mattype, matindex, matFilter
+        local partlayerok, partlayerID = false, 0
+        local qualityok, quality = false, 0
+        local itemok, itemtype, itemsubtype = showItemPrompt('What item do you want?',
+            function(itype) return df.item_type[itype] ~= 'FOOD' end, true)
+        local corpsepieceGeneric
+        local bodypart = -1
+        if not itemok then return end
+        if not args.notRestrictive then
+            matFilter = getMatFilter(itemtype)
+        end
+        if not usesCreature(itemtype) then
+            matok, mattype, matindex = showMaterialPrompt('Wish', 'And what material should it be made of?', matFilter)
+            if not matok then return end
+        else
+            local creatureok, useless, creatureTable = script.showListPrompt('Wish', 'What creature should it be?',
+                COLOR_LIGHTGREEN, getCreatureList(), 1, true)
+            if not creatureok then return end
+            mattype, matindex = getCreatureRaceAndCaste(creatureTable[3])
+        end
+        if df.item_type[itemtype] == 'CORPSEPIECE' then
+            local bodpartok, bodypartLocal = script.showListPrompt('Wish', 'What body part should it be?',
+                COLOR_LIGHTGREEN,
+                getCreaturePartList(mattype, matindex), 1, true)
+            -- createCorpsePiece() references the bodypart variable so it can't be local to here
+            bodypart = bodypartLocal
+            if bodypart == 1 then
+                corpsepieceGeneric = true
+            end
+            if not bodpartok then return end
+            if not corpsepieceGeneric then -- probably a better way of doing this tbh
+                partlayerok, partlayerID = script.showListPrompt('Wish', 'What tissue layer should it be?',
+                    COLOR_LIGHTGREEN,
+                    getCreaturePartLayerList(mattype, matindex, bodypart - 2), 1, true)
+            else
+                partlayerok, partlayerID = script.showListPrompt('Wish', 'What creature material should it be?',
+                    COLOR_LIGHTGREEN,
+                    getCreatureMaterialList(mattype, matindex), 1, true)
+            end
+            if not partlayerok then return end
+        elseif df.item_type[itemtype] ~= 'CORPSE' then
+            qualityok, quality = script.showListPrompt('Wish', 'What quality should it be?', COLOR_LIGHTGREEN,
+                qualityTable())
+            if not qualityok then return end
+        end
+        local description
+        if df.item_type[itemtype] == 'SLAB' then
+            local descriptionok
+            descriptionok, description = script.showInputPrompt('Slab', 'What should the slab say?', COLOR_WHITE)
+            if not descriptionok then return end
+        end
+        if bodypart ~= -1 then
+            --the offsets here are cause indexes in lua are wonky (some start at 0, some start at 1), so we adjust for that, as well as the index offset created by inserting the "generic" option at the start of the body part selection prompt
+            bodypart = bodypart - 2
+        end
+        if args.multi then
+            repeat
+                amountok, amount = script.showInputPrompt('Wish', 'How many do you want? (numbers only!)',
+                    COLOR_LIGHTGREEN)
+            until tonumber(amount) or not amountok
+            if not amountok then return end
+            if mattype and itemtype then
+                if df.item_type.attrs[itemtype].is_stackable then
+                    createItem({mattype, matindex}, {itemtype, itemsubtype}, quality, unit, description, amount)
+                else
+                    local isCorpsePiece = itemtype == df.item_type.CORPSEPIECE or itemtype == df.item_type.CORPSE
+                    for i = 1,amount do
+                        if not isCorpsePiece then
+                            createItem({mattype, matindex}, {itemtype, itemsubtype}, quality, unit, description, 1)
+                        else
+                            createCorpsePiece(unit, bodypart, partlayerID - 2, mattype, matindex, corpsepieceGeneric,
+                                quality)
+                        end
+                    end
+                end
+                return true
+            end
+            return false
+        else
+            if mattype and itemtype then
+                if itemtype ~= df.item_type.CORPSEPIECE and itemtype ~= df.item_type.CORPSE then
+                    createItem({mattype, matindex}, {itemtype, itemsubtype}, quality, unit, description, 1)
+                else
+                    createCorpsePiece(unit, bodypart, partlayerID - 2, mattype, matindex, corpsepieceGeneric, quality)
+                end
+                return true
+            end
+            return false
+        end
+    end)
 end
 
-scriptArgs={...}
-
-utils=require('utils')
-
-validArgs = utils.invert({
- 'startup',
- 'unrestricted',
- 'unit',
- 'multi'
-})
-
-if moduleMode then
-  return
+if dfhack_flags.module then
+    return
 end
+
+validArgs = utils.invert{
+    'startup',
+    'unrestricted',
+    'unit',
+    'multi',
+}
 
 args = utils.processArgs({...}, validArgs)
 
-eventful=require('plugins.eventful')
+if args.startup then
+    eventful.onReactionComplete.hackWishP = function(reaction, unit)
+        if not reaction.code:find('DFHACK_WISH') then return end
+        hackWish(unit)
+    end
+    return
+end
 
-if not args.startup then
- local unit=tonumber(args.unit) and df.unit.find(tonumber(args.unit)) or dfhack.gui.getSelectedUnit(true)
- if unit then
-  hackWish(unit)
- else
-  qerror('A unit needs to be selected to use gui/create-item.')
- end
+local unit = tonumber(args.unit) and df.unit.find(tonumber(args.unit)) or dfhack.gui.getSelectedUnit(true)
+if unit then
+    hackWish(unit)
 else
- eventful.onReactionComplete.hackWishP=function(reaction,unit,input_items,input_reagents,output_items,call_native)
-  if not reaction.code:find('DFHACK_WISH') then return nil end
-  hackWish(unit)
- end
+    qerror('A unit needs to be selected to use gui/create-item.')
 end

--- a/modtools/create-item.lua
+++ b/modtools/create-item.lua
@@ -1,40 +1,5 @@
 -- creates an item of a given type and material
 --author expwnent
-local usage = [====[
-
-modtools/create-item
-====================
-Replaces the `createitem` plugin, with standard
-arguments. The other versions will be phased out in a later version.
-
-Arguments::
-
-    -creator id
-        specify the id of the unit who will create the item,
-        or \\LAST to indicate the unit with id df.global.unit_next_id-1
-        examples:
-            0
-            2
-            \\LAST
-    -material matstring
-        specify the material of the item to be created
-        examples:
-            INORGANIC:IRON
-            CREATURE_MAT:DWARF:BRAIN
-            PLANT_MAT:MUSHROOM_HELMET_PLUMP:DRINK
-    -item itemstr
-        specify the itemdef of the item to be created
-        examples:
-            WEAPON:ITEM_WEAPON_PICK
-    -quality qualitystr
-        specify the quality level of the item to be created (df.item_quality)
-        examples: Ordinary, WellCrafted, FinelyCrafted, Masterful, or 0-5
-    -matchingShoes
-        create two of this item
-    -matchingGloves
-        create two of this item, and set handedness appropriately
-
-]====]
 local utils = require 'utils'
 
 local validArgs = utils.invert({
@@ -134,7 +99,7 @@ end
 local args = utils.processArgs({...}, validArgs)
 
 if args.help then
- print(usage)
+    print(dfhack.script_help())
  return
 end
 

--- a/modtools/create-item.lua
+++ b/modtools/create-item.lua
@@ -289,8 +289,6 @@ function hackWish(accessors, opts)
     if not itemok then return end
     local matok, mattype, matindex, casteId, bodypart, partlayerID, corpsepieceGeneric = accessors.get_mat(itemtype, opts)
     if not matok then return end
-    print(mattype, matindex, casteId, bodypart, partlayerID, corpsepieceGeneric)
-    print(dfhack.matinfo.getToken(mattype, matindex))
     if not no_quality_item_types[df.item_type[itemtype]] then
         qualityok, quality = accessors.get_quality()
         if not qualityok then return end
@@ -392,7 +390,9 @@ local accessors = {
         if df.item_type[itype] ~= 'CORPSEPIECE' then
             return true, mat_info['type'], mat_info.index, caste, -1
         end
-        -- TODO: also return bodypart, partlayerID, corpsepieceGeneric
+        -- support only generic corpse pieces for now. this can be extended to support
+        -- everything that gui/create-item can produce, but we need more commandline
+        -- arguments to provide the info
         return true, -1, mat_info.index, caste, 1, 0, true
     end,
     get_quality = function()

--- a/modtools/create-item.lua
+++ b/modtools/create-item.lua
@@ -385,11 +385,12 @@ local accessors = {
         if not mat_info then
             error('invalid material: ' .. tostring(opts.mat))
         end
+        local caste = get_caste(mat_info.index, opts.caste)
         if df.item_type[itype] ~= 'CORPSEPIECE' then
-            return true, mat_info['type'], mat_info.index, get_caste(mat_info.index, opts.caste), -1
+            return true, mat_info['type'], mat_info.index, caste, -1
         end
         -- TODO: also return bodypart, partlayerID, corpsepieceGeneric
-        return false
+        return true, -1, mat_info.index, caste, get_body_part(), get_part_layer()
     end,
     get_quality = function()
         return true, (tonumber(opts.quality) or df.item_quality.Ordinary) + 1

--- a/modtools/create-item.lua
+++ b/modtools/create-item.lua
@@ -1,119 +1,436 @@
 -- creates an item of a given type and material
 --author expwnent
-local utils = require 'utils'
 
-local validArgs = utils.invert({
- 'help',
- 'creator',
- 'material',
- 'item',
--- 'creature',
--- 'caste',
- 'leftHand',
- 'rightHand',
- 'matchingGloves',
- 'matchingShoes',
- 'quality'
-})
+local guidm = require('gui.dwarfmode')
+local script = require('gui.script')
+local utils = require('utils')
 
-local organicTypes = utils.invert({
- df.item_type.REMAINS,
- df.item_type.FISH,
- df.item_type.FISH_RAW,
- df.item_type.VERMIN,
- df.item_type.PET,
- df.item_type.EGG,
-})
+local no_quality_item_types = utils.invert{
+    'BAR',
+    'SMALLGEM',
+    'BLOCKS',
+    'ROUGH',
+    'BOULDER',
+    'WOOD',
+    'CORPSE',
+    'CORPSEPIECE',
+    'REMAINS',
+    'MEAT',
+    'FISH',
+    'FISH_RAW',
+    'VERMIN',
+    'PET',
+    'SEEDS',
+    'PLANT',
+    'SKIN_TANNED',
+    'PLANT_GROWTH',
+    'THREAD',
+    'DRINK',
+    'POWDER_MISC',
+    'CHEESE',
+    'FOOD',
+    'LIQUID_MISC',
+    'COIN',
+    'GLOB',
+    'ROCK',
+    'EGG',
+    'BRANCH',
+}
 
-local badTypes = utils.invert({
- df.item_type.CORPSE,
- df.item_type.CORPSEPIECE,
- df.item_type.FOOD,
-})
+local CORPSE_PIECES = utils.invert{'BONE', 'SKIN', 'CARTILAGE', 'TOOTH', 'NERVE', 'NAIL', 'HORN', 'HOOF', 'CHITIN',
+    'SHELL', 'IVORY', 'SCALE'}
+local HAIR_PIECES = utils.invert{'HAIR', 'EYEBROW', 'EYELASH', 'MOUSTACHE', 'CHIN_WHISKERS', 'SIDEBURNS'}
+local LIQUID_PIECES = utils.invert{'BLOOD', 'PUS', 'VENOM', 'SWEAT', 'TEARS', 'SPIT', 'MILK'}
 
-function createItem(creatorID, item, material, leftHand, rightHand, quality, matchingGloves, matchingShoes)
- local itemQuality = df.item_quality[quality] or tonumber(quality) or df.item_quality.Ordinary
-
- local creator = df.unit.find(creatorID)
- if not creator then
-  error 'Invalid creator.'
- end
-
- if not item then
-  error 'Invalid item.'
- end
- local itemType = dfhack.items.findType(item)
- if itemType == -1 then
-  error 'Invalid item.'
- end
- local itemSubtype = dfhack.items.findSubtype(item)
-
- if organicTypes[itemType] then
-  --TODO: look up creature and caste
-  error 'Not yet supported.'
- end
-
- if badTypes[itemType] then
-  error 'Not supported.'
- end
-
- if not material then
-  error 'Invalid material.'
- end
- local materialInfo = dfhack.matinfo.find(material)
- if not materialInfo then
-  error 'Invalid material.'
- end
-
- local item1 = dfhack.items.createItem(itemType, itemSubtype, materialInfo['type'], materialInfo.index, creator)
- local item = df.item.find(item1)
-
- item:setQuality(itemQuality)
-
- if matchingGloves then
-  if not isGloves(item) then
-   error "Passed -matchingGloves with non-glove item"
-  end
-
-  local item2 = dfhack.items.createItem(itemType, itemSubtype, materialInfo['type'], materialInfo.index, creator)
-  local item_alt = df.item.find(item2)
-  item.handedness[0] = 1
-  item_alt.handedness[1] = 1
-  item_alt:setQuality(itemQuality)
- end
- if matchingShoes then
-  if not string.find(item.subtype.id, "ITEM_SHOES") then
-   error "Passed -matchingShoes with non-shoe item"
-  end
-
-  local item3 = dfhack.items.createItem(itemType, itemSubtype, materialInfo['type'], materialInfo.index, creator)
-  local item2_alt = df.item.find(item3)
-  item2_alt:setQuality(itemQuality)
-  end
+local function usesCreature(itemtype)
+    local typesThatUseCreatures = {
+        REMAINS = true,
+        FISH = true,
+        FISH_RAW = true,
+        VERMIN = true,
+        PET = true,
+        EGG = true,
+        CORPSE = true,
+        CORPSEPIECE = true,
+    }
+    return typesThatUseCreatures[df.item_type[itemtype]]
 end
 
-if moduleMode then
- return
+-- this part was written by four rabbits in a trenchcoat (ppaawwll)
+local function createCorpsePiece(creator, bodypart, partlayer, creatureID, casteID, generic)
+    -- (partlayer is also used to determine the material if we're spawning a "generic" body part (i'm just lazy lol))
+    creatureID = tonumber(creatureID)
+    -- get the actual raws of the target creature
+    local creatorRaceRaw = df.creature_raw.find(creatureID)
+    local wholePart = false
+    casteID = tonumber(casteID)
+    bodypart = tonumber(bodypart)
+    partlayer = tonumber(partlayer)
+    -- somewhat similar to the bodypart variable below, a value of -1 here means that the user wants to spawn a whole body part. we set the partlayer to 0 (outermost) because the specific layer isn't important, and we're spawning them all anyway. if it's a generic corpsepiece we ignore it, as it gets added to anyway below (we can't do it below because between here and there there's lines that reference the part layer
+    if partlayer == -1 and not generic then
+        partlayer = 0
+        wholePart = true
+    end
+    -- get body info for easy reference
+    local creatorBody = creatorRaceRaw.caste[casteID].body_info
+    local layerName
+    local layerMat = 'BONE'
+    local tissueID
+    local liquid = false
+    -- in the hackWish function, the bodypart variable is initialized to -1, which isn't changed if the spawned item is a corpse
+    local isCorpse = bodypart == -1 and not generic
+    if not generic and not isCorpse then -- if we have a specified body part and layer, figure all the stuff out about that
+        -- store the tissue id of the specific layer we selected
+        tissueID = tonumber(creatorBody.body_parts[bodypart].layers[partlayer].tissue_id)
+        local mats = {}
+        -- get the material name from the material itself
+        for i in string.gmatch(dfhack.matinfo.getToken(creatorRaceRaw.tissue[tissueID].mat_type, creatureID), '([^:]+)') do
+            table.insert(mats, i)
+        end
+        layerMat = mats[3]
+        layerName = creatorBody.body_parts[bodypart].layers[partlayer].layer_name
+    elseif not isCorpse then -- otherwise, figure out the mat name from the dual-use partlayer argument
+        layerMat = creatorRaceRaw.material[partlayer].id
+        layerName = layerMat
+    end
+    -- default is MEAT, so if anything else fails to change it to something else, we know that the body layer is a meat item
+    local item_type = 'MEAT'
+    -- get race name and layer name, both for finding the item material, and the latter for determining the corpsepiece flags to set
+    local raceName = string.upper(creatorRaceRaw.creature_id)
+    -- every key is a valid non-hair corpsepiece, so if we try to index a key that's not on the table, we don't have a non-hair corpsepiece
+    -- we do the same as above but with hair
+    -- if the layer is fat, spawn a glob of fat and DON'T check for other layer types
+    if layerName == 'FAT' then
+        item_type = 'GLOB'
+    elseif CORPSE_PIECES[layerName] or HAIR_PIECES[layerName] then -- check if hair
+        item_type = 'CORPSEPIECE'
+    elseif LIQUID_PIECES[layerName] then
+        item_type = 'LIQUID_MISC'
+        liquid = true
+    end
+    if isCorpse then
+        item_type = 'CORPSE'
+        generic = true
+    end
+    local itemType = dfhack.items.findType(item_type .. ':NONE')
+    local itemSubtype = dfhack.items.findSubtype(item_type .. ':NONE')
+    local material = 'CREATURE_MAT:' .. raceName .. ':' .. layerMat
+    local materialInfo = dfhack.matinfo.find(material)
+    local item_id = dfhack.items.createItem(itemType, itemSubtype, materialInfo['type'], materialInfo.index, creator)
+    local item = df.item.find(item_id)
+    if liquid then
+        local bucketMat = dfhack.matinfo.find('PLANT_MAT:NETHER_CAP:WOOD')
+        if not bucketMat then
+            for i,n in ipairs(df.global.world.raws.plants.all) do
+                if n.flags.TREE then
+                    bucketMat = dfhack.matinfo.find('PLANT_MAT:' .. n.id .. ':WOOD')
+                end
+                if bucketMat then break end
+            end
+        end
+        local prevCursorPos = guidm.getCursorPos()
+        local bucketType = dfhack.items.findType('BUCKET:NONE')
+        local bucket = df.item.find(dfhack.items.createItem(bucketType, -1, bucketMat.type, bucketMat.index, creator))
+        dfhack.items.moveToContainer(item, bucket)
+        guidm.setCursorPos(creator.pos)
+        dfhack.run_command('spotclean')
+        guidm.setCursorPos(prevCursorPos)
+    end
+
+    -- if the item type is a corpsepiece, we know we have one, and then go on to set the appropriate flags
+    if item_type == 'CORPSEPIECE' then
+        if layerName == 'BONE' then -- check if bones
+            item.corpse_flags.bone = true
+            item.material_amount.Bone = 1
+        elseif layerName == 'SKIN' then -- check if skin/leather
+            item.corpse_flags.leather = true
+            item.material_amount.Leather = 1
+            -- elseif layerName == "CARTILAGE" then -- check if cartilage (NO SPECIAL FLAGS)
+        elseif layerName == 'HAIR' then -- check if hair (simplified from before)
+            item.corpse_flags.hair_wool = true
+            item.material_amount.HairWool = 1
+            if materialInfo.material.flags.YARN then
+                item.corpse_flags.yarn = true
+                item.material_amount.Yarn = 1
+            end
+        elseif layerName == 'TOOTH' or layerName == 'IVORY' then -- check if tooth
+            item.corpse_flags.tooth = true
+            item.material_amount.Tooth = 1
+        elseif layerName == 'NERVE' then    -- check if nervous tissue
+            item.corpse_flags.skull1 = true -- apparently "skull1" is supposed to be named "rots/can_rot"
+            item.corpse_flags.separated_part = true
+            -- elseif layerName == "NAIL" then -- check if nail (NO SPECIAL FLAGS)
+        elseif layerName == 'HORN' or layerName == 'HOOF' then -- check if nail
+            item.corpse_flags.horn = true
+            item.material_amount.Horn = 1
+        elseif layerName == 'SHELL' then
+            item.corpse_flags.shell = true
+            item.material_amount.Shell = 1
+        end
+        -- checking for skull
+        if not generic and not isCorpse and creatorBody.body_parts[bodypart].token == 'SKULL' then
+            item.corpse_flags.skull2 = true
+        end
+    end
+    local matType
+    -- figure out which material type the material is (probably a better way of doing this but whatever)
+    for i in pairs(creatorRaceRaw.tissue) do
+        if creatorRaceRaw.tissue[i].tissue_material_str[1] == layerMat then
+            matType = creatorRaceRaw.tissue[i].mat_type
+        end
+    end
+    if item_type == 'CORPSEPIECE' or item_type == 'CORPSE' then
+        --referencing the source unit for, material, relation purposes???
+        item.race = creatureID
+        item.normal_race = creatureID
+        item.normal_caste = casteID
+        -- usually the first two castes are for the creature's sex, so we set the item's sex to the caste if both the creature has one and it's a valid sex id (0 or 1)
+        if casteID < 2 and #(creatorRaceRaw.caste) > 1 then
+            item.sex = casteID
+        else
+            item.sex = -1 -- it
+        end
+        -- on a dwarf tissue index 3 (bone) is 22, but this is not always the case for all creatures, so we get the mat_type of index 3 instead
+        -- here we also set the actual referenced creature material of the corpsepiece
+        item.bone1.mat_type = matType
+        item.bone1.mat_index = creatureID
+        item.bone2.mat_type = matType
+        item.bone2.mat_index = creatureID
+        -- skin (and presumably other parts) use body part modifiers for size or amount
+        for i = 0,200 do                          -- fuck it this works
+            -- inserts
+            item.body.bp_modifiers:insert('#', 1) --jus,t, set a lot of it to one who cares
+        end
+        -- copy target creature's relsizes to the item's's body relsizes thing
+        for i,n in pairs(creatorBody.body_parts) do
+            -- inserts
+            item.body.body_part_relsize:insert('#', n.relsize)
+            item.body.components.body_part_status:insert(i, creator.body.components.body_part_status[0]) --copy the status of the creator's first part to every body_part_status of the desired creature
+            item.body.components.body_part_status[i].missing = true
+        end
+        for i in pairs(creatorBody.layer_part) do
+            -- inserts
+            item.body.components.layer_status:insert(i, creator.body.components.layer_status[0]) --copy the layer status of the creator's first layer to every layer_status of the desired creature
+            item.body.components.layer_status[i].gone = true
+        end
+        if item_type == 'CORPSE' then
+            item.corpse_flags.unbutchered = true
+        end
+        if not generic then
+            -- keeps the body part that the user selected to spawn the item from
+            item.body.components.body_part_status[bodypart].missing = false
+            -- restores the selected layer of the selected body part
+            item.body.components.layer_status[creatorBody.body_parts[bodypart].layers[partlayer].layer_id].gone = false
+        elseif generic then
+            for i in pairs(creatorBody.body_parts) do
+                for n in pairs(creatorBody.body_parts[i].layers) do
+                    if item_type == 'CORPSE' then
+                        item.body.components.body_part_status[i].missing = false
+                        item.body.components.layer_status[creatorBody.body_parts[i].layers[n].layer_id].gone = false
+                    else
+                        -- search through the target creature's body parts and bring back every one which has the desired material
+                        if creatorRaceRaw.tissue[creatorBody.body_parts[i].layers[n].tissue_id].tissue_material_str[1] == layerMat and creatorBody.body_parts[i].token ~= 'SKULL' and not creatorBody.body_parts[i].flags.SMALL then
+                            item.body.components.body_part_status[i].missing = false
+                            item.body.components.layer_status[creatorBody.body_parts[i].layers[n].layer_id].gone = false
+                            -- save the index of the bone layer to a variable
+                        end
+                    end
+                end
+            end
+        end
+        -- brings back every tissue layer associated with a body part if we're spawning the entire thing
+        if wholePart then
+            for i in pairs(creatorBody.body_parts[bodypart].layers) do
+                item.body.components.layer_status[creatorBody.body_parts[bodypart].layers[i].layer_id].gone = false
+                item.corpse_flags.separated_part = true
+                item.corpse_flags.unbutchered = true
+            end
+        end
+        -- DO THIS LAST or else the game crashes for some reason
+        item.caste = casteID
+    end
 end
 
-local args = utils.processArgs({...}, validArgs)
+local function createItem(mat, itemType, quality, creator, description, amount)
+    local item = df.item.find(dfhack.items.createItem(itemType[1], itemType[2], mat[1], mat[2], creator))
+    local item2 = nil
+    assert(item, 'failed to create item')
+    quality = math.max(0, math.min(5, quality - 1))
+    item:setQuality(quality)
+    if df.item_type[itemType[1]] == 'SLAB' then
+        item.description = description
+    end
+    if df.item_type[itemType[1]] == 'GLOVES' then
+        --create matching gloves
+        item:setGloveHandedness(1)
+        item2 = df.item.find(dfhack.items.createItem(itemType[1], itemType[2], mat[1], mat[2], creator))
+        assert(item2, 'failed to create item')
+        item2:setQuality(quality)
+        item2:setGloveHandedness(2)
+    end
+    if df.item_type[itemType[1]] == 'SHOES' then
+        --create matching shoes
+        item2 = df.item.find(dfhack.items.createItem(itemType[1], itemType[2], mat[1], mat[2], creator))
+        assert(item2, 'failed to create item')
+        item2:setQuality(quality)
+    end
+    if tonumber(amount) > 1 then
+        item:setStackSize(amount)
+        if item2 then item2:setStackSize(amount) end
+    end
+end
 
-if args.help then
+local function get_first_citizen()
+    local citizens = dfhack.units.getCitizens()
+    if not citizens or not citizens[1] then
+        qerror('Could not choose a creator unit. Please select one in the UI')
+    end
+    return citizens[1]
+end
+
+function hackWish(accessors, opts)
+    local unit = accessors.get_unit(opts) or get_first_citizen()
+    script.start(function()
+        local matok, mattype, matindex
+        local partlayerok, partlayerID = false, 0
+        local qualityok, quality = false, df.item_quality.Ordinary
+        local itemok, itemtype, itemsubtype = accessors.get_item_type()
+        local corpsepieceGeneric
+        local bodypart = -1
+        if not itemok then return end
+        if not usesCreature(itemtype) then
+            matok, mattype, matindex = accessors.get_mat(itemtype, opts)
+            if not matok then return end
+        else
+            local creatureok
+            creatureok, mattype, matindex = accessors.get_creature_mat()
+            if not creatureok then return end
+        end
+        if df.item_type[itemtype] == 'CORPSEPIECE' then
+            local bodpartok, bodypartLocal = accessors.get_corpse_part(mattype, matindex)
+            -- createCorpsePiece() references the bodypart variable so it can't be local to here
+            bodypart = bodypartLocal
+            if bodypart == 1 then
+                corpsepieceGeneric = true
+            else
+                --the offsets here are cause indexes in lua are wonky (some start at 0, some start at 1), so we adjust for that, as well as the index offset created by inserting the "generic" option at the start of the body part selection prompt
+                bodypart = bodypart - 2
+            end
+            if not bodpartok then return end
+            if not corpsepieceGeneric then -- probably a better way of doing this tbh
+                partlayerok, partlayerID = accessors.get_tissue_layer(mattype, matindex, bodypart)
+                partlayerID = partlayerID - 1
+            else
+                partlayerok, partlayerID = accessors.get_creature_part_mat(mattype, matindex)
+            end
+            if not partlayerok then return end
+            partlayerID = partlayerID - 1
+        elseif not no_quality_item_types[df.item_type[itemtype]] then
+            qualityok, quality = accessors.get_quality()
+            if not qualityok then return end
+        end
+        local description
+        if df.item_type[itemtype] == 'SLAB' then
+            local descriptionok
+            descriptionok, description = accessors.get_description()
+            if not descriptionok then return end
+        end
+        local count = opts.count
+        if not count then
+            repeat
+                local amountok, amount = accessors.get_count()
+                if not amountok then return end
+                count = tonumber(amount)
+            until count
+        end
+        if not mattype or not itemtype then
+            return false
+        end
+        if df.item_type.attrs[itemtype].is_stackable then
+            createItem({mattype, matindex}, {itemtype, itemsubtype}, quality, unit, description, count)
+        else
+            for _ = 1,count do
+                if itemtype == df.item_type.CORPSEPIECE or itemtype == df.item_type.CORPSE then
+                    createCorpsePiece(unit, bodypart, partlayerID, mattype, matindex, corpsepieceGeneric)
+                else
+                    createItem({mattype, matindex}, {itemtype, itemsubtype}, quality, unit, description, 1)
+                end
+            end
+        end
+        return true
+    end)
+end
+
+if dfhack_flags.module then
+    return
+end
+
+if not dfhack.isMapLoaded() then
+    qerror('modtools/create-item needs a loaded map to work')
+end
+
+local opts = {}
+local positionals = argparse.processArgsGetopt({...}, {
+    {'h', 'help', handler = function() opts.help = true end},
+    {'u', 'unit', hasArg = true, handler = function(arg) opts.unit = arg end},
+    {'i', 'item', hasArg = true, handler = function(arg) opts.item = arg end},
+    {'m', 'material', hasArg = true, handler = function(arg) opts.mat = arg end},
+    {'q', 'quality', hasArg = true, handler = function(arg) opts.quality = arg end},
+    {'d', 'description', hasArg = true, handler = function(arg) opts.description = arg end},
+    {
+        'c',
+        'count',
+        hasArg = true,
+        handler = function(arg) opts.count = argparse.nonnegativeInt(arg, 'count') end,
+    },
+})
+
+if positionals[1] == 'help' then opts.help = true end
+if opts.help then
     print(dfhack.script_help())
- return
+    return
 end
 
-if args.creator == '\\LAST' then
-  args.creator = tostring(df.global.unit_next_id-1)
+if opts.unit == '\\LAST' then
+    opts.unit = tostring(df.global.unit_next_id - 1)
 end
 
-function isGloves(i)
- for key,value in pairs(i) do
-  if key == 'handedness' then
-   return true
-  end
- end
- return false
-end
+local accessors = {
+    get_unit = function()
+        return tonumber(opts.unit) and df.unit.find(tonumber(opts.unit)) or nil
+    end,
+    get_item_type = function()
+        local item_type = dfhack.items.findType(opts.item)
+        if item_type == -1 then
+            error('invalid item: ' .. tostring(opts.item))
+        end
+        return true, item_type, dfhack.items.findSubtype(opts.item)
+    end,
+    get_mat = function()
+        local mat_info = dfhack.matinfo.find(opts.mat)
+        if not mat_info then
+            error('invalid material: ' .. tostring(opts.mat))
+        end
+        return true, mat_info['type'], mat_info.index
+    end,
+    get_corpse_part = function()
+        -- TODO: return 2 if it's a specific corpse part
+        return true, 1
+    end,
+    get_tissue_layer = function()
+        error('not implemented')
+    end,
+    get_quality = function()
+        return true, opts.quality or df.item_quality.Ordinary
+    end,
+    get_description = function()
+        return true, opts.description or error('description not specified')
+    end,
+    get_count = function()
+        return true, opts.count or 1
+    end,
+}
+accessors.get_creature_mat = accessors.get_mat
+accessors.get_creature_part_mat = accessors.get_mat
 
-createItem(tonumber(args.creator), args.item, args.material, args.leftHand, args.rightHand, args.quality, args.matchingGloves, args.matchingShoes)
+hackWish(accessors, {})

--- a/modtools/create-item.lua
+++ b/modtools/create-item.lua
@@ -1,5 +1,6 @@
 -- creates an item of a given type and material
 --author expwnent
+--@module=true
 
 local guidm = require('gui.dwarfmode')
 local script = require('gui.script')


### PR DESCRIPTION
- changed argument parsing to use `processArgsGetopt` so all options now have short forms
- removed `--multi` option, replaced with `--count`; default is now to prompt for number, but if count is set, that will override (required to support legacy HACK_WISH functionality)
- fixed filters for water, lye, potash, pearlash, coal, and ash
- liquids now spawn in barrels/buckets as appropriate
- all item creation capabilities are now accessible in CLI form via `modtools/create-item`
- fixed some logic around corpse piece offsets

Fixes DFHack/dfhack#3243
Fixes DFHack/dfhack#3280

code was reformatted to use standard indents; diff best viewed while ignoring whitespace changes: https://github.com/DFHack/scripts/pull/687/files?diff=unified&w=1