### PR TITLE
[gui/control-panel] add config options from dreamfort sample config

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,8 @@ that repo.
 - `gui/create-item`: allow blocks to be made out of wood when using the restrictive filters
 
 ## Misc Improvements
+- `gui/control-panel`: add some popular startup configuration commands for `autobutcher` and `autofarm`
+- `gui/control-panel`: add option for running `fix/blood-del` on new forts (enabled by default)
 - `gui/autodump`: add option to clear the ``trader`` flag from teleported items, allowing you to reclaim items dropped by merchants
 
 ## Removed

--- a/gui/control-panel.lua
+++ b/gui/control-panel.lua
@@ -36,9 +36,14 @@ local FORT_SERVICES = {
 }
 
 local FORT_AUTOSTART = {
+    'autobutcher target 50 50 14 2 BIRD_GOOSE',
+    'autobutcher target 50 50 14 2 BIRD_TURKEY',
+    'autobutcher target 50 50 14 2 BIRD_CHICKEN',
+    'autofarm threshold 150 grass_tail_pig',
     'ban-cooking all',
     'buildingplan set boulders false',
     'buildingplan set logs false',
+    'fix/blood-del fort',
     'light-aquifers-only fort',
 }
 for _,v in ipairs(FORT_SERVICES) do
@@ -814,7 +819,7 @@ end
 ControlPanel = defclass(ControlPanel, widgets.Window)
 ControlPanel.ATTRS {
     frame_title='DFHack Control Panel',
-    frame={w=55, h=36},
+    frame={w=61, h=36},
     resizable=true,
     resize_min={h=28},
     autoarrange_subviews=true,


### PR DESCRIPTION
common startup config for autobutcher and autofarm

plus fix/blood-del. not sure how we missed that one.