### PR TITLE
Autofish: Docs update, incorrect values

### DIFF
--- a/docs/autofish.rst
+++ b/docs/autofish.rst
@@ -26,7 +26,7 @@ Usage
     on hand in your fortress. Fishing will be disabled when the amount of fish
     goes above this value.
 
-    ``min`` (default: 50) controls the minimum fish you want before restarting
+    ``min`` (default: 75) controls the minimum fish you want before restarting
     fishing.
 
     Use ``--toggle-raw``(``-r``) (default: on) to toggle letting the script

--- a/docs/autofish.rst
+++ b/docs/autofish.rst
@@ -12,6 +12,7 @@ collecting too many rotten fish.
 
 Usage
 -----
+
 ``enable autofish``
     Enable the script
 ``disable autofish``
@@ -22,16 +23,23 @@ Usage
 ``autofish <max> [min] [<options>]``
     Change autofish settings.
 
-    ``max`` (default: 100) controls the maximum amount of fish you  want to keep
-    on hand in your fortress. Fishing will be disabled when the amount of fish
-    goes above this value.
+Positional Parameters
+---------------------
 
-    ``min`` (default: 75) controls the minimum fish you want before restarting
-    fishing.
+``max``
+    (default: 100) controls the maximum amount of fish you want to keep on hand
+    in your fortress. Fishing will be disabled when the amount of fish goes
+    above this value.
 
-    Use ``--toggle-raw``(``-r``) (default: on) to toggle letting the script
-    also count your raw fish as part of your quota. Use it a second time to
-    disable this.
+``min``
+    (default: 75) controls the minimum fish you want before restarting fishing.
+
+Options
+-------
+
+``-r``, ``--toggle-raw``
+    (default: on) to toggle letting the script also count your raw fish as part
+    of your quota. Use it a second time to disable this.
 
 Examples
 --------


### PR DESCRIPTION
Fixed autofish docs showing the incorrect minimum fish default value. (the default is 75, not 50)