### PR TITLE
[suspendmanager] Make it a class - track the job statuses

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -55,7 +55,6 @@ that repo.
 - `light-aquifers-only`: now available as a fort Autostart option in `gui/control-panel`. note that it will only appear if "armok" tools are configured to be shown on the Preferences tab.
 - `gui/gm-editor`: when passing the ``--freeze`` option, further ensure that the game is frozen by halting all rendering (other than for DFHack tool windows)
 - `gui/gm-editor`: Alt-A now enables auto-update mode, where you can watch values change live when the game is unpaused
-- `suspendmanager`: internal to be more flexible
 
 # 50.08-r1
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -51,6 +51,7 @@ that repo.
 - `light-aquifers-only`: now available as a fort Autostart option in `gui/control-panel`. note that it will only appear if "armok" tools are configured to be shown on the Preferences tab.
 - `gui/gm-editor`: when passing the ``--freeze`` option, further ensure that the game is frozen by halting all rendering (other than for DFHack tool windows)
 - `gui/gm-editor`: Alt-A now enables auto-update mode, where you can watch values change live when the game is unpaused
+- `suspendmanager`: internal to be more flexible
 
 # 50.08-r1
 

--- a/suspend.lua
+++ b/suspend.lua
@@ -16,8 +16,14 @@ if help then
     return
 end
 
+-- Only initialize suspendmanager if we want to suspend blocking jobs
+manager = onlyblocking and suspendmanager.SuspendManager{preventBlocking=true} or nil
+if manager then
+    manager:refresh()
+end
+
 suspendmanager.foreach_construction_job(function (job)
-    if not onlyblocking or suspendmanager.isBlocking(job) then
+    if not manager or manager:shouldBeSuspended(job) then
         suspendmanager.suspend(job)
     end
 end)


### PR DESCRIPTION
Rework the internals of suspendmanager to make it more flexible.

The current implementation of suspendmanager main methods is "shouldBeSuspended(job)"/"shouldStaySuspended(job)". However, in many cases it's by analysing another job that we can determine that a job should be suspended. For example, if a wall would close a dead-end, it's detectable when looking at the dead-end, not directly the job closing it. Similarly, when a multi-tile construction job would erase a designation work, it can be efficiently detected by looking at the designation work, not the construction job.

This PR reworks suspendmanager to be a class with a main instance kept between frames. The class keeps hold of a table<job_id,reason> maintaining the list of suspended jobs. The suspension is always in two steps: first store all the suspension reasons, then actually suspend/unsuspend. This allow for more flexibility on the source of suspension for a job.

Additionally, having at any time the list of suspended jobs will help for issue such as https://github.com/DFHack/dfhack/issues/3413, or could also be used to rework the "x"/"p" overlay to be more expressive.
