### PR TITLE
devel/export-dt-ini: rename `game_extra` global back to `game`

### DIFF
--- a/devel/export-dt-ini.lua
+++ b/devel/export-dt-ini.lua
@@ -129,7 +129,7 @@ address('historical_figures_vector',globals,'world','history','figures')
 address('world_site_type',df.world_site,'type')
 address('active_sites_vector',df.world_data,'active_site')
 address('gview',globals,'gview')
-address('external_flag',globals,'game_extra','external_flag')
+address('external_flag',globals,'game','external_flag')
 vtable('viewscreen_setupdwarfgame_vtable','viewscreen_setupdwarfgamest')
 
 header('offsets')


### PR DESCRIPTION
Changed in 50.08-r2

Codedependent on Discord reports that this is enough to make the script work. I haven't tested it myself.