### PR TITLE
modernize gui/prerelease-warning

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ that repo.
 - `gui/gm-editor`: press ``g`` to move the map to the currently selected item/unit/building
 - `gui/gm-editor`: press ``Ctrl-D`` to toggle read-only mode to protect from accidental changes; this state persists across sessions
 - `gui/gm-editor`: new ``--freeze`` option for ensuring the game doesn't change while you're inspecting it
+- `gui/prerelease-warning`: widgets are now clickable
 
 ## Removed
 

--- a/gui/prerelease-warning.lua
+++ b/gui/prerelease-warning.lua
@@ -1,6 +1,7 @@
-local dlg = require 'gui.dialogs'
-local json = require 'json'
-local utils = require 'utils'
+local gui = require('gui')
+local json = require('json')
+local widgets = require('gui.widgets')
+local utils = require('utils')
 
 local force = ({...})[1] == 'force'
 local config = json.open('dfhack-config/prerelease-warning.json')
@@ -22,7 +23,7 @@ if not utils.invert{'alpha', 'beta', 'rc', 'r'}[state] then
     state = 'unknown'
 end
 
-message = ({
+local message = ({
     alpha = {
         'Warning',
         COLOR_YELLOW,
@@ -61,17 +62,18 @@ message = ({
     }
 })[state]
 
-title = table.remove(message, 1)
-color = table.remove(message, 1)
+local title = table.remove(message, 1)
+local color = table.remove(message, 1)
 
-pack_message = [[
+local pack_message = [[
 
 This should not be enabled by default in a pack.
 If you are seeing this message and did not enable/install DFHack
 yourself, please report this to your pack's maintainer.]]
 
-path = dfhack.getHackPath():lower()
-if #pack_message > 0 and (path:find('lnp') or path:find('starter') or path:find('newb') or path:find('lazy') or path:find('pack')) then
+local path = dfhack.getHackPath():lower()
+if path:find('lnp') or path:find('starter') or path:find('newb') or path:find('lazy') or
+        path:find('pack') then
     for _, v in pairs(pack_message:split('\n')) do
         table.insert(message, NEWLINE)
         table.insert(message, {text=v, pen=COLOR_LIGHTMAGENTA})
@@ -81,13 +83,13 @@ end
 for _, v in pairs(([[
 
 REMINDER: Please report any issues you encounter while
-using this DFHack build on GitHub (github.com/dfhack/dfhack/issues)
+using this DFHack build on GitHub (github.com/DFHack/dfhack/issues)
 or the Bay12 forums (dfhack.org/bay12).]]):split('\n')) do
     table.insert(message, NEWLINE)
     table.insert(message, {text=v, pen=COLOR_LIGHTCYAN})
 end
 
-nightly_message = [[
+local nightly_message = [[
 
 You appear to be using a nightly build of DFHack. If you
 experience problems, check dfhack.org/builds for updates.]]
@@ -100,7 +102,7 @@ end
 
 dfhack.print('\n')
 
-for k,v in ipairs(message) do
+for _, v in ipairs(message) do
     if type(v) == 'table' then
         dfhack.color(v.pen)
         dfhack.print(v.text)
@@ -113,34 +115,44 @@ end
 dfhack.color(COLOR_RESET)
 dfhack.print('\n\n')
 
-WarningBox = defclass(nil, dlg.MessageBox)
+WarningBoxScreen = defclass(WarningBoxScreen, gui.ZScreenModal)
+WarningBoxScreen.ATTRS{focus_path='prerelease-warning'}
 
-function WarningBox:getWantedFrameSize()
-    local w, h = WarningBox.super.getWantedFrameSize(self)
-    return w, h + 2
+function WarningBoxScreen:init()
+    self:addviews{
+        widgets.Window{
+            frame_title=title,
+            frame={w=74, h=14},
+            resizable=true,
+            resize_min={h=11},
+            subviews={
+                widgets.Label{
+                    frame={t=0, b=2},
+                    text=message,
+                    text_pen=color,
+                },
+                widgets.HotkeyLabel{
+                    frame={b=0, l=0},
+                    key='CUSTOM_D',
+                    label='Do not show again',
+                    auto_width=true,
+                    on_activate=function()
+                        config.data.hide = true
+                        config:write()
+                        self:dismiss()
+                    end,
+                },
+                widgets.HotkeyLabel{
+                    frame={b=0, l=30},
+                    key='SELECT',
+                    label='Dismiss',
+                    auto_width=true,
+                    on_activate=function() self:dismiss() end,
+                },
+            },
+        },
+    }
 end
 
-function WarningBox:onRenderFrame(dc,rect)
-    WarningBox.super.onRenderFrame(self,dc,rect)
-    dc:pen(COLOR_WHITE):key_pen(COLOR_LIGHTRED)
-        :seek(rect.x1 + 2, rect.y2 - 2)
-        :key('CUSTOM_D'):string(': Do not show again')
-        :advance(10)
-        :key('LEAVESCREEN'):string('/')
-        :key('SELECT'):string(': Dismiss')
-end
-
-function WarningBox:onInput(keys)
-    if keys.CUSTOM_D then
-        config.data.hide = true
-        config:write()
-        keys.LEAVESCREEN = true
-    end
-    WarningBox.super.onInput(self, keys)
-end
-
-view = view or WarningBox{
-    frame_title = title,
-    text = message,
-    text_pen = color
-}:show()
+-- never reset view; we only want to show this dialog once
+view = view or WarningBoxScreen{}:show()


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/977482/233907211-85b96c03-2797-443f-ae5a-97d636864c2c.png)

after:
![image](https://user-images.githubusercontent.com/977482/233908534-4802ce36-943d-4460-830a-5996ab93eb4a.png)

but now the widgets are clickable, the window is resizable, etc. The extra bit of space on the right is for the scrollbar for longer text messages.

Fixes DFHack/dfhack#3281

Depends on DFHack/dfhack#3285 (or the PR that I'll eventually factor this bit of code out into) for `ZScreenModal`