### PR TITLE
[cleanup] Remove redundant checks for opentiles

### DIFF
--- a/build-now.lua
+++ b/build-now.lua
@@ -176,11 +176,8 @@ local function is_good_dump_pos(pos)
     local shape_attrs = df.tiletype_shape.attrs[attrs.shape]
     -- reject hidden tiles
     if flags.hidden then return false, false end
-    -- reject unwalkable or open tiles
+    -- reject unwalkable tiles
     if not shape_attrs.walkable then return false, false end
-    if shape_attrs.basic_shape == df.tiletype_shape_basic.Open then
-        return false, false
-    end
     -- reject footprints within other buildings. this could potentially be
     -- relaxed a bit since we can technically dump items on passable tiles
     -- within other buildings, but that would look messy.

--- a/deep-embark.lua
+++ b/deep-embark.lua
@@ -65,11 +65,7 @@ function isValidTiletype(tiletype)
     end
   end
   local shapeAttrs = df.tiletype_shape.attrs[tiletypeAttrs.shape]
-  if shapeAttrs.walkable and shapeAttrs.basic_shape ~= df.tiletype_shape_basic.Open then -- downward ramps are walkable but open; units placed here would fall
-    return true
-  else
-    return false
-  end
+  return shapeAttrs.walkable
 end
 
 function getValidEmbarkTiles(block)

--- a/modtools/create-unit.lua
+++ b/modtools/create-unit.lua
@@ -396,7 +396,7 @@ function isValidSpawnLocation(pos, locationType)
     end
     return false
   elseif locationType == 'Walkable' then
-    if tileShapeAttrs.walkable and tileShapeAttrs.basic_shape ~= df.tiletype_shape_basic.Open then
+    if tileShapeAttrs.walkable then
       return true
     end
     return false


### PR DESCRIPTION
Follow-up to https://github.com/DFHack/df-structures/pull/612
First half for fixing https://github.com/DFHack/dfhack/issues/3526

Since the semantic change in the structure PR, "walkable" is equivalent to "able to stand on". Many tools had this check written as "not an open tile", which is now redundant with the "walkable" attribute. Remove the redundant checks.

Note: I've only tested deep-embark with these changes, but I think it's quite safe