### PR TITLE
[combine] reduce aggressiveness, increase feature set

### DIFF
--- a/docs/combine.rst
+++ b/docs/combine.rst
@@ -5,6 +5,21 @@ combine
     :summary: Combine items that can be stacked together.
     :tags: fort productivity items plants stockpiles
 
+This handy tool "defragments" your items without giving your fort an undue
+advantage of unreasonably large stacks. Within stockpiles and built containers,
+similar items will be combined into fewer, larger stacks for more compact and
+easier-to-manage storage. Cloth and thread that has been partially used by
+hospitals will be rebalanced so that the used parts are associated with the
+fewest number of cloth/thread items possible. Finally, partial bars that
+accumulate in smelters when you melt metal items are gathered together so
+complete, usable bars can be created.
+
+Items inside of stockpiles or built containers will not be combined with items
+outside of those stockpiles or containers. Cloth and thread, however, can be
+dropped anywhere after being partially used, so cloth and thread is combined
+across the entire fort. If a full bar is collected from your smelters, it will
+appear at one of the smelters that contributed to that metal type.
+
 Usage
 -----
 
@@ -14,77 +29,77 @@ Usage
 
 Examples
 --------
-``combine``
-    Displays help
 ``combine all --dry-run``
-    Preview stack changes for all types in all stockpiles.
+    Preview what will be combined for all types in all
+    stockpiles/containers/smelters.
 ``combine all``
-    Merge stacks for all stockpile and all types
+    Merge all items in all stockpiles/containers/smelters.
 ``combine all --types=meat,plant``
-    Merge ``meat`` and ``plant`` type stacks in all stockpiles.
+    Merge ``meat`` and ``plant`` type stacks in all stockpiles and containers.
 ``combine here``
-    Merge stacks in the selected stockpile.
+    Merge stacks in the currently selected stockpile or container, or collect
+    all accumulated metal bars to the currently selected smelter.
 
 Commands
 --------
 ``all``
-    Search all stockpiles.
+    Combine things in all stockpiles, built containers, and smelters.
 ``here``
-    Search the currently selected stockpile.
+    Combine items in the currently selected stockpile or container, or collect
+    partial bars from all smelters into the selected smelter.
 
 Options
 -------
-``-h``, ``--help``
-    Prints help text. Default if no options are specified.
-
 ``-d``, ``--dry-run``
-    Display the stack changes without applying them.
-
+    Display what would be combined instead of actually combining items.
 ``-t``, ``--types <comma separated list of types>``
-    Filter item types. Default is ``all``. Valid types are:
-
-        ``all``:   all of the types listed here.
-
-        ``ammo``: AMMO
-
-        ``drink``: DRINK
-
-        ``fat``:   GLOB and CHEESE
-
-        ``fish``:  FISH, FISH_RAW and EGG
-
-        ``food``:  FOOD
-
-        ``meat``:  MEAT
-
-        ``parts``: CORPSEPIECE
-
-        ``plant``: PLANT and PLANT_GROWTH
-
-        ``powders``: POWDERS_MISC
-
-        ``seed``: SEEDS
-
+    Specify which item types should be combined. Default is ``all``. Valid
+    types are:
+    :all: all of the types listed here
+    :ammo: stacks of ammunition
+    :bars: partial bars left over in smelters
+    :cloth: cloth
+    :drink: stacks of drinks in barrels/pots
+    :fat: cheese, fat, tallow, and other globs
+    :fish: raw and prepared fish. this category also includes all types of eggs
+    :food: prepared food
+    :meat: meat
+    :parts: corpse pieces
+    :plant: plants and plant growths
+    :powders: dye and other non-sand, non-plaster powders
+    :seed: non-plantable seeds (plantable seeds cannot stack)
+    :thread: thread
 ``-q``, ``--quiet``
-    Only print changes instead of a summary of all processed stockpiles.
-
+    Don't print the final item distribution summary.
 ``-v``, ``--verbose n``
-    Print verbose output, n from 1 to 4.
+    Print verbose output for debugging purposes, n from 1 to 4.
 
 Notes
 -----
+
 The following conditions prevent an item from being combined:
-    1. An item is not in a stockpile.
-    2. An item is sand or plaster.
-    3. An item is rotten, forbidden/hidden, marked for dumping/melting, on fire, encased, owned by a trader/hostile/dwarf or is in a spider web.
-    4. An item is part of a corpse and not butchered.
 
-The following categories are defined:
-    1. Corpse pieces, grouped by piece type and race
-    2. Items that have an associated race/caste, grouped by item type,  race, and caste
-    3. Ammo, grouped by ammo type, material, and quality. If the ammo is a masterwork, it is also grouped by who created it.
-    4. Anything else, grouped by item type and material
+1. An item is not in a stockpile.
+2. An item is sand or plaster.
+3. An item is rotten, forbidden/hidden, marked for dumping/melting, on
+    fire, encased, owned by a trader/hostile/dwarf or is in a spider web.
+4. An item is part of a corpse and has not been butchered.
 
-Each category has a default stack size of 30 unless a larger stack already
-exists "naturally" in your fort. In that case the largest existing stack size
-is used.
+Moreover, if a stack is in a container associated with a stockpile, the stack
+will not be able to grow past the volume limit of the container.
+
+An item can be combined with others if it:
+
+1. has an associated race/caste and is of the same item type, race, and caste
+2. has the same type, material, and quality. If it is a masterwork, it is also
+   grouped by who created it.
+
+Since the player cannot easily choose what kind of cloth and thread the
+hospital uses to dress and suture wounds, `combine` will refill more expensive
+cloth/thread first and deduct accordingly from cheaper cloth/thread. Existing
+wound dressings and sutures that used the more expensive materials will be
+modified to use the cheaper materials.
+
+When partial bars are collected in smelters, collected whole bars are spawned
+at one of the smelters that had a partial amount of that bar. Any remaining
+partial amounts of spawned bar materials will be associated with that smelter.


### PR DESCRIPTION
Proposed changes:
- no more dynamic stack sizes; experience has shown that they tend to grow to absurd proportions
- limit containers to their advertised volume
- add handling of items inside built containers
- add handling of thread/cloth
- add handling of partial bars in smelters
- only combine non-plantable seeds
- the cheapest hospital thread will be chosen if possible to absorb the deductions, otherwise use the cheapest thread in the fort

discord discussion: https://discord.com/channels/793331351645323264/807444515194798090/1159933907538559016

proposed new hard limits:
```lua
local valid_types_map = {
    all    = { },
    ammo   = {[df.item_type.AMMO]        ={type_id=df.item_type.AMMO,         max_size=25}},
    parts  = {[df.item_type.CORPSEPIECE] ={type_id=df.item_type.CORPSEPIECE,  max_size=1}},
    drink  = {[df.item_type.DRINK]       ={type_id=df.item_type.DRINK,        max_size=math.huge}}, -- max size governed by container capacity
    fat    = {[df.item_type.GLOB]        ={type_id=df.item_type.GLOB,         max_size=5},
                  [df.item_type.CHEESE]      ={type_id=df.item_type.CHEESE,       max_size=5}},
    fish   = {[df.item_type.FISH]        ={type_id=df.item_type.FISH,         max_size=5},
                  [df.item_type.FISH_RAW]    ={type_id=df.item_type.FISH_RAW,     max_size=5},
                  [df.item_type.EGG]         ={type_id=df.item_type.EGG,          max_size=5}},
    food   = {[df.item_type.FOOD]        ={type_id=df.item_type.FOOD,         max_size=20}},
    meat   = {[df.item_type.MEAT]        ={type_id=df.item_type.MEAT,         max_size=5}},
    plant  = {[df.item_type.PLANT]       ={type_id=df.item_type.PLANT,        max_size=5},
                  [df.item_type.PLANT_GROWTH]={type_id=df.item_type.PLANT_GROWTH, max_size=5}},
    powder = {[df.item_type.POWDER_MISC] ={type_id=df.item_type.POWDER_MISC,  max_size=10}},
    seed   = {[df.item_type.SEEDS]       ={type_id=df.item_type.SEEDS,        max_size=5}},
}
```

note that the `seed` category is now explicitly non-plantable seeds. corpse part stack limit of 1 seems non-useful, so that should either be raised or the category should be removed.