### PR TITLE
[gui/create-item] allow armor to be made out of leather

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@ that repo.
 ## Fixes
 - `quickfort`: properly allow dwarves to smooth, engrave, and carve beneath passable tiles of buildings
 - `deathcause`: fix incorrect weapon sometimes being reported
+- `gui/create-item`: allow armor to be made out of leather when using the restrictive filters
 - `gui/design`: Fix building and stairs designation
 - `quickfort`: fixed detection of tiles where machines are allowed (e.g. water wheels *can* be built on stairs if there is a machine support nearby)
 - `quickfort`: fixed rotation of blueprints with carved track tiles

--- a/gui/create-item.lua
+++ b/gui/create-item.lua
@@ -81,7 +81,7 @@ local function getRestrictiveMatFilter(itemType, opts)
             return (mat.flags.ITEMS_AMMO)
         end,
         ARMOR = function(mat, parent, typ, idx)
-            return (mat.flags.ITEMS_ARMOR)
+            return (mat.flags.ITEMS_ARMOR or mat.flags.LEATHER)
         end,
         INSTRUMENT = function(mat, parent, typ, idx)
             return (mat.flags.ITEMS_HARD)


### PR DESCRIPTION
the restrictive filter was not allowing leather for armor items. it should be.