### PR TITLE
[fix/retrieve-units] prevent unit from being added to active vector twice

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -39,6 +39,7 @@ Template for new versions:
 - `caravan`: Apply both import and export trade agreement price adjustments to items being both bought or sold to align with how vanilla DF calculates prices
 - `suspendmanager`: Improve the detection on "T" and "+" shaped high walls
 - `starvingdead`: ensure sieges end properly when undead siegers starve
+- `fix/retrieve-units`: fix retrieved units sometimes becoming duplicated on the map
 
 ## Misc Improvements
 - `devel/lsmem`: added support for filtering by memory addresses and filenames

--- a/docs/fix/retrieve-units.rst
+++ b/docs/fix/retrieve-units.rst
@@ -15,8 +15,8 @@ forces them to enter. This can fix issues such as:
 
 .. note::
     For caravans that are missing entirely, this script may retrieve the
-    merchants but not the items. Using `fix/stuck-merchants` followed by `force`
-    to create a new caravan may work better.
+    merchants but not the items. Using `fix/stuck-merchants` to dismiss the
+    caravan followed by `force Caravan` to create a new one may work better.
 
 Usage
 -----

--- a/docs/fix/retrieve-units.rst
+++ b/docs/fix/retrieve-units.rst
@@ -16,7 +16,7 @@ forces them to enter. This can fix issues such as:
 .. note::
     For caravans that are missing entirely, this script may retrieve the
     merchants but not the items. Using `fix/stuck-merchants` to dismiss the
-    caravan followed by `force Caravan` to create a new one may work better.
+    caravan followed by ``force Caravan`` to create a new one may work better.
 
 Usage
 -----

--- a/fix/retrieve-units.lua
+++ b/fix/retrieve-units.lua
@@ -3,26 +3,6 @@
 -- http://www.bay12forums.com/smf/index.php?topic=163671.0
 --@ module = true
 
---[====[
-
-fix/retrieve-units
-==================
-
-This script forces some units off the map to enter the map, which can fix issues
-such as the following:
-
-- Stuck [SIEGE] tags due to invisible armies (or parts of armies)
-- Forgotten beasts that never appear
-- Packs of wildlife that are missing from the surface or caverns
-- Caravans that are partially or completely missing.
-
-.. note::
-    For caravans that are missing entirely, this script may retrieve the
-    merchants but not the items. Using `fix/stuck-merchants` followed by `force`
-    to create a new caravan may work better.
-
-]====]
-
 local utils = require('utils')
 
 function shouldRetrieve(unit)
@@ -49,7 +29,9 @@ function retrieveUnits()
             unit.flags1.can_swap = true
             unit.flags1.hidden_in_ambush = false
             -- add to active if missing
-            utils.insert_sorted(df.global.world.units.active, unit, 'id')
+            if not utils.linear_index(df.global.world.units.active, unit, 'id') then
+                df.global.world.units.active:insert('#', unit)
+            end
         end
     end
 end


### PR DESCRIPTION
Fixes DFHack/dfhack#3512