### PR TITLE
[gui/autodump] add option to clear the trader flag upon teleport

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ that repo.
 ## Fixes
 
 ## Misc Improvements
+- `gui/autodump`: add option to clear the ``trader`` flag from teleported items, allowing you to reclaim items dropped by merchants
 
 ## Removed
 

--- a/docs/gui/autodump.rst
+++ b/docs/gui/autodump.rst
@@ -12,6 +12,11 @@ instead. Double-click anywhere on the map to teleport the items there. Be wary
 (or excited) that if you teleport the items into an unsupported position (e.g.
 mid-air), then they will become projectiles and fall.
 
+There are options to include or exclude forbidden items, items that are
+currently tagged as being used by an active job, and items dropped by traders.
+If trader items are included, the ``trader`` flag will be cleared upon teleport
+so the items can be used.
+
 Usage
 -----
 


### PR DESCRIPTION
so piles of discarded trader goods after a wagon scuttling are usable. This could also potentially be done as a "fix" script since piles of unusable items that you are being blamed for anyway seems like a bug.