### PR TITLE
[gui/quickfort] close dialog with ctrl-D instead of left arrow

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -52,6 +52,7 @@ Template for new versions:
 - `devel/lsmem`: added support for filtering by memory addresses and filenames
 - `gui/gm-editor`: hold down shift and right click to exit, regardless of how many substructures deep you are
 - `quickfort`: linked stockpiles and workshops can now be specified by ID instead of only by name. this is mostly useful when dynamically generating blueprints and applying them via the `quickfort` API
+- `gui/quickfort`: blueprint details screen can now be closed with Ctrl-D (the same hotkey used to open the details)
 - `suspendmanager`: display a different color for jobs suspended by suspendmanager
 - `caravan`: optionally display items within bins in bring goods to depot screen
 - `gui/gm-editor`: display in the title bar whether the editor window is scanning for live updates

--- a/gui/quickfort.lua
+++ b/gui/quickfort.lua
@@ -46,12 +46,12 @@ BlueprintDetails.ATTRS{
 -- adds hint about left arrow being a valid "exit" key for this dialog
 function BlueprintDetails:onRenderFrame(dc, rect)
     BlueprintDetails.super.onRenderFrame(self, dc, rect)
-    dc:seek(rect.x1+2, rect.y2):string('Left arrow', dc.cur_key_pen):
+    dc:seek(rect.x1+2, rect.y2):string('Ctrl+D', dc.cur_key_pen):
             string(': Back', COLOR_GREY)
 end
 
 function BlueprintDetails:onInput(keys)
-    if keys.KEYBOARD_CURSOR_LEFT or keys.SELECT
+    if keys.CUSTOM_CTRL_D or keys.SELECT
             or keys.LEAVESCREEN or keys._MOUSE_R_DOWN then
         self:dismiss()
     end
@@ -367,9 +367,7 @@ function Quickfort:init()
 end
 
 function Quickfort:get_summary_label()
-    if self.mode == 'config' then
-        return 'Blueprint configures game, not map.'
-    elseif self.mode == 'notes' then
+    if self.mode == 'notes' then
         return 'Blueprint shows help text.'
     end
     return 'Reposition with the mouse.'


### PR DESCRIPTION
since the details are no longer opened with the right arrow like they used to be
also remove reference to old config modes