### PR TITLE
[quickfort] accept more tile types for placing machines

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ that repo.
 
 ## Fixes
 - `gui/design`: Fix building and stairs designation
+- `quickfort`: fixed detection of tiles where machines are allowed (e.g. water wheels *can* be built on stairs if there is a machine support nearby)
 
 ## Misc Improvements
 - `gui/create-item`: ask for number of items to spawn by default

--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -92,7 +92,9 @@ local function is_valid_tile_has_space_or_is_ramp(pos)
 end
 
 local function is_valid_tile_machine(pos)
-    return is_valid_tile_has_space_or_is_ramp(pos)
+    local shape = df.tiletype.attrs[dfhack.maps.getTileType(pos)].shape
+    local basic_shape = df.tiletype_shape.attrs[shape].basic_shape
+    return is_valid_tile_has_space_or_is_ramp(pos) or basic_shape == df.tiletype_shape_basic.Stair
 end
 
 -- ramps are ok everywhere except under the anchor point of directional bridges
@@ -312,7 +314,7 @@ local function make_ns_ew_entry(name, building_type, long_dim_min, long_dim_max,
             min_width=width_min, max_width=width_max,
             min_height=height_min, max_height=height_max,
             direction=vertical and 1 or 0,
-            is_valid_tile_fn=is_valid_tile_has_space, -- impeded by ramps
+            is_valid_tile_fn=is_valid_tile_machine,
             transform=transform}
 end
 local function make_water_wheel_entry(vertical)


### PR DESCRIPTION
Strictly, these buildings need a gear assembly nearby to support them, but I think quickfort can assume that you're doing it "right" (otherwise the machine will deconstruct after being built).

Fixes DFHack/dfhack#3350