### PR TITLE
[suspendmanager] Take in account already built buildings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,8 @@ that repo.
 
 ## Fixes
 
+- `suspendmanager`: take in account already built blocking buildings
+
 ## Misc Improvements
 
 ## Removed

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -206,7 +206,13 @@ local function walkable(pos)
     end
     local attrs = df.tiletype.attrs[tt]
     local shape_attrs = df.tiletype_shape.attrs[attrs.shape]
-    return shape_attrs.walkable
+
+    if not shape_attrs.walkable then
+        return false
+    end
+
+    local building = dfhack.buildings.findAtTile(pos)
+    return not building or not building.flags.exists or not isImpassable(building)
 end
 
 --- List neighbour coordinates of a position


### PR DESCRIPTION
When a wall is built, the shape of the tile changes to one that is not walkable. However, when other unpassable buildings are created such as windows or statues, the shape of the tile does not change. In this case, `suspendmanager` then fails to recognize risky tiles and does not behave correctly. This PR fixes this by also reading the building on the tile.

Before:
![image](https://github.com/DFHack/scripts/assets/630159/161c0f68-6565-4acb-8263-062b5f012f97)

After:
![image](https://github.com/DFHack/scripts/assets/630159/c3095be0-718f-4502-847c-9c27603adf99)
