### PR TITLE
[quickfort] don't consider itemless tiles as errors for blueprints that affect items

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ that repo.
 - `gui/design`: Fix building and stairs designation
 
 ## Misc Improvements
+- `quickfort`: blueprints that designate items for dumping/forbidding/etc. no longer show an error highlight for tiles that have no items on them
 - `gui/create-item`: ask for number of items to spawn by default
 - `light-aquifers-only`: now available as a fort Autostart option in `gui/control-panel`. note that it will only appear if "armok" tools are configured to be shown on the Preferences tab.
 - `gui/gm-editor`: when passing the ``--freeze`` option, further ensure that the game is frozen by halting all rendering (other than for the gm-editor window itself)

--- a/internal/quickfort/dig.lua
+++ b/internal/quickfort/dig.lua
@@ -375,46 +375,47 @@ local function get_items_at(pos, include_buildings)
     return items
 end
 
-local function do_item_flag(pos, flag_name, flag_value, include_buildings)
-    local items = get_items_at(pos, include_buildings)
-    if #items == 0 then return nil end
+local function do_item_flag(digctx, flag_name, flag_value, include_buildings)
+    if digctx.flags.hidden then return nil end
+    local items = get_items_at(digctx.pos, include_buildings)
+    if #items == 0 then return function() end end -- noop, but not an error
     return function()
         for _,item in ipairs(items) do item.flags[flag_name] = flag_value end
     end
 end
 
 local function do_claim(digctx)
-    return do_item_flag(digctx.pos, "forbid", values.item_claimed, true)
+    return do_item_flag(digctx, "forbid", values.item_claimed, true)
 end
 
 local function do_forbid(digctx)
-    return do_item_flag(digctx.pos, "forbid", values.item_forbidden, true)
+    return do_item_flag(digctx, "forbid", values.item_forbidden, true)
 end
 
 local function do_melt(digctx)
     -- the game appears to autoremove the flag from unmeltable items, so we
     -- don't actually need to do any filtering here
-    return do_item_flag(digctx.pos, "melt", values.item_melted, false)
+    return do_item_flag(digctx, "melt", values.item_melted, false)
 end
 
 local function do_remove_melt(digctx)
-    return do_item_flag(digctx.pos, "melt", values.item_unmelted, false)
+    return do_item_flag(digctx, "melt", values.item_unmelted, false)
 end
 
 local function do_dump(digctx)
-    return do_item_flag(digctx.pos, "dump", values.item_dumped, false)
+    return do_item_flag(digctx, "dump", values.item_dumped, false)
 end
 
 local function do_remove_dump(digctx)
-    return do_item_flag(digctx.pos, "dump", values.item_undumped, false)
+    return do_item_flag(digctx, "dump", values.item_undumped, false)
 end
 
 local function do_hide(digctx)
-    return do_item_flag(digctx.pos, "hidden", values.item_hidden, true)
+    return do_item_flag(digctx, "hidden", values.item_hidden, true)
 end
 
 local function do_unhide(digctx)
-    return do_item_flag(digctx.pos, "hidden", values.item_unhidden, true)
+    return do_item_flag(digctx, "hidden", values.item_unhidden, true)
 end
 
 local function do_traffic_high(digctx)


### PR DESCRIPTION
DFHack/dfhack#3352

in discussion whether this is enough to consider the issue fixed.