### PR TITLE
Make `workorder-recheck` work again

### DIFF
--- a/docs/workorder-recheck.rst
+++ b/docs/workorder-recheck.rst
@@ -3,13 +3,13 @@ workorder-recheck
 
 .. dfhack-tool::
     :summary: Recheck start conditions for a manager workorder.
-    :tags: unavailable fort workorders
+    :tags: fort workorders
 
-Sets the status to ``Checking`` (from ``Active``) of the selected work order (in
-the ``j-m`` or ``u-m`` screens). This makes the manager reevaluate its
-conditions. This is especially useful for an order that had its conditions met
-when it was started, but the requisite items have since disappeared and the
-workorder is now generating job cancellation spam.
+Sets the status to ``Checking`` (from ``Active``) of the selected work order.
+This makes the manager reevaluate its conditions. This is especially useful
+for an order that had its conditions met when it was started, but the requisite
+items have since disappeared and the workorder is now generating job cancellation
+spam.
 
 Usage
 -----

--- a/workorder-recheck.lua
+++ b/workorder-recheck.lua
@@ -1,11 +1,4 @@
 -- Resets the selected work order to the `Checking` state
---[====[
-
-workorder-recheck
-=================
-Sets the status to ``Checking`` (from ``Active``) of the selected work order.
-This makes the manager reevaluate its conditions.
-]====]
 
 --@ module = true
 

--- a/workorder-recheck.lua
+++ b/workorder-recheck.lua
@@ -15,6 +15,12 @@ local function set_current_inactive()
     end
 end
 
+local function is_current_active()
+    local scrConditions = df.global.game.main_interface.info.work_orders.conditions
+    local order = scrConditions.wq
+    return order.status.active
+end
+
 -- -------------------
 -- RecheckOverlay
 --
@@ -26,7 +32,8 @@ RecheckOverlay.ATTRS{
     default_pos={x=6,y=8},
     default_enabled=true,
     viewscreens=focusString,
-    frame={w=19, h=3},
+    -- width is the sum of lengths of `[` + `Ctrl+A` + `: ` + button.label + `]`
+    frame={w=1 + 6 + 2 + 16 + 1, h=3},
 }
 
 local function areTabsInTwoRows()
@@ -55,9 +62,10 @@ function RecheckOverlay:init()
         widgets.TextButton{
             view_id = 'button',
             -- frame={t=0, l=0, r=0, h=1}, -- is set in `updateTextButtonFrame()`
-            label='recheck',
+            label='request re-check',
             key='CUSTOM_CTRL_A',
             on_activate=set_current_inactive,
+            enabled=is_current_active,
         },
     }
 

--- a/workorder-recheck.lua
+++ b/workorder-recheck.lua
@@ -27,8 +27,6 @@ RecheckOverlay.ATTRS{
     default_enabled=true,
     viewscreens=focusString,
     frame={w=19, h=3},
-    -- frame_style=gui.MEDIUM_FRAME,
-    -- frame_background=gui.CLEAR_PEN,
 }
 
 local function areTabsInTwoRows()

--- a/workorder-recheck.lua
+++ b/workorder-recheck.lua
@@ -76,7 +76,7 @@ function RecheckOverlay:onRenderBody(dc)
         end
     end
 
-    RecheckOverlay.super.onRenderBody(dc)
+    RecheckOverlay.super.onRenderBody(self, dc)
 end
 
 -- -------------------

--- a/workorder-recheck.lua
+++ b/workorder-recheck.lua
@@ -2,7 +2,6 @@
 
 --@ module = true
 
-local gui = require('gui')
 local widgets = require('gui.widgets')
 local overlay = require('plugins.overlay')
 
@@ -24,23 +23,60 @@ local focusString = 'dwarfmode/Info/WORK_ORDERS/Conditions'
 
 RecheckOverlay = defclass(RecheckOverlay, overlay.OverlayWidget)
 RecheckOverlay.ATTRS{
-    default_pos={x=6,y=2},
+    default_pos={x=6,y=8},
     default_enabled=true,
     viewscreens=focusString,
-    frame={w=17, h=3},
-    frame_style=gui.MEDIUM_FRAME,
-    frame_background=gui.CLEAR_PEN,
+    frame={w=19, h=3},
+    -- frame_style=gui.MEDIUM_FRAME,
+    -- frame_background=gui.CLEAR_PEN,
 }
+
+local function areTabsInTwoRows()
+    -- get the tile above the order status icon
+    local pen = dfhack.screen.readTile(7, 7, false)
+    -- in graphics mode, `0` when one row, something else when two (`67` aka 'C' from "Creatures")
+    -- in ASCII mode, `32` aka ' ' when one row, something else when two (`196` aka '-' from tab frame's top)
+    return (pen.ch ~= 0 and pen.ch ~= 32)
+end
+
+function RecheckOverlay:updateTextButtonFrame()
+    local twoRows = areTabsInTwoRows()
+    if (self._twoRows == twoRows) then return false end
+
+    self._twoRows = twoRows
+    local frame = twoRows
+            and {b=0, l=0, r=0, h=1}
+            or  {t=0, l=0, r=0, h=1}
+    self.subviews.button.frame = frame
+
+    return true
+end
 
 function RecheckOverlay:init()
     self:addviews{
-        widgets.HotkeyLabel{
-            frame={t=0, l=0},
+        widgets.TextButton{
+            view_id = 'button',
+            -- frame={t=0, l=0, r=0, h=1}, -- is set in `updateTextButtonFrame()`
             label='recheck',
             key='CUSTOM_CTRL_A',
             on_activate=set_current_inactive,
         },
     }
+
+    self:updateTextButtonFrame()
+end
+
+function RecheckOverlay:onRenderBody(dc)
+    if (self.frame_rect.y1 == 7) then
+        -- only apply this logic if the overlay is on the same row as
+        -- originally thought: just above the order status icon
+
+        if self:updateTextButtonFrame() then
+            self:updateLayout()
+        end
+    end
+
+    RecheckOverlay.super.onRenderBody(dc)
 end
 
 -- -------------------
@@ -53,7 +89,7 @@ if dfhack_flags.module then
     return
 end
 
--- Check if on correct screen and perform the action if so
+-- Check if on the correct screen and perform the action if so
 if not dfhack.gui.matchFocusString(focusString) then
     qerror('workorder-recheck must be run from the manager order conditions view')
 end


### PR DESCRIPTION
This repairs the `workorder-recheck.lua` script and adds an overlay to the work order conditions screen.

![image](https://github.com/DFHack/scripts/assets/348150/3b94e328-3435-4a56-bba7-e7ee683452f8)
