### PR TITLE
[gui/sandbox] check specific flags instead of the graphics field

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ that repo.
 ## Fixes
 - `gui/create-item`: allow blocks to be made out of wood when using the restrictive filters
 - `emigration`: reassign home site for emigrating units so they don't just come right back to the fort
+- `gui/sandbox`: allow creatures that have separate caste-based graphics to be spawned (like ewes/rams)
 - `gui/liquids`: ensure tile temperature is set correctly when painting water or magma
 
 ## Misc Improvements

--- a/gui/sandbox.lua
+++ b/gui/sandbox.lua
@@ -346,7 +346,9 @@ local function init_arena()
     arena_unit.castes_all:resize(0)
     local arena_creatures = {}
     for i, cre in ipairs(RAWS.creatures.all) do
-        if not cre.flags.VERMIN_GROUNDER and not cre.flags.VERMIN_SOIL and cre.graphics then
+        if not cre.flags.VERMIN_GROUNDER and not cre.flags.VERMIN_SOIL
+            and not cre.flags.DOES_NOT_EXIST and not cre.flags.EQUIPMENT_WAGON
+        then
             table.insert(arena_creatures, {race=i, cre=cre})
         end
     end


### PR DESCRIPTION
checking `graphics` is not a reliable metric. checking specific flags allows the following races to be spawned:

```
BIRD_OSTRICH
OSTRICH MAN
SHEEP
BIRD_CHICKEN
BIRD_DUCK
BIRD_PEAFOWL_BLUE
DEER
DEER_MAN
MOOSE
MOOSE MAN
LION
LION_MAN
GIANT_LION
ELK
ELK_MAN
```

Fixes DFHack/dfhack#3445