### PR TITLE
get exportlegends basically working

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ that repo.
 # Future
 
 ## New Scripts
+- `exportlegends`: export extended legends information for external browsing
 
 ## Fixes
 

--- a/docs/exportlegends.rst
+++ b/docs/exportlegends.rst
@@ -2,46 +2,24 @@ exportlegends
 =============
 
 .. dfhack-tool::
-    :summary: Exports legends data for external viewing.
-    :tags: unavailable legends inspection
+    :summary: Exports extended legends data for external viewing.
+    :tags: legends inspection
 
-When run from legends mode, you can export detailed data about your world so
-that it can be browsed with external programs like
-:forums:`World Viewer <128932>` and other similar utilities. The data exported
-with this tool is more detailed than what you can get with vanilla export
-functionality, and some external tools depend on this extra information.
+When run from the legends mode screen, you can export detailed data about your
+world so that it can be browsed with external programs like
+:forums:`Legends Browser <179848>` and other similar utilities. The data
+exported with this tool is more detailed than what you can get with vanilla
+export functionality, and some external tools depend on this extra information.
 
-``exportlegends`` can be especially useful when you are generating a lot of
-worlds that you later want to inspect or when you want a map of every site when
-there are several hundred.
+To use:
+
+- enter legends mode
+- click the vanilla "Export XML" button to get the standard export
+- run this command (``exportlegends``) to get the extended export
 
 Usage
 -----
 
 ::
 
-    exportlegends <command> [<folder name>]
-
-Valid commands are:
-
-:info:   Exports the world/gen info, the legends XML, and an extended info file.
-:custom: Exports just the extended info file.
-:sites:  Exports all available site maps.
-:maps:   Exports all seventeen detailed maps.
-:all:    Equivalent to calling all of the above, in that order.
-
-The default folder name is generated from the region number of the world and the
-current in-world date: ``legends-regionX-YYYYY-MM-DD``. You can use a different
-folder by naming it on the ``exportlegends`` command line. Nested paths are
-accepted, but all but the last folder has to already exist. To export to the
-top-level DF folder, specify ``.`` as the folder name.
-
-Examples
---------
-
-``exportlegends all``
-    Export all information to the ``legends-regionX-YYYYY-MM-DD`` folder.
-``exportlegends all legends/myregion``
-    Export all information to the ``legends/myregion`` folder.
-``exportlegends custom .``
-    Export just the extended info file to the DF folder (no subfolder).
+    exportlegends

--- a/docs/open-legends.rst
+++ b/docs/open-legends.rst
@@ -3,7 +3,7 @@ open-legends
 
 .. dfhack-tool::
     :summary: Open a legends screen from fort or adventure mode.
-    :tags: unavailable adventure fort legends
+    :tags: unavailable legends inspection
 
 You can use this tool to open legends mode from a world loaded in fortress or
 adventure mode. You can browse around, or even run `exportlegends` while you're

--- a/exportlegends.lua
+++ b/exportlegends.lua
@@ -1,107 +1,23 @@
 -- Export everything from legends mode
---[====[
-
-exportlegends
-=============
-Controls legends mode to export data - especially useful to set-and-forget large
-worlds, or when you want a map of every site when there are several hundred.
-
-The 'info' option exports more data than is possible in vanilla, to a
-:file:`region-date-legends_plus.xml` file developed to extend
-:forums:`World Viewer <128932>` and other legends utilities.
-
-Usage::
-
-    exportlegends OPTION [FOLDER_NAME]
-
-Valid values for ``OPTION`` are:
-
-:info:   Exports the world/gen info, the legends XML, and a custom XML with more information
-:custom: Exports a custom XML with more information
-:sites:  Exports all available site maps
-:maps:   Exports all seventeen detailed maps
-:all:    Equivalent to calling all of the above, in that order
-
-``FOLDER_NAME``, if specified, is the name of the folder where all the files
-will be saved. This defaults to the ``legends-regionX-YYYYY-MM-DD`` format. A path is
-also allowed, although everything but the last folder has to exist. To export
-to the top-level DF folder, pass ``.`` for this argument.
-
-Examples:
-
-* Export all information to the ``legends-regionX-YYYYY-MM-DD`` folder::
-
-    exportlegends all
-
-* Export all information to the ``region6`` folder::
-
-    exportlegends all region6
-
-* Export just the files included in ``info`` (above) to the ``legends-regionX-YYYYY-MM-DD`` folder::
-
-    exportlegends info
-
-* Export just the custom XML file to the DF folder (no subfolder)::
-
-    exportlegends custom .
-
-]====]
-
 --luacheck-flags: strictsubtype
 
--- General note: If you are looking for main function look at the buttom of this script file.
-
-local gui = require 'gui'
-local script = require 'gui.script'
+local gui = require('gui')
 local args = {...}
-local vs = dfhack.gui.getCurViewscreen()
 
--- List of all the detailed maps
-local MAPS = {
-    "Standard biome+site map",
-    "Elevations including lake and ocean floors",
-    "Elevations respecting water level",
-    "Biome",
-    "Hydrosphere",
-    "Temperature",
-    "Rainfall",
-    "Drainage",
-    "Savagery",
-    "Volcanism",
-    "Current vegetation",
-    "Evil",
-    "Salinity",
-    "Structures/fields/roads/etc.",
-    "Trade",
-    "Nobility and Holdings",
-    "Diplomacy",
-}
-
--- Get that date of the world as a string
+-- Get the date of the world as a string
 -- Format: "YYYYY-MM-DD"
-function get_world_date_str()
+local function get_world_date_str()
     local month = dfhack.world.ReadCurrentMonth() + 1 --days and months are 1-indexed
     local day = dfhack.world.ReadCurrentDay()
     local date_str = string.format('%05d-%02d-%02d', df.global.cur_year, month, day)
     return date_str
 end
 
--- Go back to root folder so dfhack does not break, returns true if successfully
-function move_back_to_main_folder()
-    return dfhack.filesystem.restore_cwd()
+local function escape_xml(str)
+    return str:gsub('&', '&amp;'):gsub('<', '&lt;'):gsub('>', '&gt;')
 end
 
--- Set default folder name
-local folder_name = "legends-" .. df.global.world.cur_savegame.save_dir .. "-" .. get_world_date_str()
--- Go to save folder, returns true if successfully
-function move_to_save_folder()
-    if move_back_to_main_folder() then
-        return dfhack.filesystem.chdir(folder_name)
-    end
-    return false
-end
-
-function getItemSubTypeName(itemType, subType)
+local function getItemSubTypeName(itemType, subType)
     if (dfhack.items.getSubtypeCount(itemType)) <= 0 then
         return tostring(-1)
     end
@@ -113,16 +29,8 @@ function getItemSubTypeName(itemType, subType)
     end
 end
 
-function table_contains(self, element)
-    for _, value in pairs(self) do
-        if value == element then
-            return true
-        end
-    end
-    return false
-end
-
-function table_containskey(self, key)
+-- is this faster than pcall?
+local function table_containskey(self, key)
     for value, _ in pairs(self) do
         if value == key then
             return true
@@ -131,12 +39,8 @@ function table_containskey(self, key)
     return false
 end
 
-function escape_xml(str)
-    return str:gsub('&', '&amp;'):gsub('<', '&lt;'):gsub('>', '&gt;')
-end
-
 --luacheck: skip
-function progress_ipairs(vector, desc, interval)
+local function progress_ipairs(vector, desc, interval)
     desc = desc or 'item'
     interval = interval or 10000
     local cb = ipairs(vector)
@@ -159,7 +63,7 @@ setmetatable(df_enums, {
         local t = {}
         setmetatable(t, {
             __index = function(self, k)
-                return df[enum][k] or 'unknown ' .. k
+                return df[enum][k] or ('unknown ' .. k)
             end
         })
         return t
@@ -170,25 +74,21 @@ setmetatable(df_enums, {
 -- prints a line with the value inside the tags if the value isn't -1. Intended to be used
 -- for fields where -1 is a known "no info" value. Relies on 'indentation' being set to indicate
 -- the current indentation level
-function printifvalue (file, indentation, tag, value)
+local function printifvalue (file, indentation, tag, value)
     if value ~= -1 then
         file:write(string.rep("\t", indentation).."<"..tag..">"..tostring(value).."</"..tag..">\n")
     end
 end
 
 -- Export additional legends data, legends_plus.xml
-function export_more_legends_xml()
+local function export_more_legends_xml()
     local problem_elements = {}
 
-    -- Move into the save folder
-    if not move_to_save_folder() then
-        qerror('Could not move into the save folder.')
-    end
     local filename = df.global.world.cur_savegame.save_dir.."-"..get_world_date_str().."-legends_plus.xml"
     local file = io.open(filename, 'w')
-    move_back_to_main_folder()
     if not file then
       qerror("could not open file: " .. filename)
+      return -- so lint understands what's going on
     end
 
     file:write("<?xml version=\"1.0\" encoding='UTF-8'?>\n")
@@ -556,7 +456,6 @@ function export_more_legends_xml()
               or df.history_event_remove_hf_entity_linkst:is_instance(event)
               or df.history_event_remove_hf_site_linkst:is_instance(event)
               or df.history_event_replaced_buildingst:is_instance(event)
-              or df.history_event_masterpiece_created_arch_designst:is_instance(event)
               or df.history_event_masterpiece_created_dye_itemst:is_instance(event)
               or df.history_event_masterpiece_created_arch_constructst:is_instance(event)
               or df.history_event_masterpiece_created_itemst:is_instance(event)
@@ -1061,150 +960,11 @@ function export_more_legends_xml()
     end
 end
 
--- Export world information and legends.xml (keys: 'p and x')
-function export_legends_info()
-    -- Move into the save folder
-    if not move_to_save_folder() then
-        qerror('Could not move into the save folder.')
-    end
-    print('    Exporting:  World map/gen info')
-    gui.simulateInput(vs, 'LEGENDS_EXPORT_MAP')
-    print('    Exporting:  Legends xml')
-    gui.simulateInput(vs, 'LEGENDS_EXPORT_XML')
-    move_back_to_main_folder() -- Move back out of the save folder
-    print("    Exporting:  Extra legends_plus xml")
+-- Check if on legends screen and trigger the export if so
+if dfhack.gui.matchFocusString('legends') then
     export_more_legends_xml()
-end
-
--- Export all the detailed maps like biome and elevation maps. (key: 'd')
-function export_detailed_maps()
-    script.start(
-        function()
-        -- When script is finished run `move_back_to_main_folder()`
-        dfhack.with_finalize(
-            -- Function when script is finished
-            function()
-                -- This makes sure it will always go back to the main folder.
-                -- Even if an error occurs
-                move_back_to_main_folder()
-                -- Make sure this is always printed even when error occurs.
-                print("    Done exporting.")
-            end,
-            -- Run script
-            function()
-                -- Loop over all the detailed maps and export them.
-                for i = 1, #MAPS do
-                    -- Select the detailed map section
-                    local vs = dfhack.gui.getViewscreenByType(df.viewscreen_export_graphical_mapst, 0)
-                    if not vs then
-                        local legends_vs = dfhack.gui.getViewscreenByType(df.viewscreen_legendsst, 0)
-                        if not legends_vs then
-                            qerror("Could not find legends screen")
-                        end
-
-                        gui.simulateInput(legends_vs, 'LEGENDS_EXPORT_DETAILED_MAP')
-                    end
-
-                    vs = dfhack.gui.getViewscreenByType(df.viewscreen_export_graphical_mapst, 0)
-                    if not vs then
-                        qerror("Could not find map export screen")
-                    end
-
-                    vs.sel_type = i - 1
-                    -- Move into the save folder
-                    if not move_to_save_folder() then
-                        qerror('Could not move into the save folder.')
-                    end
-                    print('    Exporting map ' ..i.. '/' ..#MAPS..': '.. MAPS[i])
-                    -- Select the map and start exporting
-                    gui.simulateInput(vs, 'SELECT')
-                    -- Wait for the map to finish exporting
-                    while dfhack.gui.getCurViewscreen() == vs do
-                        script.sleep(10, 'frames')
-                    end
-                    -- Move back out of the save folder
-                    move_back_to_main_folder()
-                end
-            end
-        )
-        end
-    )
-end
-
--- Export the maps of all the sites (cities, towns,...) (key: 'sites', 'p')
-function export_site_maps()
-    local vs = dfhack.gui.getCurViewscreen()
-    if ((dfhack.gui.getCurFocus() ~= "legends" ) and (not table_contains(vs, "main_cursor"))) then -- Using open-legends
-        vs = vs.parent --luacheck: retype
-    end
-    if df.viewscreen_legendsst:is_instance(vs) then
-        -- Move into the save folder
-        if not move_to_save_folder() then
-            qerror('Could not move into the save folder.')
-        end
-        print('    Exporting:  All possible site maps')
-        vs.main_cursor = 1
-        gui.simulateInput(vs, 'SELECT')
-        for i=1, #vs.sites do
-            gui.simulateInput(vs, 'LEGENDS_EXPORT_MAP')
-            gui.simulateInput(vs, 'STANDARDSCROLL_DOWN')
-        end
-        gui.simulateInput(vs, 'LEAVESCREEN')
-        move_back_to_main_folder() -- Move back out of the save folder
-    else
-        qerror('this command can only be used in Legends mode')
-    end
-end
-
--- Check if a folder with this name could be created or already exists
-function create_folder(folder_name)
-    if folder_name == "-00000-01-01" then
-        qerror('"'..folder_name..'" is the default foldername, this folder will not be created as you are probably not in the legends screen.')
-    end
-    -- check if it is a file, not a folder
-    if dfhack.filesystem.isfile(folder_name) then
-        qerror(folder_name..' is a file, not a folder')
-    end
-    if dfhack.filesystem.exists(folder_name) then
-        return true
-    else
-        return dfhack.filesystem.mkdir(folder_name)
-    end
-end
-
--- If folder_name is given as a argument use that
-if #args >= 2 then
-    folder_name = args[2]
-end
--- Create folder to export all files into, if possible.
-if not create_folder(folder_name) then
-    -- no valid folder name or could not create folder
-    qerror('The foldername '..folder_name..' could not be created')
-end
-print("Writing all files in: "..folder_name)
-
--- Main: Check if on legends screen and trigger the correct export.
-if dfhack.gui.getCurFocus() == "legends" or dfhack.gui.getCurFocus() == "dfhack/lua/legends" then
-    -- either native legends mode, or using the open-legends.lua script
-    if args[1] == "all" then
-        export_legends_info()
-        export_site_maps()
-        export_detailed_maps()
-    elseif args[1] == "info" then
-        export_legends_info()
-    elseif args[1] == "custom" then
-        export_more_legends_xml()
-    elseif args[1] == "maps" then
-        export_detailed_maps()
-    elseif args[1] == "sites" then
-        export_site_maps()
-    else
-        qerror('Valid arguments are "all", "info", "custom", "maps" or "sites"')
-    end
-elseif args[1] == "maps" and dfhack.gui.getCurFocus() == "export_graphical_map" then
-    export_detailed_maps()
 else
     qerror('exportlegends must be run from the main legends view')
 end
 
-print("Exported files can be found in the \""..folder_name.."\" folder.")
+print("Exported files can be found in the top-level DF game folder.")

--- a/open-legends.lua
+++ b/open-legends.lua
@@ -1,82 +1,44 @@
 -- open legends screen when in fortress mode
 --@ module = true
---[====[
 
-open-legends
-============
-Open a legends screen when in fortress mode. Requires a world loaded in fortress
-or adventure mode. Compatible with `exportlegends`.
+local dialogs = require('gui.dialogs')
+local gui = require('gui')
+local utils = require('utils')
 
-Note that this script carries a significant risk of save corruption if the game
-is saved after exiting legends mode. To avoid this:
+Restorer = defclass(Restorer, gui.Screen)
+Restorer.ATTRS{
+    focus_path='open-legends'
+}
 
-1. Pause DF
-2. Run `quicksave` to save the game
-3. Run `open-legends` (this script) and browse legends mode as usual
-4. Immediately after exiting legends mode, run `die` to quit DF without saving
-   (saving at this point instead may corrupt your save)
-
-Note that it should be safe to run "open-legends" itself multiple times in the
-same DF session, as long as DF is killed immediately after the last run.
-Unpausing DF or running other commands risks accidentally autosaving the game,
-which can lead to save corruption.
-
-The optional ``force`` argument will bypass all safety checks, as well as the
-save corruption warning.
-
-]====]
-
-local dialogs = require 'gui.dialogs'
-local gui = require 'gui'
-local utils = require 'utils'
-
-Wrapper = defclass(Wrapper, gui.Screen)
-Wrapper.focus_path = 'legends'
-
-local region_details_backup = {} --as:df.world_region_details[]
-
-function Wrapper:onRender()
-    self._native.parent:render()
-end
-
-function Wrapper:onIdle()
-    self._native.parent:logic()
-end
-
-function Wrapper:onHelp()
-    self._native.parent:help()
-end
-
-function Wrapper:onInput(keys)
-    if self._native.parent.cur_page == 0 and keys.LEAVESCREEN then --hint:df.viewscreen_legendsst
-        local v = df.global.world.world_data.region_details
-        while (#v > 0) do v:erase(0) end
-        for _,item in pairs(region_details_backup) do
-            v:insert(0, item)
-        end
-        self:dismiss()
-        dfhack.screen.dismiss(self._native.parent)
-        return
+function Restorer:init()
+    print('initializing restorer')
+    self.region_details_backup = {} --as:df.world_region_details[]
+    local v = df.global.world.world_data.region_details
+    while (#v > 0) do
+        table.insert(self.region_details_backup, 1, v[0])
+        v:erase(0)
     end
-    gui.simulateInput(self._native.parent, keys)
+end
+
+function Restorer:onIdle()
+    self:dismiss()
+end
+
+function Restorer:onDismiss()
+    print('dismissing restorer')
+    local v = df.global.world.world_data.region_details
+    while (#v > 0) do v:erase(0) end
+    for _,item in pairs(self.region_details_backup) do
+        v:insert(0, item)
+    end
 end
 
 function show_screen()
-    local old_view = dfhack.gui.getCurViewscreen(true)
     local ok, err = pcall(function()
+        Restorer{}:show()
         dfhack.screen.show(df.viewscreen_legendsst:new())
-        Wrapper():show()
     end)
-    if ok then
-        local v = df.global.world.world_data.region_details
-        while (#v > 0) do
-            table.insert(region_details_backup, 1, v[0])
-            v:erase(0)
-        end
-    else
-        while dfhack.gui.getCurViewscreen(true) ~= old_view do
-            dfhack.screen.dismiss(dfhack.gui.getCurViewscreen(true))
-        end
+    if not ok then
         qerror('Failed to set up legends screen: ' .. tostring(err))
     end
 end
@@ -93,7 +55,6 @@ function main(force)
         end
         view = view.child
     end
-    local old_view = dfhack.gui.getCurViewscreen()
 
     if not dfhack.world.isFortressMode(df.global.gametype) and not dfhack.world.isAdventureMode(df.global.gametype) and not force then
         qerror('mode not tested: ' .. df.game_type[df.global.gametype] .. ' (use "force" to force)')
@@ -110,7 +71,7 @@ function main(force)
             '1. Press "esc" to exit this prompt\n' ..
             '2. Pause DF\n' ..
             '3. Run "quicksave" to save this world\n' ..
-            '4. Run this script again and press "y" to enter legends mode\n' ..
+            '4. Run this script again and press ENTER to enter legends mode\n' ..
             '5. IMMEDIATELY AFTER EXITING LEGENDS, run "die" to quit DF\n\n' ..
             'Press "esc" below to go back, or "y" to enter legends mode.\n' ..
             'By pressing "y", you acknowledge that your save could be\n' ..
@@ -121,7 +82,9 @@ function main(force)
     end
 end
 
-if not moduleMode then
-    local iargs = utils.invert{...}
-    main(iargs.force)
+if dfhack_flags.module then
+    return
 end
+
+local iargs = utils.invert{...}
+main(iargs.force)


### PR DESCRIPTION
no visual progress bar yet, so this does not implement DFHack/dfhack#2292

however, it does produce a usable xml file, which might be useful now that vanilla has some export functionality.

the vanilla "Export XML" button does not appear to be triggerable via the usual means (setting mouse gps coordinates and simulating a button click), so all the logic that keeps everything in a single directory is now less useful than it was. eventually, the button may be triggerable via a keybinding again, and we can restore much of the code removed in this PR.

as it is, the exported XML file is now written to the top level DF game dir since that's where the vanilla file is.


A better solution might be to wrap all this in a GUI and control the process CWD dynamically as the script walks the player through the steps, but that's a job for DFHack/dfhack#2292