### PR TITLE
Update emigration.lua

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ that repo.
 
 ## Fixes
 - `gui/create-item`: allow blocks to be made out of wood when using the restrictive filters
+- `emigration`: reassign home site for emigrating units so they don't just come right back to the fort
 
 ## Misc Improvements
 - `gui/autodump`: add option to clear the ``trader`` flag from teleported items, allowing you to reclaim items dropped by merchants

--- a/emigration.lua
+++ b/emigration.lua
@@ -1,35 +1,28 @@
 --Allow stressed dwarves to emigrate from the fortress
 -- For 34.11 by IndigoFenix; update and cleanup by PeridexisErrant
 -- old version:  http://dffd.bay12games.com/file.php?id=8404
---[====[
-emigration
-==========
-Allows dwarves to emigrate from the fortress when stressed,
-in proportion to how badly stressed they are and adjusted
-for who they would have to leave with - a dwarven merchant
-being more attractive than leaving alone (or with an elf).
-The check is made monthly.
+--@module = true
+--@enable = true
 
-A happy dwarf (ie with negative stress) will never emigrate.
+local json = require('json')
+local persist = require('persist-table')
 
-Usage::
-
-    emigration enable|disable
-]====]
+local GLOBAL_KEY = 'emigration' -- used for state change hooks and persistence
 
 enabled = enabled or false
 
-local args = {...}
-if args[1] == "enable" then
-    enabled = true
-elseif args[1] == "disable" then
-    enabled = false
+function isEnabled()
+    return enabled
+end
+
+local function persist_state()
+    persist.GlobalTable[GLOBAL_KEY] = json.encode({enabled=enabled})
 end
 
 function desireToStay(unit,method,civ_id)
     -- on a percentage scale
     local value = 100 - unit.status.current_soul.personality.stress / 5000
-    if method == 'merchant' or method == 'diplomat' then
+    if method == 'merchant' then
         if civ_id ~= unit.civ_id then value = value*2 end end
     if method == 'wild' then
         value = value*5 end
@@ -50,42 +43,40 @@ function desert(u,method,civ)
         u.flags2.visitor = true
         u.animal.leave_countdown = 2
     end
-
     local hf_id = u.hist_figure_id
     local hf = df.historical_figure.find(u.hist_figure_id)
-    local fort_ent = df.global.plotinfo.main.fortress_entity
+    local fort_ent = df.global.ui.main.fortress_entity
     local civ_ent = df.historical_entity.find(hf.civ_id)
-
     local newent_id = -1
     local newsite_id = -1
-
+    
     -- free owned rooms
     for i = #u.owned_buildings-1, 0, -1 do
         local temp_bld = df.building.find(u.owned_buildings[i].id)
         dfhack.buildings.setOwner(temp_bld, nil)
     end
-
+    
     -- erase the unit from the fortress entity
     for k,v in ipairs(fort_ent.histfig_ids) do
         if v == hf_id then
-            df.global.plotinfo.main.fortress_entity.histfig_ids:erase(k)
+            df.global.ui.main.fortress_entity.histfig_ids:erase(k)
             break
         end
     end
     for k,v in ipairs(fort_ent.hist_figures) do
         if v.id == hf_id then
-            df.global.plotinfo.main.fortress_entity.hist_figures:erase(k)
+            df.global.ui.main.fortress_entity.hist_figures:erase(k)
             break
         end
     end
     for k,v in ipairs(fort_ent.nemesis) do
         if v.figure.id == hf_id then
-            df.global.plotinfo.main.fortress_entity.nemesis:erase(k)
-            df.global.plotinfo.main.fortress_entity.nemesis_ids:erase(k)
+            df.global.ui.main.fortress_entity.nemesis:erase(k)
+            df.global.ui.main.fortress_entity.nemesis_ids:erase(k)
             break
         end
     end
-
+    
     -- remove the old entity link and create new one to indicate former membership
     hf.entity_links:insert("#", {new = df.histfig_entity_link_former_memberst, entity_id = fort_ent.id, link_strength = 100})
     for k,v in ipairs(hf.entity_links) do
@@ -94,7 +85,7 @@ function desert(u,method,civ)
             break
         end
     end
-
+    
     -- try to find a new entity for the unit to join
     for k,v in ipairs(civ_ent.entity_links) do
         if v.type == df.entity_entity_link_type.CHILD and v.target ~= fort_ent.id then
@@ -102,7 +93,7 @@ function desert(u,method,civ)
             break
         end
     end
-
+    
     if newent_id > -1 then
         hf.entity_links:insert("#", {new = df.histfig_entity_link_memberst, entity_id = newent_id, link_strength = 100})
 
@@ -113,11 +104,9 @@ function desert(u,method,civ)
                 break
             end
         end
-
         local newent = df.historical_entity.find(newent_id)
         newent.histfig_ids:insert('#', hf_id)
         newent.hist_figures:insert('#', hf)
-
         local hf_event_id = df.global.hist_event_next_id
         df.global.hist_event_next_id = df.global.hist_event_next_id+1
         df.global.world.history.events:insert("#", {new = df.history_event_add_hf_entity_linkst, year = df.global.cur_year, seconds = df.global.cur_year_tick, id = hf_event_id, civ = newent_id, histfig = hf_id, link_type = 0})
@@ -127,7 +116,6 @@ function desert(u,method,civ)
             df.global.world.history.events:insert("#", {new = df.history_event_change_hf_statest, year = df.global.cur_year, seconds = df.global.cur_year_tick, id = hf_event_id, hfid = hf_id, state = 1, reason = -1, site = newsite_id})
         end
     end
-
     print(line)
     dfhack.gui.showAnnouncement(line, COLOR_WHITE)
 end
@@ -175,9 +163,10 @@ function checkmigrationnow()
     end
 
     if #merchant_civ_ids == 0 then
-        checkForDeserters('wild', df.global.plotinfo.main.fortress_entity.entity_links[0].target)
+        checkForDeserters('wild', df.global.ui.main.fortress_entity.entity_links[0].target)
+    else
+        for _, civ_id in pairs(merchant_civ_ids) do checkForDeserters('merchant', civ_id) end
     end
-    for _, civ_id in pairs(merchant_civ_ids) do checkForDeserters('merchant', civ_id) end
 end
 
 local function event_loop()
@@ -187,17 +176,42 @@ local function event_loop()
     end
 end
 
-dfhack.onStateChange.loadEmigration = function(code)
-    if code==SC_MAP_LOADED then
-        if enabled then
-            print("Emigration enabled.")
-            event_loop()
-        else
-            print("Emigration disabled.")
-        end
+dfhack.onStateChange[GLOBAL_KEY] = function(sc)
+    if sc == SC_MAP_UNLOADED then
+        enabled = false
+        return
     end
+
+    if sc ~= SC_MAP_LOADED or df.global.gamemode ~= df.game_mode.DWARF then
+        return
+    end
+
+    local persisted_data = json.decode(persist.GlobalTable[GLOBAL_KEY] or '')
+    enabled = (persisted_data or {enabled=false})['enabled']
+    event_loop()
 end
 
-if dfhack.isMapLoaded() then
-    dfhack.onStateChange.loadEmigration(SC_MAP_LOADED)
+if dfhack_flags.module then
+    return
 end
+
+if df.global.gamemode ~= df.game_mode.DWARF or not dfhack.isMapLoaded() then
+    dfhack.printerr('emigration needs a loaded fortress map to work')
+    return
+end
+
+local args = {...}
+if dfhack_flags and dfhack_flags.enable then
+    args = {dfhack_flags.enable_state and 'enable' or 'disable'}
+end
+
+if args[1] == "enable" then
+    enabled = true
+elseif args[1] == "disable" then
+    enabled = false
+else
+    return
+end
+
+event_loop()
+persist_state()

--- a/emigration.lua
+++ b/emigration.lua
@@ -1,36 +1,29 @@
 --Allow stressed dwarves to emigrate from the fortress
--- Updated for 0.47.05 by wsfsbvchr
+-- Updated for 0.47.05 and potentially for 50.08 by wsfsbvchr
 -- For 34.11 by IndigoFenix; update and cleanup by PeridexisErrant
 -- old version:  http://dffd.bay12games.com/file.php?id=8404
---[====[
-emigration
-==========
-Allows dwarves to emigrate from the fortress when stressed,
-in proportion to how badly stressed they are and adjusted
-for who they would have to leave with - a dwarven merchant
-being more attractive than leaving alone (or with an elf).
-The check is made monthly.
+--@module = true
+--@enable = true
 
-A happy dwarf (ie with negative stress) will never emigrate.
+local json = require('json')
+local persist = require('persist-table')
 
-Usage::
-
-    emigration enable|disable
-]====]
+local GLOBAL_KEY = 'emigration' -- used for state change hooks and persistence
 
 enabled = enabled or false
 
-local args = {...}
-if args[1] == "enable" then
-    enabled = true
-elseif args[1] == "disable" then
-    enabled = false
+function isEnabled()
+    return enabled
+end
+
+local function persist_state()
+    persist.GlobalTable[GLOBAL_KEY] = json.encode({enabled=enabled})
 end
 
 function desireToStay(unit,method,civ_id)
     -- on a percentage scale
-    local value = 100 - unit.status.current_soul.personality.stress_level / 5000
-    if method == 'merchant' or method == 'diplomat' then
+    local value = 100 - unit.status.current_soul.personality.stress / 5000
+    if method == 'merchant' then
         if civ_id ~= unit.civ_id then value = value*2 end end
     if method == 'wild' then
         value = value*5 end
@@ -38,99 +31,99 @@ function desireToStay(unit,method,civ_id)
 end
 
 function desert(u,method,civ)
-	u.following = nil
-	local line = dfhack.TranslateName(dfhack.units.getVisibleName(u)) .. " has "
-	if method == 'merchant' then
-		line = line.."joined the merchants"
-		u.flags1.merchant = true
-		u.civ_id = civ
-	else
-		line = line.."abandoned the settlement in search of a better life."
-		u.civ_id = civ
-		u.flags1.forest = true
-		u.flags2.visitor = true
-		u.animal.leave_countdown = 2
-	end
+    u.following = nil
+    local line = dfhack.TranslateName(dfhack.units.getVisibleName(u)) .. " has "
+    if method == 'merchant' then
+        line = line.."joined the merchants"
+        u.flags1.merchant = true
+        u.civ_id = civ
+    else
+        line = line.."abandoned the settlement in search of a better life."
+        u.civ_id = civ
+        u.flags1.forest = true
+        u.flags2.visitor = true
+        u.animal.leave_countdown = 2
+    end
+    
+    local hf_id = u.hist_figure_id
+    local hf = df.historical_figure.find(u.hist_figure_id)
+    local fort_ent = df.global.ui.main.fortress_entity
+    local civ_ent = df.historical_entity.find(hf.civ_id)
 
-	local hf_id = u.hist_figure_id
-	local hf = df.historical_figure.find(u.hist_figure_id)
-	local fort_ent = df.global.ui.main.fortress_entity
-	local civ_ent = df.historical_entity.find(hf.civ_id)
+    local newent_id = -1
+    local newsite_id = -1
+    
+    -- free owned rooms
+    for i = #u.owned_buildings-1, 0, -1 do
+        local temp_bld = df.building.find(u.owned_buildings[i].id)
+        dfhack.buildings.setOwner(temp_bld, nil)
+    end
 
-	local newent_id = -1
-	local newsite_id = -1
-	
-	-- free owned rooms
-	for i = #u.owned_buildings-1, 0, -1 do
-		local temp_bld = df.building.find(u.owned_buildings[i].id)
-		dfhack.buildings.setOwner(temp_bld, nil)
-	end
+    -- erase the unit from the fortress entity
+    for k,v in ipairs(fort_ent.histfig_ids) do
+        if v == hf_id then
+            df.global.ui.main.fortress_entity.histfig_ids:erase(k)
+            break
+        end
+    end
+    for k,v in ipairs(fort_ent.hist_figures) do
+        if v.id == hf_id then
+            df.global.ui.main.fortress_entity.hist_figures:erase(k)
+            break
+        end
+    end
+    for k,v in ipairs(fort_ent.nemesis) do
+        if v.figure.id == hf_id then
+            df.global.ui.main.fortress_entity.nemesis:erase(k)
+            df.global.ui.main.fortress_entity.nemesis_ids:erase(k)
+            break
+        end
+    end
 
-	-- erase the unit from the fortress entity
-	for k,v in pairs(fort_ent.histfig_ids) do
-		if tonumber(v) == hf_id then
-			df.global.ui.main.fortress_entity.histfig_ids:erase(k)
-			break
-		end
-	end
-	for k,v in pairs(fort_ent.hist_figures) do
-		if v.id == hf_id then
-			df.global.ui.main.fortress_entity.hist_figures:erase(k)
-			break
-		end
-	end
-	for k,v in pairs(fort_ent.nemesis) do
-		if v.figure.id == hf_id then
-			df.global.ui.main.fortress_entity.nemesis:erase(k)
-			df.global.ui.main.fortress_entity.nemesis_ids:erase(k)
-			break
-		end
-	end
+    -- remove the old entity link and create new one to indicate former membership
+    hf.entity_links:insert("#", {new = df.histfig_entity_link_former_memberst, entity_id = fort_ent.id, link_strength = 100})
+    for k,v in ipairs(hf.entity_links) do
+        if v._type == df.histfig_entity_link_memberst and v.entity_id == fort_ent.id then
+            hf.entity_links:erase(k)
+            break
+        end
+    end
 
-	-- remove the old entity link and create new one to indicate former membership
-	hf.entity_links:insert("#", {new = df.histfig_entity_link_former_memberst, entity_id = fort_ent.id, link_strength = 100})
-	for k,v in pairs(hf.entity_links) do
-		if v._type == df.histfig_entity_link_memberst and v.entity_id == fort_ent.id then
-			hf.entity_links:erase(k)
-			break
-		end
-	end
+    -- try to find a new entity for the unit to join
+    for k,v in ipairs(civ_ent.entity_links) do
+        if v.type == df.entity_entity_link_type.CHILD and v.target ~= fort_ent.id then
+            newent_id = v.target
+            break
+        end
+    end
 
-	-- try to find a new entity for the unit to join
-	for k,v in pairs(civ_ent.entity_links) do
-		if v.type == 1 and v.target ~= fort_ent.id then
-			newent_id = v.target
-			break
-		end
-	end
+    if newent_id > -1 then
+        hf.entity_links:insert("#", {new = df.histfig_entity_link_memberst, entity_id = newent_id, link_strength = 100})
 
-	if newent_id > -1 then
-		hf.entity_links:insert("#", {new = df.histfig_entity_link_memberst, entity_id = newent_id, link_strength = 100})
+        -- try to find a new site for the unit to join
+        for k,v in ipairs(df.global.world.entities.all[hf.civ_id].site_links) do
+            if v.type == df.entity_site_link_type.Claim and v.target ~= site_id then
+                newsite_id = v.target
+                break
+            end
+        end
 
-		-- try to find a new site for the unit to join
-		for k,v in pairs(df.global.world.entities.all[hf.civ_id].site_links) do
-			if v.type == 0 and v.target ~= site_id then
-				newsite_id = v.target
-				break
-			end
-		end
+        local newent = df.historical_entity.find(newent_id)
+        newent.histfig_ids:insert('#', hf_id)
+        newent.hist_figures:insert('#', hf)
 
-		local newent = df.historical_entity.find(newent_id)
-		newent.histfig_ids:insert('#', hf_id)
-		newent.hist_figures:insert('#', hf)
-
-		local hf_event_id = df.global.hist_event_next_id
-		df.global.hist_event_next_id = df.global.hist_event_next_id+1
-		df.global.world.history.events:insert("#", {new = df.history_event_add_hf_entity_linkst, year = df.global.cur_year, seconds = df.global.cur_year_tick, id = hf_event_id, civ = newent_id, histfig = hf_id, link_type = 0})
-		if newsite_id > -1 then
-			local hf_event_id = df.global.hist_event_next_id
-			df.global.hist_event_next_id = df.global.hist_event_next_id+1
-			df.global.world.history.events:insert("#", {new = df.history_event_change_hf_statest, year = df.global.cur_year, seconds = df.global.cur_year_tick, id = hf_event_id, hfid = hf_id, state = 1, reason = -1, site = newsite_id})
-		end
-	end
-
-	print(line)
-	dfhack.gui.showAnnouncement(line, COLOR_WHITE)
+        local hf_event_id = df.global.hist_event_next_id
+        df.global.hist_event_next_id = df.global.hist_event_next_id+1
+        df.global.world.history.events:insert("#", {new = df.history_event_add_hf_entity_linkst, year = df.global.cur_year, seconds = df.global.cur_year_tick, id = hf_event_id, civ = newent_id, histfig = hf_id, link_type = 0})
+        if newsite_id > -1 then
+            local hf_event_id = df.global.hist_event_next_id
+            df.global.hist_event_next_id = df.global.hist_event_next_id+1
+            df.global.world.history.events:insert("#", {new = df.history_event_change_hf_statest, year = df.global.cur_year, seconds = df.global.cur_year_tick, id = hf_event_id, hfid = hf_id, state = 1, reason = -1, site = newsite_id})
+        end
+    end
+    
+    print(line)
+    dfhack.gui.showAnnouncement(line, COLOR_WHITE)
 end
 
 function canLeave(unit)
@@ -163,7 +156,6 @@ end
 
 function checkmigrationnow()
     local merchant_civ_ids = {} --as:number[]
-    local diplomat_civ_ids = {} --as:number[]
     local allUnits = df.global.world.units.active
     for i=0, #allUnits-1 do
         local unit = allUnits[i]
@@ -173,15 +165,14 @@ function checkmigrationnow()
         and not unit.flags1.tame
         then
             if unit.flags1.merchant then table.insert(merchant_civ_ids, unit.civ_id) end
-            --if unit.flags1.diplomat then table.insert(diplomat_civ_ids, unit.civ_id) end
         end
     end
     
-    if #merchant_civ_ids == 0 and #diplomat_civ_ids == 0 then
+    if #merchant_civ_ids == 0 then
         checkForDeserters('wild', df.global.ui.main.fortress_entity.entity_links[0].target)
+    else
+        for _, civ_id in pairs(merchant_civ_ids) do checkForDeserters('merchant', civ_id) end
     end
-    for _, civ_id in pairs(merchant_civ_ids) do checkForDeserters('merchant', civ_id) end
-    --for _, civ_id in pairs(diplomat_civ_ids) do checkForDeserters('diplomat', civ_id) end
 end
 
 local function event_loop()
@@ -191,17 +182,42 @@ local function event_loop()
     end
 end
 
-dfhack.onStateChange.loadEmigration = function(code)
-    if code==SC_MAP_LOADED then
-        if enabled then
-            print("Emigration enabled.")
-            event_loop()
-        else
-            print("Emigration disabled.")
-        end
+dfhack.onStateChange[GLOBAL_KEY] = function(sc)
+    if sc == SC_MAP_UNLOADED then
+        enabled = false
+        return
     end
+
+    if sc ~= SC_MAP_LOADED or df.global.gamemode ~= df.game_mode.DWARF then
+        return
+    end
+
+    local persisted_data = json.decode(persist.GlobalTable[GLOBAL_KEY] or '')
+    enabled = (persisted_data or {enabled=false})['enabled']
+    event_loop()
 end
 
-if dfhack.isMapLoaded() then
-    dfhack.onStateChange.loadEmigration(SC_MAP_LOADED)
+if dfhack_flags.module then
+    return
 end
+
+if df.global.gamemode ~= df.game_mode.DWARF or not dfhack.isMapLoaded() then
+    dfhack.printerr('emigration needs a loaded fortress map to work')
+    return
+end
+
+local args = {...}
+if dfhack_flags and dfhack_flags.enable then
+    args = {dfhack_flags.enable_state and 'enable' or 'disable'}
+end
+
+if args[1] == "enable" then
+    enabled = true
+elseif args[1] == "disable" then
+    enabled = false
+else
+    return
+end
+
+event_loop()
+persist_state()

--- a/emigration.lua
+++ b/emigration.lua
@@ -45,7 +45,7 @@ function desert(u,method,civ)
     end
     local hf_id = u.hist_figure_id
     local hf = df.historical_figure.find(u.hist_figure_id)
-    local fort_ent = df.global.ui.main.fortress_entity
+    local fort_ent = df.global.plotinfo.main.fortress_entity
     local civ_ent = df.historical_entity.find(hf.civ_id)
     local newent_id = -1
     local newsite_id = -1
@@ -59,20 +59,20 @@ function desert(u,method,civ)
     -- erase the unit from the fortress entity
     for k,v in ipairs(fort_ent.histfig_ids) do
         if v == hf_id then
-            df.global.ui.main.fortress_entity.histfig_ids:erase(k)
+            df.global.plotinfo.main.fortress_entity.histfig_ids:erase(k)
             break
         end
     end
     for k,v in ipairs(fort_ent.hist_figures) do
         if v.id == hf_id then
-            df.global.ui.main.fortress_entity.hist_figures:erase(k)
+            df.global.plotinfo.main.fortress_entity.hist_figures:erase(k)
             break
         end
     end
     for k,v in ipairs(fort_ent.nemesis) do
         if v.figure.id == hf_id then
-            df.global.ui.main.fortress_entity.nemesis:erase(k)
-            df.global.ui.main.fortress_entity.nemesis_ids:erase(k)
+            df.global.plotinfo.main.fortress_entity.nemesis:erase(k)
+            df.global.plotinfo.main.fortress_entity.nemesis_ids:erase(k)
             break
         end
     end
@@ -163,7 +163,7 @@ function checkmigrationnow()
     end
 
     if #merchant_civ_ids == 0 then
-        checkForDeserters('wild', df.global.ui.main.fortress_entity.entity_links[0].target)
+        checkForDeserters('wild', df.global.plotinfo.main.fortress_entity.entity_links[0].target)
     else
         for _, civ_id in pairs(merchant_civ_ids) do checkForDeserters('merchant', civ_id) end
     end

--- a/emigration.lua
+++ b/emigration.lua
@@ -49,13 +49,13 @@ function desert(u,method,civ)
     local civ_ent = df.historical_entity.find(hf.civ_id)
     local newent_id = -1
     local newsite_id = -1
-    
+
     -- free owned rooms
     for i = #u.owned_buildings-1, 0, -1 do
         local temp_bld = df.building.find(u.owned_buildings[i].id)
         dfhack.buildings.setOwner(temp_bld, nil)
     end
-    
+
     -- erase the unit from the fortress entity
     for k,v in ipairs(fort_ent.histfig_ids) do
         if v == hf_id then
@@ -76,7 +76,7 @@ function desert(u,method,civ)
             break
         end
     end
-    
+
     -- remove the old entity link and create new one to indicate former membership
     hf.entity_links:insert("#", {new = df.histfig_entity_link_former_memberst, entity_id = fort_ent.id, link_strength = 100})
     for k,v in ipairs(hf.entity_links) do
@@ -85,7 +85,7 @@ function desert(u,method,civ)
             break
         end
     end
-    
+
     -- try to find a new entity for the unit to join
     for k,v in ipairs(civ_ent.entity_links) do
         if v.type == df.entity_entity_link_type.CHILD and v.target ~= fort_ent.id then
@@ -93,7 +93,7 @@ function desert(u,method,civ)
             break
         end
     end
-    
+
     if newent_id > -1 then
         hf.entity_links:insert("#", {new = df.histfig_entity_link_memberst, entity_id = newent_id, link_strength = 100})
 

--- a/emigration.lua
+++ b/emigration.lua
@@ -1,27 +1,35 @@
 --Allow stressed dwarves to emigrate from the fortress
+-- Updated for 0.47.05 by wsfsbvchr
 -- For 34.11 by IndigoFenix; update and cleanup by PeridexisErrant
 -- old version:  http://dffd.bay12games.com/file.php?id=8404
---@module = true
---@enable = true
+--[====[
+emigration
+==========
+Allows dwarves to emigrate from the fortress when stressed,
+in proportion to how badly stressed they are and adjusted
+for who they would have to leave with - a dwarven merchant
+being more attractive than leaving alone (or with an elf).
+The check is made monthly.
 
-local json = require('json')
-local persist = require('persist-table')
+A happy dwarf (ie with negative stress) will never emigrate.
 
-local GLOBAL_KEY = 'emigration' -- used for state change hooks and persistence
+Usage::
+
+    emigration enable|disable
+]====]
 
 enabled = enabled or false
 
-function isEnabled()
-    return enabled
-end
-
-local function persist_state()
-    persist.GlobalTable[GLOBAL_KEY] = json.encode({enabled=enabled})
+local args = {...}
+if args[1] == "enable" then
+    enabled = true
+elseif args[1] == "disable" then
+    enabled = false
 end
 
 function desireToStay(unit,method,civ_id)
     -- on a percentage scale
-    local value = 100 - unit.status.current_soul.personality.stress / 5000
+    local value = 100 - unit.status.current_soul.personality.stress_level / 5000
     if method == 'merchant' or method == 'diplomat' then
         if civ_id ~= unit.civ_id then value = value*2 end end
     if method == 'wild' then
@@ -30,24 +38,99 @@ function desireToStay(unit,method,civ_id)
 end
 
 function desert(u,method,civ)
-    u.following = nil
-    local line = dfhack.TranslateName(dfhack.units.getVisibleName(u)) .. " has "
-    if method == 'merchant' then
-        line = line.."joined the merchants"
-        u.flags1.merchant = true
-        u.civ_id = civ
-    elseif method == 'diplomat' then
-        line = line.."followed the diplomat"
-        u.flags1.diplomat = true
-        u.civ_id = civ
-    else
-        line = line.."abandoned the settlement in search of a better life."
-        u.civ_id = -1
-        u.flags1.forest = true
-        u.animal.leave_countdown = 2
-    end
-    print(line)
-    dfhack.gui.showAnnouncement(line, COLOR_WHITE)
+	u.following = nil
+	local line = dfhack.TranslateName(dfhack.units.getVisibleName(u)) .. " has "
+	if method == 'merchant' then
+		line = line.."joined the merchants"
+		u.flags1.merchant = true
+		u.civ_id = civ
+	else
+		line = line.."abandoned the settlement in search of a better life."
+		u.civ_id = civ
+		u.flags1.forest = true
+		u.flags2.visitor = true
+		u.animal.leave_countdown = 2
+	end
+
+	local hf_id = u.hist_figure_id
+	local hf = df.historical_figure.find(u.hist_figure_id)
+	local fort_ent = df.global.ui.main.fortress_entity
+	local civ_ent = df.historical_entity.find(hf.civ_id)
+
+	local newent_id = -1
+	local newsite_id = -1
+	
+	-- free owned rooms
+	for i = #u.owned_buildings-1, 0, -1 do
+		local temp_bld = df.building.find(u.owned_buildings[i].id)
+		dfhack.buildings.setOwner(temp_bld, nil)
+	end
+
+	-- erase the unit from the fortress entity
+	for k,v in pairs(fort_ent.histfig_ids) do
+		if tonumber(v) == hf_id then
+			df.global.ui.main.fortress_entity.histfig_ids:erase(k)
+			break
+		end
+	end
+	for k,v in pairs(fort_ent.hist_figures) do
+		if v.id == hf_id then
+			df.global.ui.main.fortress_entity.hist_figures:erase(k)
+			break
+		end
+	end
+	for k,v in pairs(fort_ent.nemesis) do
+		if v.figure.id == hf_id then
+			df.global.ui.main.fortress_entity.nemesis:erase(k)
+			df.global.ui.main.fortress_entity.nemesis_ids:erase(k)
+			break
+		end
+	end
+
+	-- remove the old entity link and create new one to indicate former membership
+	hf.entity_links:insert("#", {new = df.histfig_entity_link_former_memberst, entity_id = fort_ent.id, link_strength = 100})
+	for k,v in pairs(hf.entity_links) do
+		if v._type == df.histfig_entity_link_memberst and v.entity_id == fort_ent.id then
+			hf.entity_links:erase(k)
+			break
+		end
+	end
+
+	-- try to find a new entity for the unit to join
+	for k,v in pairs(civ_ent.entity_links) do
+		if v.type == 1 and v.target ~= fort_ent.id then
+			newent_id = v.target
+			break
+		end
+	end
+
+	if newent_id > -1 then
+		hf.entity_links:insert("#", {new = df.histfig_entity_link_memberst, entity_id = newent_id, link_strength = 100})
+
+		-- try to find a new site for the unit to join
+		for k,v in pairs(df.global.world.entities.all[hf.civ_id].site_links) do
+			if v.type == 0 and v.target ~= site_id then
+				newsite_id = v.target
+				break
+			end
+		end
+
+		local newent = df.historical_entity.find(newent_id)
+		newent.histfig_ids:insert('#', hf_id)
+		newent.hist_figures:insert('#', hf)
+
+		local hf_event_id = df.global.hist_event_next_id
+		df.global.hist_event_next_id = df.global.hist_event_next_id+1
+		df.global.world.history.events:insert("#", {new = df.history_event_add_hf_entity_linkst, year = df.global.cur_year, seconds = df.global.cur_year_tick, id = hf_event_id, civ = newent_id, histfig = hf_id, link_type = 0})
+		if newsite_id > -1 then
+			local hf_event_id = df.global.hist_event_next_id
+			df.global.hist_event_next_id = df.global.hist_event_next_id+1
+			df.global.world.history.events:insert("#", {new = df.history_event_change_hf_statest, year = df.global.cur_year, seconds = df.global.cur_year_tick, id = hf_event_id, hfid = hf_id, state = 1, reason = -1, site = newsite_id})
+		end
+	end
+
+	print(line)
+	dfhack.gui.showAnnouncement(line, COLOR_WHITE)
 end
 
 function canLeave(unit)
@@ -55,12 +138,7 @@ function canLeave(unit)
         return false
     end
 
-    for _, skill in pairs(unit.status.current_soul.skills) do
-        if skill.rating > 14 then return false end
-    end
-
-    return dfhack.units.isOwnRace(unit) and  --  Doubtful check. naturalized citizens
-           dfhack.units.isOwnCiv(unit) and   --  might also want to leave.
+    return dfhack.units.isCitizen(unit) and
            dfhack.units.isActive(unit) and
            not dfhack.units.isOpposedToLife(unit) and
            not unit.flags1.merchant and
@@ -68,7 +146,6 @@ function canLeave(unit)
            not unit.flags1.chained and
            dfhack.units.getNoblePositions(unit) == nil and
            unit.military.squad_id == -1 and
-           dfhack.units.isCitizen(unit) and
            dfhack.units.isSane(unit) and
            not dfhack.units.isBaby(unit) and
            not dfhack.units.isChild(unit)
@@ -96,13 +173,15 @@ function checkmigrationnow()
         and not unit.flags1.tame
         then
             if unit.flags1.merchant then table.insert(merchant_civ_ids, unit.civ_id) end
-            if unit.flags1.diplomat then table.insert(diplomat_civ_ids, unit.civ_id) end
+            --if unit.flags1.diplomat then table.insert(diplomat_civ_ids, unit.civ_id) end
         end
     end
-
+    
+    if #merchant_civ_ids == 0 and #diplomat_civ_ids == 0 then
+        checkForDeserters('wild', df.global.ui.main.fortress_entity.entity_links[0].target)
+    end
     for _, civ_id in pairs(merchant_civ_ids) do checkForDeserters('merchant', civ_id) end
-    for _, civ_id in pairs(diplomat_civ_ids) do checkForDeserters('diplomat', civ_id) end
-    checkForDeserters('wild', -1)
+    --for _, civ_id in pairs(diplomat_civ_ids) do checkForDeserters('diplomat', civ_id) end
 end
 
 local function event_loop()
@@ -112,42 +191,17 @@ local function event_loop()
     end
 end
 
-dfhack.onStateChange[GLOBAL_KEY] = function(sc)
-    if sc == SC_MAP_UNLOADED then
-        enabled = false
-        return
+dfhack.onStateChange.loadEmigration = function(code)
+    if code==SC_MAP_LOADED then
+        if enabled then
+            print("Emigration enabled.")
+            event_loop()
+        else
+            print("Emigration disabled.")
+        end
     end
-
-    if sc ~= SC_MAP_LOADED or df.global.gamemode ~= df.game_mode.DWARF then
-        return
-    end
-
-    local persisted_data = json.decode(persist.GlobalTable[GLOBAL_KEY] or '')
-    enabled = (persisted_data or {enabled=false})['enabled']
-    event_loop()
 end
 
-if dfhack_flags.module then
-    return
+if dfhack.isMapLoaded() then
+    dfhack.onStateChange.loadEmigration(SC_MAP_LOADED)
 end
-
-if df.global.gamemode ~= df.game_mode.DWARF or not dfhack.isMapLoaded() then
-    dfhack.printerr('emigration needs a loaded fortress map to work')
-    return
-end
-
-local args = {...}
-if dfhack_flags and dfhack_flags.enable then
-    args = {dfhack_flags.enable_state and 'enable' or 'disable'}
-end
-
-if args[1] == "enable" then
-    enabled = true
-elseif args[1] == "disable" then
-    enabled = false
-else
-    return
-end
-
-event_loop()
-persist_state()

--- a/emigration.lua
+++ b/emigration.lua
@@ -44,7 +44,7 @@ function desert(u,method,civ)
         u.flags2.visitor = true
         u.animal.leave_countdown = 2
     end
-    
+
     local hf_id = u.hist_figure_id
     local hf = df.historical_figure.find(u.hist_figure_id)
     local fort_ent = df.global.ui.main.fortress_entity
@@ -52,7 +52,7 @@ function desert(u,method,civ)
 
     local newent_id = -1
     local newsite_id = -1
-    
+
     -- free owned rooms
     for i = #u.owned_buildings-1, 0, -1 do
         local temp_bld = df.building.find(u.owned_buildings[i].id)
@@ -121,7 +121,7 @@ function desert(u,method,civ)
             df.global.world.history.events:insert("#", {new = df.history_event_change_hf_statest, year = df.global.cur_year, seconds = df.global.cur_year_tick, id = hf_event_id, hfid = hf_id, state = 1, reason = -1, site = newsite_id})
         end
     end
-    
+
     print(line)
     dfhack.gui.showAnnouncement(line, COLOR_WHITE)
 end
@@ -167,7 +167,7 @@ function checkmigrationnow()
             if unit.flags1.merchant then table.insert(merchant_civ_ids, unit.civ_id) end
         end
     end
-    
+
     if #merchant_civ_ids == 0 then
         checkForDeserters('wild', df.global.ui.main.fortress_entity.entity_links[0].target)
     else


### PR DESCRIPTION
Followup to https://github.com/DFHack/dfhack/issues/1784#issuecomment-1566146480

Fix for emigration.lua not working since the citizenship logic was changed.

It works at least in 0.47.05, based on some testing by myself. It can be tested relatively easy with stress-inducing scripts, such as this one I created while testing this: https://github.com/wsfsbvchr/dfhack-utils/blob/main/stress-tests.lua

The 50.* version seems to have some different things in the plugin part of the script, so at least adding those might be necessary. Also the exact location of unit's stress has apparently changed?