### PR TITLE
[combine] reduce max stack sizes in containers to 30

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -35,6 +35,7 @@ that repo.
 - `gui/quickfort`: protect against meta blueprints recursing infinitely if they include themselves
 - `gui/quickfort`: adapt "cursor lock" to mouse controls so it's easier to see the full preview for multi-level blueprints before you apply them
 - `gui/quickfort`: only display post-blueprint messages once when repeating the blueprint up or down z-levels
+- `combine`: reduce default max stack sizes in containers to 30
 
 ## Removed
 - `gui/automelt`: replaced by an overlay panel that appears when you click on a stockpile

--- a/combine.lua
+++ b/combine.lua
@@ -16,8 +16,8 @@ local opts, args = {
 -- default max stack size of 30
 local MAX_ITEM_STACK=30
 local MAX_AMMO_STACK=25
-local MAX_CONT_ITEMS=500
-local MAX_MAT_AMT=500
+local MAX_CONT_ITEMS=30
+local MAX_MAT_AMT=30
 
 -- list of types that use race and caste
 local typesThatUseCreatures = utils.invert{'REMAINS', 'FISH', 'FISH_RAW', 'VERMIN', 'PET', 'EGG', 'CORPSE', 'CORPSEPIECE'}


### PR DESCRIPTION
this might be a fair compromise until we get better measurements of container capacities. It will still allow stacks to automatically "float" to the "natural" maximum