### PR TITLE
[suspendmanager] Protect floor designation from being erased

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -55,6 +55,7 @@ that repo.
 - `light-aquifers-only`: now available as a fort Autostart option in `gui/control-panel`. note that it will only appear if "armok" tools are configured to be shown on the Preferences tab.
 - `gui/gm-editor`: when passing the ``--freeze`` option, further ensure that the game is frozen by halting all rendering (other than for DFHack tool windows)
 - `gui/gm-editor`: Alt-A now enables auto-update mode, where you can watch values change live when the game is unpaused
+- `suspendmanager`: now suspends construction jobs on top of floor designations, protecting the designations from being erased
 
 # 50.08-r1
 

--- a/docs/suspendmanager.rst
+++ b/docs/suspendmanager.rst
@@ -11,6 +11,9 @@ This tool will watch your active jobs and:
     items temporarily in the way, or worker dwarves getting scared by wildlife
 - suspend construction jobs that would prevent a dwarf from reaching an adjacent
     construction job, such as when building a wall corner.
+- suspend construction jobs on top of a smoothing, engraving or track carving
+  job. This prevent the construction job to be completed first, which would
+  erase the other
 
 Usage
 -----


### PR DESCRIPTION
Fixes https://github.com/DFHack/dfhack/issues/3407

Checks for construction jobs being built on top of designation jobs, and ensure the designation job is completed before the construction job. The other way around would erase the designation job.

(same PR as https://github.com/DFHack/scripts/pull/715, without the refactoring clutter)