### PR TITLE
suspendmanager: improve detection on "T" and "+" shapes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@ Template for new versions:
 - `suspendmanager`: Fix the overlay enabling/disabling `suspendmanager` unexpectedly
 - `caravan`: Correct price adjustment values in trade agreement details screen
 - `caravan`: Apply both import and export trade agreement price adjustments to items being both bought or sold to align with how vanilla DF calculates prices
+- `suspendmanager`: Improve the detection on "T" and "+" shaped high walls
 
 ## Misc Improvements
 - `devel/lsmem`: added support for filtering by memory addresses and filenames


### PR DESCRIPTION
On any "corridor" shape with a branching, suspendmanager currently fails to detect that it was about to be enclosed. This was pleasantly fixable by storing the building leading to a dead-end, and keeping this list across the various dead-end detections. This way, on a T shape, the first pass of either of the two extremities will suspend the extremity branch as before, but the second pass now suspends the remainder of the shape since it does not any more consider the first dead-end as an exit candidate.

Before:
![image](https://github.com/DFHack/scripts/assets/630159/92667866-3b03-4a18-83e3-5b05abc69c92)

The corridor leading to the shape is not suspended, and the shape will not be properly finished

After:
![image](https://github.com/DFHack/scripts/assets/630159/39f821a1-547b-4a2e-9049-8b0971fdfcd7)

Only the actual extremities of the shape are allowed to be built.

Fixes [#3548](https://github.com/DFHack/dfhack/issues/3548)
