### PR TITLE
[suspendmanager] Suspend blocking jobs when building high walls or filling corridors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ that repo.
 - `quickfort`: now handles zones, locations, stockpile configuration, hauling routes, and more
 - `suspendmanager`: now suspends construction jobs on top of floor designations, protecting the designations from being erased
 - `prioritize`: add wild animal management tasks and lever pulling to the default list of prioritized job types
+- `suspendmanager`: suspend jobs when building high walls or filling corridors
 
 ## Removed
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -25,7 +25,7 @@ that repo.
 - `quickfort`: now handles zones, locations, stockpile configuration, hauling routes, and more
 - `suspendmanager`: now suspends construction jobs on top of floor designations, protecting the designations from being erased
 - `prioritize`: add wild animal management tasks and lever pulling to the default list of prioritized job types
-- `suspendmanager`: suspend jobs when building high walls or filling corridors
+- `suspendmanager`: suspend blocking jobs when building high walls or filling corridors
 
 ## Removed
 

--- a/docs/suspendmanager.rst
+++ b/docs/suspendmanager.rst
@@ -9,8 +9,8 @@ This tool will watch your active jobs and:
 
 - unsuspend jobs that have become suspended due to inaccessible materials,
     items temporarily in the way, or worker dwarves getting scared by wildlife
-- suspend construction jobs that would prevent a dwarf from reaching an adjacent
-    construction job, such as when building a wall corner.
+- suspend most construction jobs that would prevent a dwarf from reaching another
+    construction job, such as when building a wall corner or high walls
 - suspend construction jobs on top of a smoothing, engraving or track carving
   designation. This prevents the construction job from being completed first,
   which would erase the designation.


### PR DESCRIPTION
Fixes https://github.com/DFHack/dfhack/issues/3049
Fixes https://github.com/DFHack/dfhack/issues/3157

Add a new suspension reason for suspendmanager, focused on improving situations such as building a high wall or filling a corridor. The detection works by finding a "dead end" (tile with a single walkable neighbour), and suspending any job that would prevent its access by following the "corridor" leading to it.

Note: I'm pretty sure it's doable to refine this detection and make it replace the fuzzy "risk based" detection, but all my previous attempts where far too complicated and unreliable, so keeping both for now seems like a good choice.