### PR TITLE
[modtools/spawn-liquid] account for wonky interpretation of liquid type

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ that repo.
 ## Fixes
 - `gui/create-item`: allow blocks to be made out of wood when using the restrictive filters
 - `emigration`: reassign home site for emigrating units so they don't just come right back to the fort
+- `gui/liquids`: ensure tile temperature is set correctly when painting water or magma
 
 ## Misc Improvements
 - `gui/control-panel`: add some popular startup configuration commands for `autobutcher` and `autofarm`

--- a/modtools/spawn-liquid.lua
+++ b/modtools/spawn-liquid.lua
@@ -7,10 +7,11 @@ function resetTemperature(position)
   local map_block = dfhack.maps.getTileBlock(position)
   local tile = dfhack.maps.getTileFlags(position)
 
-  if tile.liquid_type == df.tile_liquid.Water or tile.flow_size == 0 then
+  -- tile.liquid_type is interpreted as a boolean; 0 (Water) is interpreted as false
+  if tile.liquid_type == false or tile.liquid_type == df.tile_liquid.Water or tile.flow_size == 0 then
     map_block.temperature_1[position.x % 16][position.y % 16] = 10015
     map_block.temperature_2[position.x % 16][position.y % 16] = 10015
-  elseif tile.liquid_type == df.tile_liquid.Magma then
+  elseif tile.liquid_type == true or tile.liquid_type == df.tile_liquid.Magma then
     map_block.temperature_1[position.x % 16][position.y % 16] = 12000
     map_block.temperature_2[position.x % 16][position.y % 16] = 12000
   end


### PR DESCRIPTION
The enum for water is interpreted as a boolean. can this be fixed in the structures? I vaguely remember that we tried that in the past and failed.