### PR TITLE
[workorder] modify existing orders if __reduce_amount is true

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ that repo.
 - `suspendmanager`: now suspends construction jobs on top of floor designations, protecting the designations from being erased
 - `prioritize`: add wild animal management tasks and lever pulling to the default list of prioritized job types
 - `suspendmanager`: suspend blocking jobs when building high walls or filling corridors
+- `workorder`: reduce existing orders for automatic shearing and milking jobs when animals are no longer available
 
 ## Removed
 - `gui/automelt`: replaced by an overlay panel that appears when you click on a stockpile

--- a/docs/workorder.rst
+++ b/docs/workorder.rst
@@ -73,5 +73,7 @@ Also:
   ``load(code)(order, orders)`` that must return an integer.
 
 A custom field ``__reduce_amount`` can be set if existing open orders should be
-taken into account, reducing the new order's ``total_amount`` (possibly all the
-way to ``0``). An empty ``amount_total`` implies ``"__reduce_amount": true``.
+taken into account. The first matching existing order will be modified to have
+the desired quantity remaining. If the desired quantity is negative, the
+existing order will be removed. An empty ``amount_total`` implies
+``"__reduce_amount": true``.


### PR DESCRIPTION
this solves the cancellation spam issue where autoMilk/autoShear jobs are queued, but then the animals are butchered.

It also keeps the manager orders cleaner by only having one job instead of many. Before, if you still had a milk order open, but a new animal became milkable, an additional milk job would be ordered in a new order. this could result in many 1/1 milk jobs appearing in the manager orders list.