### PR TITLE
[quickfort] cancel old dig jobs when tile designation is changed

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -43,6 +43,7 @@ Template for new versions:
 - `suspendmanager`: Improve the detection on "T" and "+" shaped high walls
 - `starvingdead`: ensure sieges end properly when undead siegers starve
 - `fix/retrieve-units`: fix retrieved units sometimes becoming duplicated on the map
+- `quickfort`: cancel old dig jobs that point to a tile when a new designation is applied to the tile
 - `gui/launcher`, `gui/gm-editor`: recover gracefully when the saved frame position is now offscreen
 
 ## Misc Improvements


### PR DESCRIPTION
When applying a blueprint over existing designations, or when undoing a blueprint, any designations that have been converted into jobs will still be "alive". so if you used to have a channel designation and you convert it to a stairs designation with a blueprint, a dwarf could come by and dig a channel anyway. This PR clears out designation-related jobs associated with the tiles that are being modified.

Depends on DFHack/dfhack/#3713