### PR TITLE
[suspendmanager] Don't consider branches suitable to access a build

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ that repo.
 - `gui/autodump`: when "include items claimed by jobs" is on, actually cancel the job so the item can be teleported
 - `gui/gm-unit`: fix commandline processing when a unit id is specified
 - `suspendmanager`: take in account already built blocking buildings
+- `suspendmanager`: don't consider branches as a suitable access to a build
 
 ## Misc Improvements
 

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -205,6 +205,12 @@ local function walkable(pos)
         return false
     end
     local attrs = df.tiletype.attrs[tt]
+
+    if attrs.shape == df.tiletype_shape.BRANCH or attrs.shape == df.tiletype_shape.TRUNK_BRANCH then
+        -- Branches can be walked on, but most of the time we can assume that it's not a suitable access.
+        return false
+    end
+
     local shape_attrs = df.tiletype_shape.attrs[attrs.shape]
 
     if not shape_attrs.walkable then


### PR DESCRIPTION
When looking at walkable tiles, consider that branches are not. Even though dwarves can stand on it (or under pressure climb to it), most of the time they cannot use them to access a build.

Before:
![image](https://github.com/DFHack/scripts/assets/630159/31b49ff9-6ba7-4751-bd1b-489905544ee9)

After:
![image](https://github.com/DFHack/scripts/assets/630159/aff024d0-aeb9-4439-a0f2-b5f55f0821e3)
