### PR TITLE
Use a separate icon for jobs suspended by suspendmanager

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ that repo.
 ## Fixes
 
 ## Misc Improvements
+- `suspendmanager`: display a different color for jobs suspended by suspendmanager
 
 ## Removed
 

--- a/docs/unsuspend.rst
+++ b/docs/unsuspend.rst
@@ -39,6 +39,8 @@ buildings:
 - A clock icon (green ``P`` in ASCII mode) indicates that the building is still
   in planning mode and is waiting on materials. The `buildingplan` plugin will
   unsuspend it for you when those materials become available.
+- A white ``x`` means that the building is maintained suspended by
+  `suspendmanager`, selecting it will provide a reason for the suspension
 - A yellow ``x`` means that the building is suspended. If you don't have
   `suspendmanager` managing suspensions for you, you can unsuspend it
   manually or with the `unsuspend` command.

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -92,6 +92,17 @@ function preventBlockingEnabled()
     return Instance.preventBlocking
 end
 
+--- Returns true if the job is maintained suspended by suspendmanager
+---@param job job
+function isKeptSuspended(job)
+    if not isEnabled() or not preventBlockingEnabled() then
+        return false
+    end
+
+    local reason = Instance.suspensions[job.id]
+    return reason and not EXTERNAL_REASONS[reason]
+end
+
 local function persist_state()
     persist.GlobalTable[GLOBAL_KEY] = json.encode({
         enabled=enabled,

--- a/unsuspend.lua
+++ b/unsuspend.lua
@@ -143,9 +143,9 @@ local function get_texposes()
         return valid and start + offset or nil
     end
 
-    return tp(3), tp(1), tp(0)
+    return tp(3), tp(2), tp(1), tp(0)
 end
-local PLANNED_TEXPOS, SUSPENDED_TEXPOS, REPEAT_SUSPENDED_TEXPOS = get_texposes()
+local PLANNED_TEXPOS, KEPT_SUSPENDED_TEXTPOS, SUSPENDED_TEXPOS, REPEAT_SUSPENDED_TEXPOS = get_texposes()
 
 function SuspendOverlay:render_marker(dc, bld, screen_pos)
     if not bld or #bld.jobs ~= 1 then return end
@@ -159,6 +159,8 @@ function SuspendOverlay:render_marker(dc, bld, screen_pos)
     local color, ch, texpos = COLOR_YELLOW, 'x', SUSPENDED_TEXPOS
     if buildingplan and buildingplan.isPlannedBuilding(bld) then
         color, ch, texpos = COLOR_GREEN, 'P', PLANNED_TEXPOS
+    elseif suspendmanager and suspendmanager.isKeptSuspended(job) then
+        color, ch, texpos = COLOR_WHITE, 'x', KEPT_SUSPENDED_TEXTPOS
     elseif data.suspend_count > 1 then
         color, ch, texpos = COLOR_RED, 'X', REPEAT_SUSPENDED_TEXPOS
     end


### PR DESCRIPTION
Use the new icon for jobs suspended by suspendmanager, to make them less attention grabbing and create an easier to read global situation when there are jobs that are actually in need of attention (transient or repetitive issues).

![image](https://github.com/DFHack/scripts/assets/630159/6de01030-1af2-4db9-b4cd-1a575a36510a)

![image](https://github.com/DFHack/scripts/assets/630159/1c0a97f7-86ae-42f5-be44-96379489655d)

Needs [#3602](https://github.com/DFHack/dfhack/pull/3602)
Fixes [#3554](https://github.com/DFHack/dfhack/issues/3554)