### PR TITLE
Misc improvement: `suspendmanager.lua` has new suspension reason for unsupported constructions.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -34,6 +34,7 @@ Template for new versions:
 
 ## Misc Improvements
 - `devel/inspect-screen`: display total grid size for UI and map layers
+- `suspendmanager`: now suspends constructions that would cave-in immediately on completion
 
 ## Removed
 

--- a/docs/suspendmanager.rst
+++ b/docs/suspendmanager.rst
@@ -14,6 +14,8 @@ This tool will watch your active jobs and:
 - suspend construction jobs on top of a smoothing, engraving or track carving
   designation. This prevents the construction job from being completed first,
   which would erase the designation.
+- suspend construction jobs that would cave in immediately on completion,
+  such as when building walls or floors next to grates/bars.
 
 Usage
 -----

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -172,7 +172,7 @@ local CONSTRUCTION_WALL_SUPPORT = utils.invert{
 }
 
 local CONSTRUCTION_FLOOR_SUPPORT = utils.invert{
-    df.construction_type.FLOOR,
+    df.construction_type.Floor,
     df.construction_type.DownStair,
     df.construction_type.Ramp,
     df.construction_type.TrackN,
@@ -447,7 +447,7 @@ local function constructionIsUnsupported(job)
     local wall_would_support = {}
     local floor_would_support = {}
     local supportbld_would_support = {}
-    
+
     if CONSTRUCTION_FLOOR_SUPPORT[constr_type] then
         wall_would_support = neighboursWallSupportsFloor(pos)
         floor_would_support = neighboursFloorSupportsFloor(pos)

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -409,6 +409,13 @@ local function neighboursFloorSupportsFloor(pos)
     }
 end
 
+local function hasWalkableNeighbour(pos)
+    for _,n in pairs(neighbours(pos)) do
+        if (walkable(n)) then return true end
+    end
+    return false
+end
+
 local function tileHasSupportWall(pos)
     local tt = dfhack.maps.getTileType(pos)
     if tt then
@@ -442,6 +449,10 @@ local function constructionIsUnsupported(job)
     if not building or building:getType() ~= df.building_type.Construction then return false end
 
     local pos = {x=building.centerx, y=building.centery,z=building.z}
+
+    -- if no neighbour is walkable it can't be constructed now anyways,
+    -- this early return helps reduce "spam"
+    if not hasWalkableNeighbour(pos) then return false end
 
     -- find out what type of construction
     local constr_type = building:getSubtype()

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -56,7 +56,7 @@ REASON_DESCRIPTION = {
     [REASON.RISK_BLOCKING] = 'May block another build job',
     [REASON.ERASE_DESIGNATION] = 'Waiting for carve/smooth/engrave',
     [REASON.DEADEND] = 'Blocks another build job',
-    [REASON.UNSUPPORTED] = 'Construction is unsupported'
+    [REASON.UNSUPPORTED] = 'Would collapse immediately'
 }
 
 --- Suspension reasons from an external source

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -452,7 +452,7 @@ local function constructionIsUnsupported(job)
 
     -- if no neighbour is walkable it can't be constructed now anyways,
     -- this early return helps reduce "spam"
-    if not hasWalkableNeighbour(pos) then return false end
+    -- if not hasWalkableNeighbour(pos) then return false end -- commented out pending `walkable()` fix
 
     -- find out what type of construction
     local constr_type = building:getSubtype()

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -36,6 +36,7 @@ REASON = {
     ERASE_DESIGNATION = 4,
     --- Blocks a dead end (either a corridor or on top of a wall)
     DEADEND = 5,
+    --- Would cave in immediately on completion
     UNSUPPORTED = 6,
 }
 

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -346,20 +346,20 @@ end
 ---@return table<number, coord>
 local function neighboursWallSupportsWall(pos)
     return {
-        {x=pos.x-1, y=pos.y, z=pos.z},
+        {x=pos.x-1, y=pos.y, z=pos.z}, -- orthogonal same level
         {x=pos.x+1, y=pos.y, z=pos.z},
         {x=pos.x, y=pos.y-1, z=pos.z},
         {x=pos.x, y=pos.y+1, z=pos.z},
-        {x=pos.x-1, y=pos.y, z=pos.z-1},
+        {x=pos.x-1, y=pos.y, z=pos.z-1}, -- orthogonal level below
         {x=pos.x+1, y=pos.y, z=pos.z-1},
         {x=pos.x, y=pos.y-1, z=pos.z-1},
         {x=pos.x, y=pos.y+1, z=pos.z-1},
-        {x=pos.x-1, y=pos.y, z=pos.z+1},
+        {x=pos.x-1, y=pos.y, z=pos.z+1}, -- orthogonal level above
         {x=pos.x+1, y=pos.y, z=pos.z+1},
         {x=pos.x, y=pos.y-1, z=pos.z+1},
         {x=pos.x, y=pos.y+1, z=pos.z+1},
-        {x=pos.x, y=pos.y, z=pos.z-1},
-        {x=pos.x, y=pos.y, z=pos.z+1},
+        {x=pos.x, y=pos.y, z=pos.z-1}, -- directly below
+        {x=pos.x, y=pos.y, z=pos.z+1}, -- directly above
     }
 end
 
@@ -368,12 +368,12 @@ end
 ---@return table<number, coord>
 local function neighboursFloorSupportsWall(pos)
     return {
-        {x=pos.x-1, y=pos.y, z=pos.z},
+        {x=pos.x-1, y=pos.y, z=pos.z}, -- orthogonal same level
         {x=pos.x+1, y=pos.y, z=pos.z},
         {x=pos.x, y=pos.y-1, z=pos.z},
         {x=pos.x, y=pos.y+1, z=pos.z},
-        {x=pos.x, y=pos.y, z=pos.z+1},
-        {x=pos.x-1, y=pos.y, z=pos.z+1},
+        {x=pos.x, y=pos.y, z=pos.z+1}, -- directly above
+        {x=pos.x-1, y=pos.y, z=pos.z+1}, --orthogonal level above
         {x=pos.x+1, y=pos.y, z=pos.z+1},
         {x=pos.x, y=pos.y-1, z=pos.z+1},
         {x=pos.x, y=pos.y+1, z=pos.z+1},
@@ -385,10 +385,15 @@ end
 ---@return table<number, coord>
 local function neighboursWallSupportsFloor(pos)
     return {
-        {x=pos.x-1, y=pos.y, z=pos.z},
+        {x=pos.x-1, y=pos.y, z=pos.z}, -- orthogonal same level
         {x=pos.x+1, y=pos.y, z=pos.z},
         {x=pos.x, y=pos.y-1, z=pos.z},
         {x=pos.x, y=pos.y+1, z=pos.z},
+        {x=pos.x-1, y=pos.y, z=pos.z-1}, -- orthogonal level below
+        {x=pos.x+1, y=pos.y, z=pos.z-1},
+        {x=pos.x, y=pos.y-1, z=pos.z-1},
+        {x=pos.x, y=pos.y+1, z=pos.z-1},
+        {x=pos.x, y=pos.y, z=pos.z-1}, -- directly below
     }
 end
 
@@ -397,15 +402,10 @@ end
 ---@return table<number, coord>
 local function neighboursFloorSupportsFloor(pos)
     return {
-        {x=pos.x-1, y=pos.y, z=pos.z},
+        {x=pos.x-1, y=pos.y, z=pos.z}, -- orthogonal same level
         {x=pos.x+1, y=pos.y, z=pos.z},
         {x=pos.x, y=pos.y-1, z=pos.z},
         {x=pos.x, y=pos.y+1, z=pos.z},
-        {x=pos.x, y=pos.y, z=pos.z+1},
-        {x=pos.x-1, y=pos.y, z=pos.z+1},
-        {x=pos.x+1, y=pos.y, z=pos.z+1},
-        {x=pos.x, y=pos.y-1, z=pos.z+1},
-        {x=pos.x, y=pos.y+1, z=pos.z+1},
     }
 end
 

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -639,16 +639,18 @@ function SuspendManager:refresh()
             end
         end
 
-        -- Check for construction jobs which may be unsupported
-        if constructionIsUnsupported(job) then
-            self.suspensions[job.id]=REASON.UNSUPPORTED
-        end
+
 
         if not self.preventBlocking then goto continue end
 
         -- Internal reasons to suspend a job
         if riskBlocking(job) then
             self.suspensions[job.id]=REASON.RISK_BLOCKING
+        end
+
+        -- Check for construction jobs which may be unsupported
+        if constructionIsUnsupported(job) then
+            self.suspensions[job.id]=REASON.UNSUPPORTED
         end
 
         -- If this job is a dead end, mark jobs leading to it as dead end


### PR DESCRIPTION
This change to suspendmanager deals with https://github.com/DFHack/dfhack/issues/3601. I've added a new suspension reason `UNSUPPORTED` and added some checks relating to it. The way it works is based on an observation: each tiletype shape that can provide support provides it in one of two ways - either it supports like a wall (all 6 ortho axes as well as orthogonally on the layer above, with an invisible floor), or it supports like a floor (orthogonally on the same level). The only other thing that can provide support is a support building (pillar), which provides support to floors above it or walls both above and below.

I have tested this to a standard that I hope is rigorous enough although @plule says he's willing to take a shot at testing some other cases I may have missed.