### PR TITLE
[gui/launcher, gui/gm-editor] recover gracefully when saved frame positions are offscreen

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -39,6 +39,7 @@ Template for new versions:
 - `caravan`: Apply both import and export trade agreement price adjustments to items being both bought or sold to align with how vanilla DF calculates prices
 - `suspendmanager`: Improve the detection on "T" and "+" shaped high walls
 - `starvingdead`: ensure sieges end properly when undead siegers starve
+- `gui/launcher`, `gui/gm-editor`: recover gracefully when the saved frame position is now offscreen
 
 ## Misc Improvements
 - `devel/lsmem`: added support for filtering by memory addresses and filenames

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -113,6 +113,12 @@ end
 function GmEditorUi:init(args)
     if not next(self.frame) then
         self.frame = {w=80, h=50}
+    else
+        for k,v in pairs(self.frame) do
+            if v < 0 then
+                self.frame[k] = 0
+            end
+        end
     end
 
     -- don't appear directly over the current window

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -43,6 +43,7 @@ end
 
 -- removes duplicate existing history lines and adds the given line to the front
 local function add_history(hist, hist_set, line)
+    line = line:trim()
     if hist_set[line] then
         for i,v in ipairs(hist) do
             if v == line then
@@ -586,6 +587,12 @@ function LauncherUI:init(args)
             new_frame = config.data
             if not next(new_frame) then
                 new_frame = {w=110, h=36}
+            else
+                for k,v in pairs(new_frame) do
+                    if v < 0 then
+                        new_frame[k] = 0
+                    end
+                end
             end
         end
         main_panel.frame = new_frame


### PR DESCRIPTION
this comes up when you set a frame position, resize the DF window by a lot, then bring up the tool again.