### PR TITLE
devel/lsmem: add filtering capabilities

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ that repo.
 - `suspendmanager`: Fix the overlay enabling/disabling `suspendmanager` unexpectedly
 
 ## Misc Improvements
+- `devel/lsmem`: added support for filtering by memory addresses and filenames
 - `suspendmanager`: display a different color for jobs suspended by suspendmanager
 
 ## Removed

--- a/devel/lsmem.lua
+++ b/devel/lsmem.lua
@@ -8,6 +8,39 @@ valid, whether a certain library/plugin is loaded, etc.
 
 ]====]
 
+function range_contains_any(range, addrs)
+    for _, a in ipairs(addrs) do
+        if a >= range.start_addr and a < range.end_addr then
+            return true
+        end
+    end
+    return false
+end
+
+function range_name_match_any(range, names)
+    for _, n in ipairs(names) do
+        if range.name:lower():find(n, 1, true) or range.name:lower():find(n) then
+            return true
+        end
+    end
+    return false
+end
+
+local args = {...}
+local filter_addrs = {}
+local filter_names = {}
+for _, arg in ipairs(args) do
+    if arg:lower():startswith('0x') then
+        arg = arg:sub(3)
+    end
+    local addr = tonumber(arg, 16)
+    if addr then
+        table.insert(filter_addrs, addr)
+    else
+        table.insert(filter_names, arg:lower())
+    end
+end
+
 for _,v in ipairs(dfhack.internal.getMemRanges()) do
     local access = { '-', '-', '-', 'p' }
     if v.read then access[1] = 'r' end
@@ -18,5 +51,9 @@ for _,v in ipairs(dfhack.internal.getMemRanges()) do
     elseif v.shared then
         access[4] = 's'
     end
-    print(string.format('%08x-%08x %s %s', v.start_addr, v.end_addr, table.concat(access), v.name))
+    if (#filter_addrs == 0 or range_contains_any(v, filter_addrs)) and
+        (#filter_names == 0 or range_name_match_any(v, filter_names))
+    then
+        print(string.format('%08x-%08x %s %s', v.start_addr, v.end_addr, table.concat(access), v.name))
+    end
 end

--- a/docs/devel/lsmem.rst
+++ b/docs/devel/lsmem.rst
@@ -3,7 +3,7 @@ devel/lsmem
 
 .. dfhack-tool::
     :summary: Print memory ranges of the DF process.
-    :tags: unavailable dev
+    :tags: dev
 
 Useful for checking whether a pointer is valid, whether a certain library/plugin
 is loaded, etc.
@@ -13,4 +13,18 @@ Usage
 
 ::
 
-    devel/lsmem
+    devel/lsmem [<address> ...] [<name|pattern> ...]
+
+Examples
+--------
+
+``devel/lsmem 0x1234 5678 90ab``
+    List any ranges containing the addresses ``0x1234``, ``0x5678``, or ``0x90ab``.
+    Addresses are interpreted as hex; the ``0x`` prefix is optional.
+
+``devel/lsmem dwarf g_src``
+    List any ranges corresponding to files matching ``dwarf`` or ``g_src``
+    (case-insensitive).
+
+``devel/lsmem .+``
+    List any ranges with non-empty filenames. Any Lua patterns are allowed.


### PR DESCRIPTION
It's now possible to list ranges containing a given address, or ranges matching a given filename.

Also mark the script as available.
