### PR TITLE
new script: gui/sandbox

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ that repo.
 - `fix/stuck-instruments`: fix instruments that are attached to invalid jobs, making them unusable
 - `gui/mod-manager`: automatically restore your list of active mods when generating new worlds
 - `gui/autodump`: point and click item teleportation and destruction interface
+- `gui/sandbox`: creation interface for units, trees, and items
 
 ## Fixes
 - `quickfort`: properly allow dwarves to smooth, engrave, and carve beneath passable tiles of buildings

--- a/docs/gui/sandbox.rst
+++ b/docs/gui/sandbox.rst
@@ -1,0 +1,22 @@
+gui/sandbox
+===========
+
+.. dfhack-tool::
+    :summary: Create units, trees, liquids, snow, and mud.
+    :tags: fort armok animals map plants units
+
+This tool brings up the arena creation interface while you're in fort mode. You
+can create units (with arbitrary skillsets) and trees, spawn liquids, and paint
+the ground with snow or mud. You can also use this tool to clean the map of
+spatters (like snow, mud, or blood). Note that the weather controls do not have
+an effect on your fort.
+
+See `clean` for other ways to clean the map of spatters and `gui/liquids` for a
+more focused interface for creating liquids.
+
+Usage
+-----
+
+::
+
+    gui/sandbox

--- a/docs/gui/sandbox.rst
+++ b/docs/gui/sandbox.rst
@@ -11,6 +11,13 @@ the ground with snow or mud. You can also use this tool to clean the map of
 spatters (like snow, mud, or blood). Note that the weather controls do not have
 an effect on your fort.
 
+You can choose whether spawned units are:
+
+- hostile (default)
+- independent/wild
+- friendly
+- citizens/pets
+
 See `clean` for other ways to clean the map of spatters and `gui/liquids` for a
 more focused interface for creating liquids.
 

--- a/docs/gui/sandbox.rst
+++ b/docs/gui/sandbox.rst
@@ -5,14 +5,22 @@ gui/sandbox
     :summary: Create units, trees, or items.
     :tags: fort armok animals items map plants units
 
-This tool provides a spawning interface for units, trees, and/or items. Units can be created with arbitrary skillsets, and trees can be created either as saplings or as fully grown (depending on the age you set).
+This tool provides a spawning interface for units, trees, and/or items. Units
+can be created with arbitrary skillsets, and trees can be created either as
+saplings or as fully grown (depending on the age you set). The item creation
+interface is the same as `gui/create-item`.
 
 You can choose whether spawned units are:
 
 - hostile (default)
+- hostile undead
 - independent/wild
 - friendly
 - citizens/pets
+
+Note that if you create new citizens and you're not using `autolabor`, you'll
+have to got into the labors screen and make at least one change (any change) to
+get DF to assign them labors. Otherwise they'll stand around with "No job".
 
 Usage
 -----

--- a/docs/gui/sandbox.rst
+++ b/docs/gui/sandbox.rst
@@ -2,14 +2,10 @@ gui/sandbox
 ===========
 
 .. dfhack-tool::
-    :summary: Create units, trees, liquids, snow, and mud.
-    :tags: fort armok animals map plants units
+    :summary: Create units, trees, or items.
+    :tags: fort armok animals items map plants units
 
-This tool brings up the arena creation interface while you're in fort mode. You
-can create units (with arbitrary skillsets) and trees, spawn liquids, and paint
-the ground with snow or mud. You can also use this tool to clean the map of
-spatters (like snow, mud, or blood). Note that the weather controls do not have
-an effect on your fort.
+This tool provides a spawning interface for units, trees, and/or items. Units can be created with arbitrary skillsets, and trees can be created either as saplings or as fully grown (depending on the age you set).
 
 You can choose whether spawned units are:
 
@@ -17,9 +13,6 @@ You can choose whether spawned units are:
 - independent/wild
 - friendly
 - citizens/pets
-
-See `clean` for other ways to clean the map of spatters and `gui/liquids` for a
-more focused interface for creating liquids.
 
 Usage
 -----

--- a/docs/makeown.rst
+++ b/docs/makeown.rst
@@ -6,7 +6,7 @@ makeown
     :tags: fort armok units
 
 Select a unit in the UI and run this tool to converts that unit to be a fortress
-citizen. It also removes their foreign affiliation, if any.
+citizen (if sentient). It also removes their foreign affiliation, if any.
 
 Usage
 -----

--- a/gui/sandbox.lua
+++ b/gui/sandbox.lua
@@ -1,5 +1,13 @@
 local gui = require('gui')
+local makeown = reqscript('makeown')
 local widgets = require('gui.widgets')
+
+local DISPOSITIONS = {
+    HOSTILE = 1,
+    WILD = 2,
+    FRIENDLY = 3,
+    FORT = 4,
+}
 
 ---------------------
 -- Sandbox
@@ -8,14 +16,34 @@ local widgets = require('gui.widgets')
 Sandbox = defclass(Sandbox, widgets.Window)
 Sandbox.ATTRS {
     frame_title='Arena Sandbox',
-    frame={r=2, t=18, w=40, h=10},
+    frame={r=2, t=18, w=40, h=15},
+    autoarrange_subviews=true,
 }
 
 function Sandbox:init()
     self:addviews{
         widgets.WrappedLabel{
-            text_to_wrap='Use the buttons at the bottom of the screen to create units, trees, or fluids. \n\nClose this window to return to your fort.'
-        }
+            frame={l=0},
+            text_to_wrap='Use the buttons at the bottom of the screen to create units, trees, or fluids. \n\nClick on this window to focus and then right click to close and return to your fort.'
+        },
+        widgets.Panel{frame={h=1}},
+        widgets.WrappedLabel{
+            frame={l=0},
+            text_pen=COLOR_GREY,
+            text_to_wrap='When returning to fort mode, mark created units as:'
+        },
+        widgets.CycleHotkeyLabel{
+            view_id='disposition',
+            frame={l=0},
+            key='CUSTOM_SHIFT_D',
+            key_back='CUSTOM_SHIFT_A',
+            options={
+                {label='hostile', value=DISPOSITIONS.HOSTILE, pen=COLOR_RED},
+                {label='independent/wild', value=DISPOSITIONS.WILD, pen=COLOR_YELLOW},
+                {label='friendly', value=DISPOSITIONS.FRIENDLY, pen=COLOR_GREEN},
+                {label='citizens/pets', value=DISPOSITIONS.FORT, pen=COLOR_BLUE},
+            },
+        },
     }
 end
 
@@ -37,10 +65,9 @@ SandboxScreen = defclass(SandboxScreen, gui.ZScreen)
 SandboxScreen.ATTRS {
     focus_path='sandbox',
     force_pause=true,
-    pass_movement_keys=true,
 }
 
-function SandboxScreen:init()
+local function init_arena()
     local arena = df.global.world.arena
     local arena_unit = df.global.game.main_interface.arena_unit
     local arena_tree = df.global.game.main_interface.arena_tree
@@ -99,15 +126,77 @@ function SandboxScreen:init()
     for _, tree in ipairs(df.global.world.raws.plants.trees) do
         arena.tree_types:insert('#', tree)
     end
+end
 
-    df.global.gametype = df.game_type.DWARF_ARENA
+local function is_sentient(unit)
+    local caste_flags = unit.enemy.caste_flags
+    return caste_flags.CAN_SPEAK or caste_flags.CAN_LEARN
+end
+
+local function finalize_sentient(unit, disposition)
+
+    if disposition == DISPOSITIONS.HOSTILE then
+        unit.flags1.marauder = true;
+    elseif disposition == DISPOSITIONS.WILD then
+        unit.flags2.visitor = true
+        unit.flags3.guest = true
+        unit.animal.leave_countdown = 20000
+    elseif disposition == DISPOSITIONS.FRIENDLY then
+        -- noop; units are created friendly by default
+    elseif disposition == DISPOSITIONS.FORT then
+        makeown.make_own(unit)
+    end
+end
+
+local function finalize_animal(unit, disposition)
+    if disposition == DISPOSITIONS.HOSTILE then
+        unit.flags1.active_invader = true;
+        unit.flags1.marauder = true;
+        unit.flags4.agitated_wilderness_creature = true
+    elseif disposition == DISPOSITIONS.WILD then
+        unit.flags2.roaming_wilderness_population_source = true
+        unit.animal.leave_countdown = 20000
+    elseif disposition == DISPOSITIONS.FRIENDLY then
+        -- noop; units are created friendly by default
+    elseif disposition == DISPOSITIONS.FORT then
+        makeown.make_own(unit)
+        unit.flags1.tame = true
+        unit.training_level = df.animal_training_level.Domesticated
+    end
+end
+
+local function finalize_units(first_created_unit_id, disposition)
+    print(first_created_unit_id, disposition)
+    -- unit->flags4.bits.agitated_wilderness_creature
+    for unit_id=first_created_unit_id,df.global.unit_next_id-1 do
+        local unit = df.unit.find(unit_id)
+        if not unit then goto continue end
+        unit.profession = df.profession.STANDARD
+        unit.name.has_name = false
+        if is_sentient(unit) then
+            finalize_sentient(unit, disposition)
+        else
+            finalize_animal(unit, disposition)
+        end
+        ::continue::
+    end
+end
+
+function SandboxScreen:init()
+    self.first_created_unit_id = df.global.unit_next_id
+
+    init_arena()
 
     self:addviews{Sandbox{}}
+
+    df.global.gametype = df.game_type.DWARF_ARENA
 end
 
 function SandboxScreen:onDismiss()
     df.global.gametype = df.game_type.DWARF_MAIN
     view = nil
+    finalize_units(self.first_created_unit_id,
+            self.subviews.disposition:getOptionValue())
 end
 
 if df.global.gametype ~= df.game_type.DWARF_MAIN then

--- a/gui/sandbox.lua
+++ b/gui/sandbox.lua
@@ -31,7 +31,6 @@ local function is_sentient(unit)
 end
 
 local function finalize_sentient(unit, disposition)
-
     if disposition == DISPOSITIONS.HOSTILE or disposition == DISPOSITIONS.HOSTILE_UNDEAD then
         unit.flags1.active_invader = true;
         unit.flags1.marauder = true;

--- a/gui/sandbox.lua
+++ b/gui/sandbox.lua
@@ -1,0 +1,117 @@
+local gui = require('gui')
+local widgets = require('gui.widgets')
+
+---------------------
+-- Sandbox
+--
+
+Sandbox = defclass(Sandbox, widgets.Window)
+Sandbox.ATTRS {
+    frame_title='Arena Sandbox',
+    frame={r=2, t=18, w=40, h=10},
+}
+
+function Sandbox:init()
+    self:addviews{
+        widgets.WrappedLabel{
+            text_to_wrap='Use the buttons at the bottom of the screen to create units, trees, or fluids. \n\nClose this window to return to your fort.'
+        }
+    }
+end
+
+function Sandbox:onInput(keys)
+    if keys.LEAVESCREEN or keys._MOUSE_R_DOWN then
+        -- close any open UI elements
+        df.global.game.main_interface.arena_unit.open = false
+        df.global.game.main_interface.arena_tree.open = false
+        df.global.game.main_interface.bottom_mode_selected = -1
+    end
+    return Sandbox.super.onInput(self, keys)
+end
+
+---------------------
+-- SandboxScreen
+--
+
+SandboxScreen = defclass(SandboxScreen, gui.ZScreen)
+SandboxScreen.ATTRS {
+    focus_path='sandbox',
+    force_pause=true,
+    pass_movement_keys=true,
+}
+
+function SandboxScreen:init()
+    local arena = df.global.world.arena
+    local arena_unit = df.global.game.main_interface.arena_unit
+    local arena_tree = df.global.game.main_interface.arena_tree
+
+    -- races
+    arena.race:resize(0)
+    arena.caste:resize(0)
+    arena.creature_cnt:resize(0)
+    arena.type = -1
+    arena_unit.race = 0
+    arena_unit.caste = 0
+    arena_unit.races_filtered:resize(0)
+    arena_unit.races_all:resize(0)
+    arena_unit.castes_filtered:resize(0)
+    arena_unit.castes_all:resize(0)
+    for i, cre in ipairs(df.global.world.raws.creatures.all) do
+        arena.creature_cnt:insert('#', 0)
+        for caste in ipairs(cre.caste) do
+            -- the real interface sorts these alphabetically
+            arena.race:insert('#', i)
+            arena.caste:insert('#', caste)
+        end
+    end
+
+    -- interactions
+    arena.interactions:resize(0)
+    arena.interaction = -1
+    arena_unit.interactions:resize(0)
+    arena_unit.interaction = -1
+    for _, inter in ipairs(df.global.world.raws.interactions) do
+        for _, effect in ipairs(inter.effects) do
+            if #effect.arena_name > 0 then
+                arena.interactions:insert('#', effect)
+            end
+        end
+    end
+
+    -- skills
+    arena.skills:resize(0)
+    arena.skill_levels:resize(0)
+    arena_unit.skills:resize(0)
+    arena_unit.skill_levels:resize(0)
+    for i in ipairs(df.job_skill) do
+        if i >= 0 then
+            arena.skills:insert('#', i)
+            arena.skill_levels:insert('#', 0)
+        end
+    end
+
+    -- trees
+    arena.tree_types:resize(0)
+    arena.tree_age = 100
+    arena_tree.tree_types_filtered:resize(0)
+    arena_tree.tree_types_all:resize(0)
+    arena_tree.age = 100
+    for _, tree in ipairs(df.global.world.raws.plants.trees) do
+        arena.tree_types:insert('#', tree)
+    end
+
+    df.global.gametype = df.game_type.DWARF_ARENA
+
+    self:addviews{Sandbox{}}
+end
+
+function SandboxScreen:onDismiss()
+    df.global.gametype = df.game_type.DWARF_MAIN
+    view = nil
+end
+
+if df.global.gametype ~= df.game_type.DWARF_MAIN then
+    qerror('must have a fort loaded')
+end
+
+view = view and view:raise() or SandboxScreen{}:show()

--- a/gui/sandbox.lua
+++ b/gui/sandbox.lua
@@ -16,8 +16,8 @@ local DISPOSITIONS = {
 Sandbox = defclass(Sandbox, widgets.Window)
 Sandbox.ATTRS {
     frame_title='Arena Sandbox',
-    frame={r=2, t=18, w=26, h=24},
-    frame_inset=0,
+    frame={r=2, t=18, w=26, h=20},
+    frame_inset={b=1},
 }
 
 local function is_sentient(unit)
@@ -83,7 +83,7 @@ function Sandbox:init()
         widgets.ResizingPanel{
             frame={t=0},
             frame_style=gui.FRAME_INTERIOR,
-            frame_inset=1,
+            frame_inset={l=1, r=1},
             autoarrange_subviews=1,
             subviews={
                 widgets.Label{
@@ -133,9 +133,9 @@ function Sandbox:init()
             },
         },
         widgets.ResizingPanel{
-            frame={t=10},
+            frame={t=11},
             frame_style=gui.FRAME_INTERIOR,
-            frame_inset=1,
+            frame_inset={l=1, r=1},
             autoarrange_subviews=1,
             subviews={
                 widgets.HotkeyLabel{

--- a/gui/sandbox.lua
+++ b/gui/sandbox.lua
@@ -243,12 +243,14 @@ local function init_arena()
     arena_unit.castes_filtered:resize(0)
     arena_unit.castes_all:resize(0)
     for i, cre in ipairs(df.global.world.raws.creatures.all) do
+        if cre.flags.VERMIN_GROUNDER or cre.flags.VERMIN_SOIL then goto continue end
         arena.creature_cnt:insert('#', 0)
         for caste in ipairs(cre.caste) do
             -- the real interface sorts these alphabetically
             arena.race:insert('#', i)
             arena.caste:insert('#', caste)
         end
+        ::continue::
     end
 
     -- interactions

--- a/gui/sandbox.lua
+++ b/gui/sandbox.lua
@@ -16,45 +16,200 @@ local DISPOSITIONS = {
 Sandbox = defclass(Sandbox, widgets.Window)
 Sandbox.ATTRS {
     frame_title='Arena Sandbox',
-    frame={r=2, t=18, w=40, h=15},
-    autoarrange_subviews=true,
+    frame={r=2, t=18, w=26, h=24},
+    frame_inset=0,
 }
 
+local function is_sentient(unit)
+    local caste_flags = unit.enemy.caste_flags
+    return caste_flags.CAN_SPEAK or caste_flags.CAN_LEARN
+end
+
+local function finalize_sentient(unit, disposition)
+
+    if disposition == DISPOSITIONS.HOSTILE then
+        unit.flags1.marauder = true;
+    elseif disposition == DISPOSITIONS.WILD then
+        unit.flags2.visitor = true
+        unit.flags3.guest = true
+        unit.animal.leave_countdown = 20000
+    elseif disposition == DISPOSITIONS.FRIENDLY then
+        -- noop; units are created friendly by default
+    elseif disposition == DISPOSITIONS.FORT then
+        makeown.make_own(unit)
+    end
+end
+
+local function finalize_animal(unit, disposition)
+    if disposition == DISPOSITIONS.HOSTILE then
+        unit.flags1.active_invader = true;
+        unit.flags1.marauder = true;
+        unit.flags4.agitated_wilderness_creature = true
+    elseif disposition == DISPOSITIONS.WILD then
+        unit.flags2.roaming_wilderness_population_source = true
+        unit.flags2.roaming_wilderness_population_source_not_a_map_feature = true
+        unit.animal.leave_countdown = 20000
+    elseif disposition == DISPOSITIONS.FRIENDLY then
+        -- noop; units are created friendly by default
+    elseif disposition == DISPOSITIONS.FORT then
+        makeown.make_own(unit)
+        unit.flags1.tame = true
+        unit.training_level = df.animal_training_level.Domesticated
+    end
+end
+
+local function finalize_units(first_created_unit_id, disposition)
+    print(first_created_unit_id, disposition)
+    -- unit->flags4.bits.agitated_wilderness_creature
+    for unit_id=first_created_unit_id,df.global.unit_next_id-1 do
+        local unit = df.unit.find(unit_id)
+        if not unit then goto continue end
+        unit.profession = df.profession.STANDARD
+        unit.name.has_name = false
+        if is_sentient(unit) then
+            finalize_sentient(unit, disposition)
+        else
+            finalize_animal(unit, disposition)
+        end
+        ::continue::
+    end
+end
+
 function Sandbox:init()
+    self.spawn_group = 1
+    self.first_unit_id = df.global.unit_next_id
+
     self:addviews{
-        widgets.WrappedLabel{
-            frame={l=0},
-            text_to_wrap='Use the buttons at the bottom of the screen to create units, trees, or fluids. \n\nClick on this window to focus and then right click to close and return to your fort.'
-        },
-        widgets.Panel{frame={h=1}},
-        widgets.WrappedLabel{
-            frame={l=0},
-            text_pen=COLOR_GREY,
-            text_to_wrap='When returning to fort mode, mark created units as:'
-        },
-        widgets.CycleHotkeyLabel{
-            view_id='disposition',
-            frame={l=0},
-            key='CUSTOM_SHIFT_D',
-            key_back='CUSTOM_SHIFT_A',
-            options={
-                {label='hostile', value=DISPOSITIONS.HOSTILE, pen=COLOR_RED},
-                {label='independent/wild', value=DISPOSITIONS.WILD, pen=COLOR_YELLOW},
-                {label='friendly', value=DISPOSITIONS.FRIENDLY, pen=COLOR_GREEN},
-                {label='citizens/pets', value=DISPOSITIONS.FORT, pen=COLOR_BLUE},
+        widgets.ResizingPanel{
+            frame={t=0},
+            frame_style=gui.FRAME_INTERIOR,
+            frame_inset=1,
+            autoarrange_subviews=1,
+            subviews={
+                widgets.Label{
+                    frame={l=0},
+                    text={
+                        'Spawn group #',
+                        {text=function() return self.spawn_group end},
+                        NEWLINE,
+                        '  unit',
+                        {text=function() return df.global.unit_next_id - self.first_unit_id == 1 and '' or 's' end}, ': ',
+                        {text=function() return df.global.unit_next_id - self.first_unit_id end},
+                    },
+                },
+                widgets.Panel{frame={h=1}},
+                widgets.CycleHotkeyLabel{
+                    view_id='disposition',
+                    frame={l=0},
+                    key='CUSTOM_SHIFT_D',
+                    key_back='CUSTOM_SHIFT_A',
+                    label='Unit disposition',
+                    label_below=true,
+                    options={
+                        {label='hostile', value=DISPOSITIONS.HOSTILE, pen=COLOR_RED},
+                        {label='independent/wild', value=DISPOSITIONS.WILD, pen=COLOR_YELLOW},
+                        {label='friendly', value=DISPOSITIONS.FRIENDLY, pen=COLOR_GREEN},
+                        {label='citizens/pets', value=DISPOSITIONS.FORT, pen=COLOR_BLUE},
+                    },
+                },
+                widgets.Panel{frame={h=1}},
+                widgets.HotkeyLabel{
+                    frame={l=0},
+                    key='CUSTOM_SHIFT_U',
+                    label="Spawn unit",
+                    on_activate=function()
+                        df.global.enabler.mouse_lbut = 0
+                        view:sendInputToParent{ARENA_CREATE_CREATURE=true}
+                    end,
+                },
+                widgets.Panel{frame={h=1}},
+                widgets.HotkeyLabel{
+                    frame={l=0},
+                    key='CUSTOM_SHIFT_G',
+                    label='Start new group',
+                    on_activate=self:callback('finalize_group'),
+                    enabled=function() return df.global.unit_next_id ~= self.first_unit_id end,
+                },
             },
+        },
+        widgets.ResizingPanel{
+            frame={t=10},
+            frame_style=gui.FRAME_INTERIOR,
+            frame_inset=1,
+            autoarrange_subviews=1,
+            subviews={
+                widgets.HotkeyLabel{
+                    frame={l=0},
+                    key='CUSTOM_SHIFT_T',
+                    label="Spawn tree",
+                    on_activate=function()
+                        df.global.enabler.mouse_lbut = 0
+                        view:sendInputToParent{ARENA_CREATE_TREE=true}
+                    end,
+                },
+                widgets.HotkeyLabel{
+                    frame={l=0},
+                    key='CUSTOM_SHIFT_I',
+                    label="Create item",
+                    on_activate=function() dfhack.run_script('gui/create-item') end
+                },
+            },
+        },
+        widgets.HotkeyLabel{
+            frame={l=1, b=0},
+            key='LEAVESCREEN',
+            label="Return to fortress",
+            on_activate=function()
+                repeat until not self:onInput{LEAVESCREEN=true}
+                view:dismiss()
+            end,
         },
     }
 end
 
 function Sandbox:onInput(keys)
-    if keys.LEAVESCREEN or keys._MOUSE_R_DOWN then
+    if keys._MOUSE_R_DOWN and self:getMouseFramePos() then
         -- close any open UI elements
         df.global.game.main_interface.arena_unit.open = false
         df.global.game.main_interface.arena_tree.open = false
         df.global.game.main_interface.bottom_mode_selected = -1
+        return false
     end
-    return Sandbox.super.onInput(self, keys)
+    if keys.LEAVESCREEN or keys._MOUSE_R_DOWN then
+        if df.global.game.main_interface.arena_unit.open or
+                df.global.game.main_interface.arena_tree.open or
+                df.global.game.main_interface.bottom_mode_selected ~= -1 then
+            view:sendInputToParent{LEAVESCREEN=true}
+            return true
+        else
+            return false
+        end
+    end
+    if not Sandbox.super.onInput(self, keys) then
+        view:sendInputToParent(keys)
+    end
+    return true
+end
+
+function Sandbox:finalize_group()
+    finalize_units(self.first_unit_id,
+            self.subviews.disposition:getOptionValue())
+
+    self.spawn_group = self.spawn_group + 1
+    self.first_unit_id = df.global.unit_next_id
+end
+
+---------------------
+-- InterfaceMask
+--
+
+InterfaceMask = defclass(InterfaceMask, widgets.Panel)
+InterfaceMask.ATTRS{
+    frame_background=gui.TRANSPARENT_PEN,
+}
+
+function InterfaceMask:onInput(keys)
+    return keys._MOUSE_L and self:getMousePos()
 end
 
 ---------------------
@@ -65,6 +220,7 @@ SandboxScreen = defclass(SandboxScreen, gui.ZScreen)
 SandboxScreen.ATTRS {
     focus_path='sandbox',
     force_pause=true,
+    defocusable=false,
 }
 
 local function init_arena()
@@ -128,67 +284,21 @@ local function init_arena()
     end
 end
 
-local function is_sentient(unit)
-    local caste_flags = unit.enemy.caste_flags
-    return caste_flags.CAN_SPEAK or caste_flags.CAN_LEARN
-end
-
-local function finalize_sentient(unit, disposition)
-
-    if disposition == DISPOSITIONS.HOSTILE then
-        unit.flags1.marauder = true;
-    elseif disposition == DISPOSITIONS.WILD then
-        unit.flags2.visitor = true
-        unit.flags3.guest = true
-        unit.animal.leave_countdown = 20000
-    elseif disposition == DISPOSITIONS.FRIENDLY then
-        -- noop; units are created friendly by default
-    elseif disposition == DISPOSITIONS.FORT then
-        makeown.make_own(unit)
-    end
-end
-
-local function finalize_animal(unit, disposition)
-    if disposition == DISPOSITIONS.HOSTILE then
-        unit.flags1.active_invader = true;
-        unit.flags1.marauder = true;
-        unit.flags4.agitated_wilderness_creature = true
-    elseif disposition == DISPOSITIONS.WILD then
-        unit.flags2.roaming_wilderness_population_source = true
-        unit.flags2.roaming_wilderness_population_source_not_a_map_feature = true
-        unit.animal.leave_countdown = 20000
-    elseif disposition == DISPOSITIONS.FRIENDLY then
-        -- noop; units are created friendly by default
-    elseif disposition == DISPOSITIONS.FORT then
-        makeown.make_own(unit)
-        unit.flags1.tame = true
-        unit.training_level = df.animal_training_level.Domesticated
-    end
-end
-
-local function finalize_units(first_created_unit_id, disposition)
-    print(first_created_unit_id, disposition)
-    -- unit->flags4.bits.agitated_wilderness_creature
-    for unit_id=first_created_unit_id,df.global.unit_next_id-1 do
-        local unit = df.unit.find(unit_id)
-        if not unit then goto continue end
-        unit.profession = df.profession.STANDARD
-        unit.name.has_name = false
-        if is_sentient(unit) then
-            finalize_sentient(unit, disposition)
-        else
-            finalize_animal(unit, disposition)
-        end
-        ::continue::
-    end
-end
-
 function SandboxScreen:init()
-    self.first_created_unit_id = df.global.unit_next_id
-
     init_arena()
 
-    self:addviews{Sandbox{}}
+    self:addviews{
+        Sandbox{
+            view_id='sandbox',
+        },
+        InterfaceMask{
+            frame={l=17, r=38, t=0, h=3},
+            frame_background=gui.CLEAR_PEN,
+        },
+        InterfaceMask{
+            frame={l=0, r=0, b=0, h=3},
+        },
+    }
 
     df.global.gametype = df.game_type.DWARF_ARENA
 end
@@ -196,8 +306,7 @@ end
 function SandboxScreen:onDismiss()
     df.global.gametype = df.game_type.DWARF_MAIN
     view = nil
-    finalize_units(self.first_created_unit_id,
-            self.subviews.disposition:getOptionValue())
+    self.subviews.sandbox:finalize_group()
 end
 
 if df.global.gametype ~= df.game_type.DWARF_MAIN then

--- a/gui/sandbox.lua
+++ b/gui/sandbox.lua
@@ -19,7 +19,7 @@ local DISPOSITIONS = {
 
 Sandbox = defclass(Sandbox, widgets.Window)
 Sandbox.ATTRS {
-    frame_title='Arena Sandbox',
+    frame_title='Armok\'s Sandbox',
     frame={r=2, t=18, w=26, h=20},
     frame_inset={b=1},
     interface_masks=DEFAULT_NIL,
@@ -206,6 +206,7 @@ function Sandbox:onInput(keys)
         return true
     end
     if keys._MOUSE_L then
+        if self:getMouseFramePos() then return true end
         for _,mask_panel in ipairs(self.interface_masks) do
             if mask_panel:getMousePos() then return true end
         end

--- a/gui/sandbox.lua
+++ b/gui/sandbox.lua
@@ -155,6 +155,7 @@ local function finalize_animal(unit, disposition)
         unit.flags4.agitated_wilderness_creature = true
     elseif disposition == DISPOSITIONS.WILD then
         unit.flags2.roaming_wilderness_population_source = true
+        unit.flags2.roaming_wilderness_population_source_not_a_map_feature = true
         unit.animal.leave_countdown = 20000
     elseif disposition == DISPOSITIONS.FRIENDLY then
         -- noop; units are created friendly by default

--- a/makeown.lua
+++ b/makeown.lua
@@ -3,6 +3,7 @@
     make_own(unit)        -- removes foreign flags, sets civ_id to fort civ_id, and sets clothes ownership
     make_citizen(unit)    -- called by make_own if unit.race == fort race
 --]]
+--@module=true
 
 local utils = require 'utils'
 
@@ -65,7 +66,7 @@ local function entity_link(hf, eid, do_event, add, replace_idx)
     end
 
     if do_event then
-        event = add and df.history_event_add_hf_entity_linkst:new() or df.history_event_remove_hf_entity_linkst:new()
+        local event = add and df.history_event_add_hf_entity_linkst:new() or df.history_event_remove_hf_entity_linkst:new()
         event.year = df.global.cur_year
         event.seconds = df.global.cur_year_tick
         event.civ = eid
@@ -81,7 +82,7 @@ end
 local function change_state(hf, site_id, pos)
     hf.info.whereabouts.whereabouts_type = 1    -- state? arrived?
     hf.info.whereabouts.site = site_id
-    event = df.history_event_change_hf_statest:new()
+    local event = df.history_event_change_hf_statest:new()
     event.year = df.global.cur_year
     event.seconds = df.global.cur_year_tick
     event.id = df.global.hist_event_next_id
@@ -101,12 +102,10 @@ function make_citizen(unit)
     local civ_id = df.global.plotinfo.civ_id                                                --get civ id
     local group_id = df.global.plotinfo.group_id                                            --get group id
     local site_id = df.global.plotinfo.site_id                                                --get site id
-    local events = df.global.world.history.events                                            --get events
 
     local fortent = df.historical_entity.find(group_id)                                        --get fort's entity
     local civent = df.historical_entity.find(civ_id)
 
-    local event
     local region_pos = df.world_site.find(site_id).pos -- used with state events and hf state
 
     local hf
@@ -116,7 +115,7 @@ function make_citizen(unit)
 
     if not hf then                                                                                --if its not a histfig then make it a histfig
         --new_hf = true
-        hf = df.historical_figure.new()
+        hf = df.new(df.historical_figure)
         hf.id = df.global.hist_figure_next_id
         df.global.hist_figure_next_id = df.global.hist_figure_next_id+1
         hf.profession = unit.profession
@@ -128,7 +127,7 @@ function make_citizen(unit)
         hf.born_seconds = unit.birth_time
         hf.curse_year = unit.curse_year
         hf.curse_seconds = unit.curse_time
-        hf.birth_year_bias=unit.bias_birth_bias
+        hf.birth_year_bias=unit.birth_year_bias
         hf.birth_time_bias=unit.birth_time_bias
         hf.old_year = unit.old_year
         hf.old_seconds = unit.old_time
@@ -291,9 +290,14 @@ function make_own(unit)
 
     fix_clothing_ownership(unit)
 
-    if unit.hist_figure_id > -1 and unit.hist_figure_id2 > -1 then    --previously this just checked if the units race was the same as the
-        make_citizen(unit)                                            --player's civ, but now it checks if the creature is a histfig
+    local caste_flags = unit.enemy.caste_flags
+    if caste_flags.CAN_SPEAK or caste_flags.CAN_LEARN then
+        make_citizen(unit)
     end
+end
+
+if dfhack_flags.module then
+    return
 end
 
 unit = dfhack.gui.getSelectedUnit()


### PR DESCRIPTION
Borne from my research for `modtools/create-unit`. This gives the player direct access to the arena creation interface while in fort mode. Game is force-paused while this interface is open (since otherwise your dwarves will immediately slaughter each other in "No Quarter" combat).

~~TODO:~~ I think this script is "good enough" for now, and there are other things I need to work on. I filed the last two items as issues.


- [x] `makeown` integration so created units are (optionally) automatically made part of your fort
- [x] de-emphasize arena mode in the docs; move to "implementation details" section
- [x] provide link to launch `gui/create-item`
- [x] prevent the weather button from being invoked (it doesn't do anything useful in the context of this tool)
- [x] add a button to finalize units up to this point with current settings so players can spawn multiple "sets" of units (e.g. setting up an invasion force)
- [x] equipment configuration
- [x] undead invaders
- [ ] figure out how to make wild animals labeled as "Wild Animal"
- [ ] provide equipment loadout/skill templates ("peasant", "melee, bronze", "melee, iron", "melee, steel", "archer", etc.)