### PR TITLE
suspendmanager: walkable() now correctly identifies all walkable squares and broke out a new function to explicitly exclude cases where that tile is a tree branch

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `suspendmanager`: fixed a bug where floor grates, bars, bridges etc. wouldn't be recognised as walkable, leading to unnecessary suspensions in certain cases.
 
 ## Misc Improvements
 - `devel/inspect-screen`: display total grid size for UI and map layers


### PR DESCRIPTION
Fixes https://github.com/DFHack/dfhack/issues/3814

This change fixes this issue. Decision of where to apply `walkable()` and where to apply `isSuitableAccess()` was discussed in the discord 