### PR TITLE
[gui/sandbox] protect against out of range vector access in modded games

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -47,6 +47,7 @@ Template for new versions:
 - `fix/retrieve-units`: fix retrieved units sometimes becoming duplicated on the map
 - `quickfort`: cancel old dig jobs that point to a tile when a new designation is applied to the tile
 - `gui/launcher`, `gui/gm-editor`: recover gracefully when the saved frame position is now offscreen
+- `gui/sandbox`: correctly load equipment materials in modded games that categorize non-wood plants as wood
 
 ## Misc Improvements
 - `devel/lsmem`: added support for filtering by memory addresses and filenames

--- a/gui/sandbox.lua
+++ b/gui/sandbox.lua
@@ -317,12 +317,14 @@ local function scan_organic(cat, vec, start_idx, base, do_insert)
     local indexes = MAT_TABLE.organic_indexes[cat]
     for idx = start_idx,#indexes-1 do
         local matindex = indexes[idx]
+        if #vec <= matindex then goto continue end
         local organic = vec[matindex]
         for offset, mat in ipairs(organic.material) do
             if do_insert(mat, base + offset, matindex) then
                 return matindex
             end
         end
+        ::continue::
     end
     return 0
 end


### PR DESCRIPTION
where there are invalid plant indices in the Wood vector

Fixes DFHack/dfhack#3556