### PR TITLE
Fix suspendmanager preentively suspending jobs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ that repo.
 
 ## Fixes
 - `deteriorate`: ensure remains of enemy dwarves are properly deteriorated
+- `suspendmanager`: Fix actively suspending jobs that could still be tentatively done
 
 ## Misc Improvements
 - `combine`: Now supports ammo, parts, powders, and seeds, and combines into containers

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,7 +17,7 @@ that repo.
 
 ## Fixes
 - `deteriorate`: ensure remains of enemy dwarves are properly deteriorated
-- `suspendmanager`: Fix actively suspending jobs that could still be tentatively done
+- `suspendmanager`: Fix over-aggressive suspension of jobs that could still possibly be done (e.g. jobs that are partially submerged in water)
 
 ## Misc Improvements
 - `combine`: Now supports ammo, parts, powders, and seeds, and combines into containers

--- a/unsuspend.lua
+++ b/unsuspend.lua
@@ -189,7 +189,7 @@ local unsuspended_count = 0
 suspendmanager.foreach_construction_job(function(job)
     if not job.flags.suspend then return end
 
-    local skip,reason=suspendmanager.shouldBeSuspended(job, skipblocking)
+    local skip,reason=suspendmanager.shouldStaySuspended(job, skipblocking)
     if skip then
         skipped_counts[reason] = (skipped_counts[reason] or 0) + 1
         return


### PR DESCRIPTION
Previously, suspendmanager had a single function for all the suspension reasons (blocking, building plan, underwater). The first one is computed by suspendmanager, but the last two are external suspension factors. When suspending jobs, all three were taken in account, meaning that suspendmanager would actively suspend jobs that were about to be suspended by these external factors.

This was effectively getting in the way of completing jobs, like one that were half under water that would blink on and off, without dwarves even attempting the job.

This PR splits the check between the jobs that "should be suspended" (only internal factors), and the ones that "should stay suspended" (internal + external factors), and only take in account the first one when suspending jobs.

Fix https://github.com/DFHack/dfhack/issues/3132