### PR TITLE
suspendmanager job overlay

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ that repo.
 
 ## Misc Improvements
 - `gui/unit-syndromes`: make lists searchable
+- `suspendmanager`: display the suspension reason
 
 ## Removed
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -25,7 +25,7 @@ that repo.
 
 ## Misc Improvements
 - `gui/unit-syndromes`: make lists searchable
-- `suspendmanager`: display the suspension reason
+- `suspendmanager`: display the suspension reason when viewing a suspended building
 
 ## Removed
 

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -581,7 +581,7 @@ end
 function StatusOverlay:get_status_string()
     local job = dfhack.gui.getSelectedJob()
     if job and job.flags.suspend then
-        return "Suspended because: " .. Instance:suspensionDescription(job) or "External interruption" .. "."
+        return "Suspended because: " .. Instance:suspensionDescription(job) .. "."
     end
     return "Not suspended."
 end

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -404,11 +404,6 @@ function SuspendManager:suspensionDescription(job)
     end
     local reason = self.suspensions[job.id]
     return reason and REASON_DESCRIPTION[reason] or "External interruption"
---    if not reason then
---        return "External Interruption"
---    end
---
---    return REASON_DESCRIPTION[reason] or "External Interruption"
 end
 
 --- Recompute the list of suspended jobs

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -397,7 +397,7 @@ function SuspendManager:shouldStaySuspended(job)
 end
 
 --- Return a human readable description of why suspendmanager keeps a job suspended
---- or nil if the job is not kept suspended
+--- or "External interruption" if the job is not kept suspended by suspendmanager
 function SuspendManager:suspensionDescription(job)
     local reason = self.suspensions[job.id]
     return reason and REASON_DESCRIPTION[reason] or "External interruption"
@@ -581,7 +581,7 @@ end
 function StatusOverlay:get_status_string()
     local job = dfhack.gui.getSelectedJob()
     if job and job.flags.suspend then
-        return "Suspended because: " .. Instance:suspensionDescription(job) .. "."
+        return "Suspended because: " .. Instance:suspensionDescription(job) or "External interruption" .. "."
     end
     return "Not suspended."
 end

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -51,7 +51,7 @@ REASON_TEXT = {
 --- suspend jobs
 REASON_DESCRIPTION = {
     [REASON.RISK_BLOCKING] = 'May block another build job',
-    [REASON.ERASE_DESIGNATION] = 'Waiting for carve/smooth/engrave on same tile',
+    [REASON.ERASE_DESIGNATION] = 'Waiting for carve/smooth/engrave',
     [REASON.DEADEND] = 'Blocks another build job'
 }
 

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -47,8 +47,8 @@ REASON_TEXT = {
 }
 
 --- Description of suspension
---- This should likely not include description for any of the external
---- reasons
+--- This only cover the reason where suspendmanager actively
+--- suspend jobs
 REASON_DESCRIPTION = {
     [REASON.RISK_BLOCKING] = 'Risk blocking another',
     [REASON.ERASE_DESIGNATION] = 'On a tile designation',
@@ -390,6 +390,8 @@ function SuspendManager:shouldStaySuspended(job)
     return self.suspensions[job.id]
 end
 
+--- Return a human readable description of why suspendmanager keeps a job suspended
+--- or nil if the job is not kept suspended
 function SuspendManager:suspensionDescription(job)
     if not job then
         return nil

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -399,9 +399,6 @@ end
 --- Return a human readable description of why suspendmanager keeps a job suspended
 --- or nil if the job is not kept suspended
 function SuspendManager:suspensionDescription(job)
-    if not job then
-        return ''
-    end
     local reason = self.suspensions[job.id]
     return reason and REASON_DESCRIPTION[reason] or "External interruption"
 end

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -588,7 +588,7 @@ end
 
 function StatusOverlay:render(dc)
     local job = dfhack.gui.getSelectedJob()
-    if not job or not isEnabled() or isBuildingPlanJob(job) then
+    if not job or job.job_type ~= df.job_type.ConstructBuilding or not isEnabled() or isBuildingPlanJob(job) then
         return
     end
     StatusOverlay.super.render(self, dc)
@@ -620,7 +620,7 @@ end
 
 function ToggleOverlay:render(dc)
     local job = dfhack.gui.getSelectedJob()
-    if not job or isBuildingPlanJob(job) then
+    if not job or job.job_type ~= df.job_type.ConstructBuilding or isBuildingPlanJob(job) then
         return
     end
     -- Update the option: the "initial_option" value is not up to date since the widget


### PR DESCRIPTION
Add a job overlay to `suspendmanager`. When suspendmanager is enabled, it hides the "Suspend/Resume construction" button with a text overlay and include the toggle for enabling and disabling `suspendmanager`. This overlay either explains why the job is suspended or simply indicate that it is not suspended.

The reason for overlaying the button is that once enabled, suspendmanager will not take in account anymore any choice that the player makes here. This overlay makes this explicit, while providing feedback on its choice and a way to act on it.

![image](https://github.com/DFHack/scripts/assets/630159/b51dd87c-02a0-4769-a77b-69b1bc1dc31c)

![image](https://github.com/DFHack/scripts/assets/630159/d717a56b-332d-43bc-b552-42113d869be5)

![image](https://github.com/DFHack/scripts/assets/630159/0ba87a50-5a1f-4069-afed-0c476c80d192)

![image](https://github.com/DFHack/scripts/assets/630159/21b632fb-bf17-441c-a645-560ff2666746)

No overlay at all for buildingplan jobs in the waiting list.

Fixes https://github.com/DFHack/dfhack/issues/3413
