### PR TITLE
[suspendmanager] Protect floor designation from being erased

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -40,6 +40,7 @@ that repo.
 - `light-aquifers-only`: now available as a fort Autostart option in `gui/control-panel`. note that it will only appear if "armok" tools are configured to be shown on the Preferences tab.
 - `gui/gm-editor`: when passing the ``--freeze`` option, further ensure that the game is frozen by halting all rendering (other than for the gm-editor window itself)
 - `gui/gm-editor`: Alt-A now enables auto-update mode, where you can watch values change live when the game is unpaused
+- `suspendmanager`: now suspends construction jobs on top of floor designations, to protect the designations from being erased
 
 ## Removed
 

--- a/suspend.lua
+++ b/suspend.lua
@@ -17,7 +17,7 @@ if help then
 end
 
 -- Only initialize suspendmanager if we want to suspend blocking jobs
-manager = onlyblocking and suspendmanager.SuspendManager.new(true) or nil
+manager = onlyblocking and suspendmanager.SuspendManager{preventBlocking=true} or nil
 if manager then
     manager:refresh()
 end

--- a/suspend.lua
+++ b/suspend.lua
@@ -16,8 +16,14 @@ if help then
     return
 end
 
+-- Only initialize suspendmanager if we want to suspend blocking jobs
+manager = onlyblocking and suspendmanager.SuspendManager.new(true) or nil
+if manager then
+    manager:refresh()
+end
+
 suspendmanager.foreach_construction_job(function (job)
-    if not onlyblocking or suspendmanager.isBlocking(job) then
+    if not manager or manager:shouldBeSuspended(job) then
         suspendmanager.suspend(job)
     end
 end)

--- a/unsuspend.lua
+++ b/unsuspend.lua
@@ -186,10 +186,12 @@ argparse.processArgsGetopt({...}, {
 local skipped_counts = {}
 local unsuspended_count = 0
 
+local manager = suspendmanager.SuspendManager.new(skipblocking)
+manager:refresh()
 suspendmanager.foreach_construction_job(function(job)
     if not job.flags.suspend then return end
 
-    local skip,reason=suspendmanager.shouldStaySuspended(job, skipblocking)
+    local skip,reason=manager:shouldStaySuspended(job, skipblocking)
     if skip then
         skipped_counts[reason] = (skipped_counts[reason] or 0) + 1
         return

--- a/unsuspend.lua
+++ b/unsuspend.lua
@@ -186,7 +186,7 @@ argparse.processArgsGetopt({...}, {
 local skipped_counts = {}
 local unsuspended_count = 0
 
-local manager = suspendmanager.SuspendManager.new(skipblocking)
+local manager = suspendmanager.SuspendManager{preventBlocking=skipblocking}
 manager:refresh()
 suspendmanager.foreach_construction_job(function(job)
     if not job.flags.suspend then return end


### PR DESCRIPTION
Fixes https://github.com/DFHack/dfhack/issues/3407

In vanilla DF, floor designations (track carving, smoothing, engraving) order are erased if a building is built on top of it before the job is done. However, if the designation is completed before the building, then both are correctly done.

This PR makes suspendmanager suspend constructions that are on top of floor designations, so that the dwarf can do this kind of construction unattended.

https://github.com/DFHack/scripts/assets/630159/0085373f-4ea1-4e92-b451-a14069b89cc8

Internally, it reworks suspendmanager to have a class. This helps managing multi-step operations, for example here detecting the designations require to loop on the designation jobs, and store the layered jobs. The same kind of situation will occur when implementing dead-end detection.