### PR TITLE
[suspendmanager] Don't suspend construction on unwalkable tiles

### DIFF
--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -252,6 +252,9 @@ local function riskBlocking(job)
     --- job.pos is sometimes off by one, get the building pos
     local pos = {x=building.centerx,y=building.centery,z=building.z}
 
+    -- The construction is on a non walkable tile, it can't get worst
+    if not walkable(pos) then return false end
+
     --- Get self risk of being blocked
     local risk = riskOfStuckConstructionAt(pos)
 


### PR DESCRIPTION
When a construction is located on a non walkable tile (typically open air), it's never at risk of blocking other, as it can't get worst. Skip them in from the RISK_BLOCKING suspension reason.

Fixes [#3491](https://github.com/DFHack/dfhack/issues/3491)
