### PR TITLE
[quickfort] handle buildings that can overlap (i.e. zones)

### DIFF
--- a/internal/quickfort/building.lua
+++ b/internal/quickfort/building.lua
@@ -66,32 +66,46 @@ end
 -- populates seen_grid coordinates with the building id so we can build an
 -- extent_grid later. spreadsheet cells that define extents (e.g. a(5x5)) create
 -- buildings separate from adjacent cells, even if they have the same type.
-local function flood_fill(ctx, grid, x, y, seen_grid, data, db, aliases)
-    if seen_grid[x] and seen_grid[x][y] then return 0 end
-    if not grid[y] or not grid[y][x] then return 0 end
+local function flood_fill(ctx, grid, seen_cells, x, y, data, db, aliases)
+    local seen_grid = data.seen_grid
+    if safe_index(seen_grid, x, y) then return 0 end
+    if not safe_index(grid, y, x) then return 0 end
     local cell, text = grid[y][x].cell, grid[y][x].text
+    if seen_cells[cell] then return 0 end
     local keys, extent = quickfort_parse.parse_cell(ctx, text)
     if aliases[string.lower(keys)] then keys = aliases[string.lower(keys)] end
     local db_entry = db[keys]
     if not db_entry then
-        if not seen_grid[x] then seen_grid[x] = {} end
-        seen_grid[x][y] = true -- seen, but not part of any building
-        dfhack.printerr(string.format('invalid key sequence in cell %s: "%s"',
-                                      cell, text))
+        ensure_key(seen_grid, x)[y] = true -- seen, but not part of any building
+        dfhack.printerr(('invalid key sequence in cell %s: "%s"'):format(cell, text))
         return 1
     end
     if db_entry.transform then
-        keys = db_entry.transform(ctx)
+        keys = db_entry:transform(ctx)
+        db_entry = keys and db[keys] or nil
+        if not db_entry then
+            ensure_key(seen_grid, x)[y] = true -- seen, but not part of any building
+            dfhack.printerr(('invalid transformed key sequence in cell %s: "%s"->"%s"'):format(cell, text, keys))
+            return 1
+        end
     end
-    if data.type and (data.type ~= keys or extent.specified) then return 0 end
+    if data.db_entry and (data.db_entry.label ~= db_entry.label or extent.specified) then
+        return 0
+    end
     log('mapping spreadsheet cell %s with text "%s"', cell, text)
-    if not data.type then data.type = keys end
+    if data.db_entry then
+        if data.db_entry.merge_fn then data.db_entry:merge_fn(db_entry) end
+    else
+        data.db_entry = copyall(db_entry)
+    end
     table.insert(data.cells, cell)
+    seen_cells[cell] = true
+    -- note that extent width and height can be negative: they can
+    -- describe a box from any corner
     for tgt_x=math.min(x,x+extent.width+1),math.max(x+extent.width-1,x) do
         for tgt_y=math.min(y,y+extent.height+1),math.max(y+extent.height-1,y) do
-            if not seen_grid[tgt_x] then seen_grid[tgt_x] = {} end
             -- this may overlap with another building, but that's handled later
-            seen_grid[tgt_x][tgt_y] = data.id
+            ensure_key(seen_grid, tgt_x)[tgt_y] = data.id
             if tgt_x < data.x_min then data.x_min = tgt_x end
             if tgt_x > data.x_max then data.x_max = tgt_x end
             if tgt_y < data.y_min then data.y_min = tgt_y end
@@ -99,14 +113,14 @@ local function flood_fill(ctx, grid, x, y, seen_grid, data, db, aliases)
         end
     end
     if extent.specified then return 0 end
-    return flood_fill(ctx, grid, x-1, y-1, seen_grid, data, db, aliases) +
-            flood_fill(ctx, grid, x-1, y, seen_grid, data, db, aliases) +
-            flood_fill(ctx, grid, x-1, y+1, seen_grid, data, db, aliases) +
-            flood_fill(ctx, grid, x, y-1, seen_grid, data, db, aliases) +
-            flood_fill(ctx, grid, x, y+1, seen_grid, data, db, aliases) +
-            flood_fill(ctx, grid, x+1, y-1, seen_grid, data, db, aliases) +
-            flood_fill(ctx, grid, x+1, y, seen_grid, data, db, aliases) +
-            flood_fill(ctx, grid, x+1, y+1, seen_grid, data, db, aliases)
+    return flood_fill(ctx, grid, seen_cells, x-1, y-1, data, db, aliases) +
+            flood_fill(ctx, grid, seen_cells, x-1, y, data, db, aliases) +
+            flood_fill(ctx, grid, seen_cells, x-1, y+1, data, db, aliases) +
+            flood_fill(ctx, grid, seen_cells, x, y-1, data, db, aliases) +
+            flood_fill(ctx, grid, seen_cells, x, y+1, data, db, aliases) +
+            flood_fill(ctx, grid, seen_cells, x+1, y-1, data, db, aliases) +
+            flood_fill(ctx, grid, seen_cells, x+1, y, data, db, aliases) +
+            flood_fill(ctx, grid, seen_cells, x+1, y+1, data, db, aliases)
 end
 
 local function swap_id_and_trim_chunk(chunk, seen_grid, from_id)
@@ -114,7 +128,7 @@ local function swap_id_and_trim_chunk(chunk, seen_grid, from_id)
     local y_min, y_max = chunk.y_max,chunk.y_min
     for x=chunk.x_min,chunk.x_max do
         for y=chunk.y_min,chunk.y_max do
-            if seen_grid[x] and seen_grid[x][y] == from_id then
+            if safe_index(seen_grid, x, y) == from_id then
                 seen_grid[x][y] = chunk.id
                 x_min, x_max = math.min(x_min, x), math.max(x_max, x)
                 y_min, y_max = math.min(y_min, y), math.max(y_max, y)
@@ -130,10 +144,11 @@ end
 -- (think of a solid block of staggered workshops of the same type). instead,
 -- scan the edges and break off pieces as we find them. scan in an order that
 -- results in the same chunking regardless of any applied transformations.
-local function chunk_extents(data_tables, seen_grid, db, invert)
+local function chunk_extents(data_tables, invert)
     local chunks = {}
     for i, data in ipairs(data_tables) do
-        local db_entry = db[data.type]
+        local seen_grid = data.seen_grid
+        local db_entry = data.db_entry
         local max_width = db_entry.max_width
         local max_height = db_entry.max_height
         local width = data.x_max - data.x_min + 1
@@ -154,7 +169,7 @@ local function chunk_extents(data_tables, seen_grid, db, invert)
         end
         for x=startx,endx,stepx do
             for y=starty,endy,stepy do
-                if not seen_grid[x] or seen_grid[x][y] ~= data.id then
+                if safe_index(seen_grid, x, y) ~= data.id then
                     goto inner_continue
                 end
                 chunk = copyall(data)
@@ -194,9 +209,10 @@ end
 -- expand multi-tile buildings that are less than their min dimensions around
 -- their current center. if the blueprint has been transformed, ensures the
 -- expansion respects the original orientation.
-local function expand_buildings(data_tables, seen_grid, db, invert)
+local function expand_buildings(data_tables, invert)
     for _, data in ipairs(data_tables) do
-        local db_entry = db[data.type]
+        local seen_grid = data.seen_grid
+        local db_entry = data.db_entry
         if db_entry.has_extents then goto continue end
         local width = data.x_max - data.x_min + 1
         local height = data.y_max - data.y_min + 1
@@ -233,7 +249,8 @@ local function expand_buildings(data_tables, seen_grid, db, invert)
     end
 end
 
-local function build_extent_grid(seen_grid, data)
+local function build_extent_grid(data)
+    local seen_grid = data.seen_grid
     local extent_grid, num_tiles = {}, 0
     for x=data.x_min,data.x_max do
         local extent_x = x - data.x_min + 1
@@ -252,46 +269,87 @@ local function build_extent_grid(seen_grid, data)
             num_tiles == width * height
 end
 
+local function merge_building_data(to_data, from_data)
+    to_data.db_entry:merge_fn(from_data.db_entry)
+    for _,cell in ipairs(from_data.cells) do
+        table.insert(to_data.cells, cell)
+    end
+    to_data.x_min = math.min(to_data.x_min, from_data.x_min)
+    to_data.x_max = math.max(to_data.x_max, from_data.x_max)
+    to_data.y_min = math.min(to_data.y_min, from_data.y_min)
+    to_data.y_max = math.max(to_data.y_max, from_data.y_max)
+    for x=from_data.x_min,from_data.x_max do
+        for y=from_data.y_min,from_data.y_max do
+            if safe_index(from_data.seen_grid, x, y) == from_data.id then
+                ensure_key(to_data.seen_grid, x)[y] = to_data.id
+            end
+        end
+    end
+end
+
+local function dump_data_tables(desc, data_tables, common_seen_grid, non_occluding)
+    if non_occluding then
+        for _,data in ipairs(data_tables) do
+            logfn(dump_seen_grid, desc, data.seen_grid, #data_tables)
+        end
+    else
+        logfn(dump_seen_grid, desc, common_seen_grid, #data_tables)
+    end
+end
+
 -- build boundaries and extent maps from blueprint grid input
-function init_buildings(ctx, zlevel, grid, buildings, db, aliases)
+function init_buildings(ctx, zlevel, grid, buildings, db, aliases, non_occluding)
     local invalid_keys = 0
     local data_tables = {}
-    local seen_grid = {} -- [x][y] -> id
+    local global_labels = {} -- label -> id
+    local common_seen_grid = {} -- [x][y] -> id
+    local seen_cells = {} -- str -> true
     aliases = aliases or {}
     for y, row in pairs(grid) do
-        for x, cell_and_text in pairs(row) do
-            if seen_grid[x] and seen_grid[x][y] then goto continue end
+        for x in pairs(row) do
+            if safe_index(common_seen_grid, x, y) then goto continue end
             local data = {
-                id=#data_tables+1, type=nil, cells={},
+                id=#data_tables+1, cells={}, db_entry=nil,
+                seen_grid=non_occluding and {} or common_seen_grid,
                 x_min=30000, x_max=-30000, y_min=30000, y_max=-30000
             }
             invalid_keys = invalid_keys +
-                    flood_fill(ctx, grid, x, y, seen_grid, data, db, aliases)
-            if data.type then table.insert(data_tables, data) end
+                    flood_fill(ctx, grid, seen_cells, x, y, data, db, aliases)
+            if data.db_entry then
+                if data.db_entry.global_label then
+                    local prev_id = global_labels[data.db_entry.global_label]
+                    if prev_id then
+                        merge_building_data(data_tables[prev_id], data)
+                        goto continue
+                    end
+                    global_labels[data.db_entry.global_label] = data.id
+                end
+                table.insert(data_tables, data)
+            end
             ::continue::
         end
     end
-    logfn(dump_seen_grid, 'after edge detection', seen_grid, #data_tables)
+    dump_data_tables('after edge detection', data_tables, common_seen_grid, non_occluding)
     local tvec = ctx.transform_fn({x=1, y=-2}, true)
     local invert = {
         x=tvec.x == -1 or tvec.x == 2,
         y=tvec.y == -1 or tvec.y == 2
     }
-    data_tables = chunk_extents(data_tables, seen_grid, db, invert)
-    logfn(dump_seen_grid, 'after chunking', seen_grid, #data_tables)
-    expand_buildings(data_tables, seen_grid, db, invert)
-    logfn(dump_seen_grid, 'after expansion', seen_grid, #data_tables)
+    data_tables = chunk_extents(data_tables, invert)
+    dump_data_tables('after chunking', data_tables, common_seen_grid, non_occluding)
+    expand_buildings(data_tables, invert)
+    dump_data_tables('after expansion', data_tables, common_seen_grid, non_occluding)
     for _, data in ipairs(data_tables) do
-        local extent_grid, is_solid = build_extent_grid(seen_grid, data)
-        if not db[data.type].has_extents and not is_solid then
+        local extent_grid, is_solid = build_extent_grid(data)
+        if not data.db_entry.has_extents and not is_solid then
             dfhack.printerr(
                 ('space needed for "%s" is taken by adjacent structures ' ..
                  '(defined in spreadsheet cells: %s)'):format(
-                        db[data.type].label, table.concat(data.cells, ', ')))
+                        data.db_entry.label, table.concat(data.cells, ', ')))
         else
             table.insert(buildings,
-                         {type=data.type,
-                          cells=data.cells,
+                         {cells=data.cells,
+                          db_entry=data.db_entry,
                           pos=xyz2pos(data.x_min, data.y_min, zlevel),
                           width=data.x_max-data.x_min+1,
                           height=data.y_max-data.y_min+1,
@@ -369,12 +427,12 @@ end
 -- check bounds against size limits and map edges, adjust pos, width, height,
 -- and extent_grid accordingly. nulls or zeroes out config for buildings that
 -- are cropped below their minimum dimensions
-function crop_to_bounds(ctx, buildings, db)
+function crop_to_bounds(ctx, buildings)
     local out_of_bounds_tiles = 0
     local bounds = ctx.bounds or quickfort_map.MapBoundsChecker{}
     for _, b in ipairs(buildings) do
         if not b.pos then goto continue end
-        local prev_oob, db_entry = out_of_bounds_tiles, db[b.type]
+        local prev_oob, db_entry = out_of_bounds_tiles, b.db_entry
         -- if zlevel is out of bounds, the whole extent is out of bounds
         if not bounds:is_on_map_z(b.pos.z) then
             out_of_bounds_tiles = out_of_bounds_tiles +
@@ -456,11 +514,11 @@ end
 -- check tiles for validity, adjust the extent_grid, and checks the validity of
 -- the adjusted extent_grid. marks building as invalid if the extent_grid is
 -- invalid.
-function check_tiles_and_extents(ctx, buildings, db)
+function check_tiles_and_extents(ctx, buildings)
     local occupied_tiles = 0
     for _, b in ipairs(buildings) do
         if not b.pos then goto continue end
-        local db_entry = db[b.type]
+        local db_entry = b.db_entry
         local owns_preview = false
         for extent_x=1,b.width do
             local col = b.extent_grid[extent_x]


### PR DESCRIPTION
fundamental layout logic shared by build, place, and zone modes. it turned out that we were never handling overlapping zones correctly. they were incorrectly occluding one another if they weren't all declared on the same tile (that is, a multi-type zone was ok, but independent zones that partially overlapped was not).

now, both overlapping and non-overlapping (buildings, stockpiles) use cases are handled properly