### PR TITLE
Allow raw fish option to be set from command line

### DIFF
--- a/autofish.lua
+++ b/autofish.lua
@@ -218,7 +218,6 @@ local positionals = argparse.processArgsGetopt(args,
             set_useRaw(toBool[optArg])
         else
             qerror("Invalid argument to --raw \"".. optArg .."\". expected boolean")
-            return
         end
     end}
 })

--- a/autofish.lua
+++ b/autofish.lua
@@ -1,5 +1,5 @@
 -- handles automatic fishing jobs to limit the number of fish the fortress keeps on hand
--- autofish [enable | disable] <max> [min] <options>
+-- autofish [enable | disable] <max> [min] [<options>]
 
 --@ enable=true
 --@ module=true

--- a/docs/autofish.rst
+++ b/docs/autofish.rst
@@ -37,9 +37,9 @@ Positional Parameters
 Options
 -------
 
-``-r``, ``--toggle-raw``
-    (default: on) to toggle letting the script also count your raw fish as part
-    of your quota. Use it a second time to disable this.
+``r``, ``--raw <true | false>``
+    (default: on) Set whether or not raw fish should be counted in the running
+    total of fish in your fortress.
 
 Examples
 --------

--- a/docs/autofish.rst
+++ b/docs/autofish.rst
@@ -46,7 +46,7 @@ Examples
 
 ``enable autofish``
     Enables the script.
-``autofish -r 150``
+``autofish 150 -r true``
     Sets your maximum fish to 150, and enables counting raw fish.
 ``autofish 300 250``
     Sets your maximum fish to 300 and minimum to 250.

--- a/docs/autofish.rst
+++ b/docs/autofish.rst
@@ -38,7 +38,7 @@ Options
 -------
 
 ``r``, ``--raw (true | false)``
-    (default: on) Set whether or not raw fish should be counted in the running
+    (default: ``true``) Set whether or not raw fish should be counted in the running
     total of fish in your fortress.
 
 Examples

--- a/docs/autofish.rst
+++ b/docs/autofish.rst
@@ -37,7 +37,7 @@ Positional Parameters
 Options
 -------
 
-``r``, ``--raw <true | false>``
+``r``, ``--raw (true | false)``
     (default: on) Set whether or not raw fish should be counted in the running
     total of fish in your fortress.
 


### PR DESCRIPTION
Makes changes necessary to replace the "count raw fish" switch on the command line into a settable option, instead of a toggle.

Other minor changes to output as well.