### PR TITLE
[quickfort] fix location generation

### DIFF
--- a/internal/quickfort/building.lua
+++ b/internal/quickfort/building.lua
@@ -96,7 +96,7 @@ local function flood_fill(ctx, grid, seen_cells, x, y, data, db, aliases)
     if data.db_entry then
         if data.db_entry.merge_fn then data.db_entry:merge_fn(db_entry) end
     else
-        data.db_entry = copyall(db_entry)
+        data.db_entry = db_entry
     end
     table.insert(data.cells, cell)
     seen_cells[cell] = true

--- a/internal/quickfort/notes.lua
+++ b/internal/quickfort/notes.lua
@@ -12,16 +12,24 @@ local log = quickfort_common.log
 
 function do_run(_, grid, ctx)
     local cells = quickfort_parse.get_ordered_grid_cells(grid)
-    local lines = {}
-    local prev_y = nil
+    local line, lines = {}, {}
+    local prev_x, prev_y = nil, nil
     for _,cell in ipairs(cells) do
-        if prev_y then
-            for dy = prev_y,cell.y-2 do
+        if prev_y ~= cell.y and #line > 0 then
+            table.insert(lines, table.concat(line, '    '))
+            for _ = prev_y or cell.y,cell.y-2 do
                 table.insert(lines, '')
             end
+            line = {}
         end
-        table.insert(lines, cell.text)
-        prev_y = cell.y
+        for _ = prev_x or cell.x,cell.x-2 do
+            table.insert(line, '    ')
+        end
+        table.insert(line, cell.text)
+        prev_x, prev_y = cell.x, cell.y
+    end
+    if #line > 0 then
+        table.insert(lines, table.concat(line, '    '))
     end
     table.insert(ctx.messages, table.concat(lines, '\n'))
 end

--- a/internal/quickfort/zone.lua
+++ b/internal/quickfort/zone.lua
@@ -353,9 +353,10 @@ local function set_location(zone, location, ctx)
         data.pos = copyall(site.pos)
         for _,entity_site_link in ipairs(site.entity_links) do
             local he = df.historical_entity.find(entity_site_link.entity_id)
-            if not he or he.type ~= df.historical_entity_type.SiteGovernment then goto continue end
-            data.site_owner_id = he.id
-            ::continue::
+            if he and he.type == df.historical_entity_type.SiteGovernment then
+                data.site_owner_id = he.id
+                break
+            end
         end
         site.buildings:insert('#', data)
         site.next_building_id = site.next_building_id + 1
@@ -364,10 +365,8 @@ local function set_location(zone, location, ctx)
         for flag, val in pairs(data.assign.flags) do
             bld.flags[flag] = val
         end
-        if data.flags then
-            for flag, val in pairs(data.flags) do
-                bld.flags[flag] = val
-            end
+        for flag, val in pairs(data.flags or {}) do
+            bld.flags[flag] = val
         end
         bld.contents.building_ids:insert('#', zone.id)
     end

--- a/internal/quickfort/zone.lua
+++ b/internal/quickfort/zone.lua
@@ -133,16 +133,6 @@ end
 -- we may want to offer full name aliases for the single letter ones above
 local aliases = {}
 
-local hospital_max_values = {
-    thread=1500000,
-    cloth=1000000,
-    splints=100,
-    crutches=100,
-    plaster=15000,
-    buckets=100,
-    soap=15000
-}
-
 local valid_locations = {
     tavern={new=df.abstract_building_inn_tavernst,
         assign={name={type=df.language_name_type.SymbolFood},
@@ -176,15 +166,6 @@ for _, v in pairs(valid_locations) do
     ensure_key(v.assign.name, 'parts_of_speech').resize = false
     v.assign.name.parts_of_speech.FirstAdjective = df.part_of_speech.Adjective
 end
-
-local location_occupations = {
-    tavern={df.occupation_type.TAVERN_KEEPER, df.occupation_type.PERFORMER},
-    hospital={df.occupation_type.DOCTOR, df.occupation_type.DIAGNOSTICIAN,
-              df.occupation_type.SURGEON, df.occupation_type.BONE_DOCTOR},
-    guildhall={},
-    library={},
-    temple={},
-}
 
 local prop_prefix = 'desired_'
 
@@ -226,7 +207,7 @@ local function parse_location_props(props)
                 local prop = props[short_prop]
                 props[short_prop] = nil
                 local val = tonumber(prop)
-                if not val or val ~= math.floor(val) or val < 0 then
+                if not val or val ~= math.floor(val) or val < 0 or val > 999 then
                     dfhack.printerr(('ignoring invalid %s value: "%s"'):format(short_prop, prop))
                     goto continue
                 end
@@ -366,20 +347,6 @@ local function set_location(zone, location, ctx)
     utils.assign(data, location.data)
     if not loc_id then
         loc_id = site.next_building_id
-        local occupations = df.global.world.occupations.all
-        for _,ot in ipairs(location_occupations[location.type]) do
-            local occ_id = df.global.occupation_next_id
-            occupations:insert('#', {
-                new=df.occupation,
-                id=occ_id,
-                type=ot,
-                location_id=loc_id,
-                site_id=site.id,
-            })
-            table.insert(ensure_key(data, 'occupations'), occupations[#occupations-1])
-            df.global.occupation_next_id = df.global.occupation_next_id + 1
-        end
-
         data.name = generate_name()
         data.id = loc_id
         data.site_id = site.id

--- a/internal/quickfort/zone.lua
+++ b/internal/quickfort/zone.lua
@@ -406,6 +406,8 @@ local function set_location(zone, location, ctx)
     end
     zone.site_id = site.id
     zone.location_id = loc_id
+    -- categorize the zone in the location vector
+    utils.insert_sorted(df.global.world.buildings.other.LOCATION_ASSIGNED, zone, 'id')
     if location.label then
         -- remember this location for future associations in this blueprint
         ensure_keys(ctx, 'zone', 'locations')[location.label] = loc_id

--- a/internal/quickfort/zone.lua
+++ b/internal/quickfort/zone.lua
@@ -384,8 +384,11 @@ local function create_zone(zone, data, ctx)
     local extents, ntiles =
             quickfort_building.make_extents(zone, ctx.dry_run)
     if ctx.dry_run then return ntiles end
-    local fields = {room={x=zone.pos.x, y=zone.pos.y, width=zone.width,
-                            height=zone.height, extents=extents}}
+    local fields = {
+        assigned_unit_id=-1,
+        room={x=zone.pos.x, y=zone.pos.y, width=zone.width, height=zone.height,
+            extents=extents},
+    }
     local bld, err = dfhack.buildings.constructBuilding{
         type=df.building_type.Civzone, subtype=data.type,
         abstract=true, pos=zone.pos, width=zone.width, height=zone.height,

--- a/internal/quickfort/zone.lua
+++ b/internal/quickfort/zone.lua
@@ -402,6 +402,7 @@ local function set_location(zone, location, ctx)
                 bld.flags[flag] = val
             end
         end
+        bld.contents.building_ids:insert('#', zone.id)
     end
     zone.site_id = site.id
     zone.location_id = loc_id


### PR DESCRIPTION
so dwarves actually use the locations for their intended purposes

also fixes a few bugs that came up in Dreamfort testing
- stop data from one blueprint entity from leaking into the parent database entry (e.g. a name assigned to one door could get assigned to *all* doors on the blueprint)
- remove unneeded occupation initialization. the game does this for us on first display
- bounds check the number of desired location items the same way the game does -- [0,999]
- initialize `assigned_unit_id` properly when no unit is assigned
- add missed reverse link for locations back to their component zones