### PR TITLE
Quickfix: Restore the "kept suspended" color

### DIFF
--- a/unsuspend.lua
+++ b/unsuspend.lua
@@ -154,7 +154,7 @@ function SuspendOverlay:render_marker(dc, bld, screen_pos)
     if buildingplan and buildingplan.isPlannedBuilding(bld) then
         color, ch, texpos = COLOR_GREEN, 'P', tp(4)
     elseif suspendmanager and suspendmanager.isKeptSuspended(job) then
-        color, ch, texpos = COLOR_WHITE, 'x', tp(1)
+        color, ch, texpos = COLOR_WHITE, 'x', tp(3)
     elseif data.suspend_count > 1 then
         color, ch, texpos = COLOR_RED, 'X', tp(1)
     end


### PR DESCRIPTION
In the switch to dynamic textures, the "kept suspended" white cross texture position was changed from 3 to 1, making the cross red instead of white (https://github.com/DFHack/scripts/pull/798/files#diff-d5774fd6bdc7eb51dd274343c52ae384d20ad8ec2ff8ad0e9f7adb8253989a56R157)

It looks like an unintentional change in the refactor, restore the texture position to the white cross.