### PR TITLE
remove tags from unavailable tools

### DIFF
--- a/docs/adaptation.rst
+++ b/docs/adaptation.rst
@@ -3,7 +3,7 @@ adaptation
 
 .. dfhack-tool::
     :summary: Adjust a unit's cave adaptation level.
-    :tags: unavailable fort armok units
+    :tags: unavailable
 
 View or set level of cavern adaptation for the selected unit or the whole fort.
 

--- a/docs/add-thought.rst
+++ b/docs/add-thought.rst
@@ -3,7 +3,7 @@ add-thought
 
 .. dfhack-tool::
     :summary: Adds a thought to the selected unit.
-    :tags: unavailable fort armok units
+    :tags: unavailable
 
 Usage
 -----

--- a/docs/adv-fix-sleepers.rst
+++ b/docs/adv-fix-sleepers.rst
@@ -3,7 +3,7 @@ adv-fix-sleepers
 
 .. dfhack-tool::
     :summary: Fix units who refuse to awaken in adventure mode.
-    :tags: unavailable adventure bugfix units
+    :tags: unavailable
 
 Use this tool if you encounter sleeping units who refuse to awaken regardless of
 talking to them, hitting them, or waiting so long you die of thirst

--- a/docs/adv-max-skills.rst
+++ b/docs/adv-max-skills.rst
@@ -3,7 +3,7 @@ adv-max-skills
 
 .. dfhack-tool::
     :summary: Raises adventurer stats to max.
-    :tags: unavailable adventure embark armok
+    :tags: unavailable
 
 When creating an adventurer, raises all changeable skills and attributes to
 their maximum level.

--- a/docs/adv-rumors.rst
+++ b/docs/adv-rumors.rst
@@ -3,7 +3,7 @@ adv-rumors
 
 .. dfhack-tool::
     :summary: Improves the rumors menu in adventure mode.
-    :tags: unavailable adventure interface
+    :tags: unavailable
 
 In adventure mode, start a conversation with someone and then run this tool
 to improve the "Bring up specific incident or rumor" menu. Specifically, this

--- a/docs/assign-profile.rst
+++ b/docs/assign-profile.rst
@@ -3,7 +3,7 @@ assign-profile
 
 .. dfhack-tool::
     :summary: Adjust characteristics of a unit according to saved profiles.
-    :tags: unavailable fort armok units
+    :tags: unavailable
 
 This tool can load a profile stored in a JSON file and apply the
 characteristics to a unit.

--- a/docs/autolabor-artisans.rst
+++ b/docs/autolabor-artisans.rst
@@ -3,7 +3,7 @@ autolabor-artisans
 
 .. dfhack-tool::
     :summary: Configures autolabor to produce artisan dwarves.
-    :tags: unavailable fort labors
+    :tags: unavailable
 
 This script runs an `autolabor` command for all labors where skill level
 influences output quality (e.g. Carpentry, Stone detailing, Weaponsmithing,

--- a/docs/binpatch.rst
+++ b/docs/binpatch.rst
@@ -3,7 +3,7 @@ binpatch
 
 .. dfhack-tool::
     :summary: Applies or removes binary patches.
-    :tags: unavailable dev
+    :tags: unavailable
 
 See `binpatches` for more info.
 

--- a/docs/bodyswap.rst
+++ b/docs/bodyswap.rst
@@ -3,7 +3,7 @@ bodyswap
 
 .. dfhack-tool::
     :summary: Take direct control of any visible unit.
-    :tags: unavailable adventure armok units
+    :tags: unavailable
 
 This script allows the player to take direct control of any unit present in
 adventure mode whilst giving up control of their current player character.

--- a/docs/break-dance.rst
+++ b/docs/break-dance.rst
@@ -3,7 +3,7 @@ break-dance
 
 .. dfhack-tool::
     :summary: Fixes buggy tavern dances.
-    :tags: unavailable fort bugfix units
+    :tags: unavailable
 
 Sometimes when a unit can't find a dance partner, the dance becomes stuck and
 never stops. This tool can get them unstuck.

--- a/docs/build-now.rst
+++ b/docs/build-now.rst
@@ -3,7 +3,7 @@ build-now
 
 .. dfhack-tool::
     :summary: Instantly completes building construction jobs.
-    :tags: unavailable fort armok buildings
+    :tags: unavailable
 
 By default, all unsuspended buildings on the map are completed, but the area of
 effect is configurable.

--- a/docs/cannibalism.rst
+++ b/docs/cannibalism.rst
@@ -3,7 +3,7 @@ cannibalism
 
 .. dfhack-tool::
     :summary: Allows a player character to consume sapient corpses.
-    :tags: unavailable adventure gameplay
+    :tags: unavailable
 
 This tool clears the flag from items that mark them as being from a sapient
 creature. Use from an adventurer's inventory screen or an individual item's

--- a/docs/color-schemes.rst
+++ b/docs/color-schemes.rst
@@ -3,7 +3,7 @@ color-schemes
 
 .. dfhack-tool::
     :summary: Modify the colors used by the DF UI.
-    :tags: unavailable fort gameplay graphics
+    :tags: unavailable
 
 This tool allows you to set exactly which shades of colors should be used in the
 DF interface color palette.

--- a/docs/combat-harden.rst
+++ b/docs/combat-harden.rst
@@ -3,7 +3,7 @@ combat-harden
 
 .. dfhack-tool::
     :summary: Set the combat-hardened value on a unit.
-    :tags: unavailable fort armok military units
+    :tags: unavailable
 
 This tool can make a unit care more/less about seeing corpses.
 

--- a/docs/deteriorate.rst
+++ b/docs/deteriorate.rst
@@ -3,7 +3,7 @@ deteriorate
 
 .. dfhack-tool::
     :summary: Cause corpses, clothes, and/or food to rot away over time.
-    :tags: unavailable fort auto fps gameplay items plants
+    :tags: unavailable
 
 When enabled, this script will cause the specified item types to slowly rot
 away. By default, items disappear after a few months, but you can choose to slow

--- a/docs/devel/block-borders.rst
+++ b/docs/devel/block-borders.rst
@@ -3,7 +3,7 @@ devel/block-borders
 
 .. dfhack-tool::
     :summary: Outline map blocks on the map screen.
-    :tags: unavailable dev map
+    :tags: unavailable
 
 This tool displays an overlay that highlights the borders of map blocks. See
 :doc:`/docs/api/Maps` for details on map blocks.

--- a/docs/devel/cmptiles.rst
+++ b/docs/devel/cmptiles.rst
@@ -3,7 +3,7 @@ devel/cmptiles
 
 .. dfhack-tool::
     :summary: List or compare two tiletype material groups.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Lists and/or compares two tiletype material groups. You can see the list of
 valid material groups by running::

--- a/docs/devel/find-offsets.rst
+++ b/docs/devel/find-offsets.rst
@@ -3,7 +3,7 @@ devel/find-offsets
 
 .. dfhack-tool::
     :summary: Find memory offsets of DF data structures.
-    :tags: unavailable dev
+    :tags: unavailable
 
 .. warning::
 

--- a/docs/devel/find-twbt.rst
+++ b/docs/devel/find-twbt.rst
@@ -3,7 +3,7 @@ devel/find-twbt
 
 .. dfhack-tool::
     :summary: Display the memory offsets of some important TWBT functions.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Finds some TWBT-related offsets - currently just ``twbt_render_map``.
 

--- a/docs/devel/inject-raws.rst
+++ b/docs/devel/inject-raws.rst
@@ -3,7 +3,7 @@ devel/inject-raws
 
 .. dfhack-tool::
     :summary: Add objects and reactions into an existing world.
-    :tags: unavailable dev
+    :tags: unavailable
 
 WARNING: THIS SCRIPT CAN PERMANENTLY DAMAGE YOUR SAVE.
 

--- a/docs/devel/kill-hf.rst
+++ b/docs/devel/kill-hf.rst
@@ -3,7 +3,7 @@ devel/kill-hf
 
 .. dfhack-tool::
     :summary: Kill a historical figure.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This tool can kill the specified historical figure, even if off-site, or
 terminate a pregnancy. Useful for working around :bug:`11549`.

--- a/docs/devel/light.rst
+++ b/docs/devel/light.rst
@@ -3,7 +3,7 @@ devel/light
 
 .. dfhack-tool::
     :summary: Experiment with lighting overlays.
-    :tags: unavailable dev graphics
+    :tags: unavailable
 
 This is an experimental lighting engine for DF, using the `rendermax` plugin.
 

--- a/docs/devel/list-filters.rst
+++ b/docs/devel/list-filters.rst
@@ -3,7 +3,7 @@ devel/list-filters
 
 .. dfhack-tool::
     :summary: List input items for the selected building type.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This tool lists input items for the building that is currently being built. You
 must be in build mode and have a building type selected for placement. This is

--- a/docs/devel/lua-example.rst
+++ b/docs/devel/lua-example.rst
@@ -3,7 +3,7 @@ devel/lua-example
 
 .. dfhack-tool::
     :summary: An example lua script.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This is an example Lua script which just reports the number of times it has been
 called. Useful for testing environment persistence.

--- a/docs/devel/luacov.rst
+++ b/docs/devel/luacov.rst
@@ -3,7 +3,7 @@ devel/luacov
 
 .. dfhack-tool::
     :summary: Lua script coverage report generator.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This script generates a coverage report from collected statistics. By default it
 reports on every Lua file in all of DFHack. To filter filenames, specify one or

--- a/docs/devel/nuke-items.rst
+++ b/docs/devel/nuke-items.rst
@@ -3,7 +3,7 @@ devel/nuke-items
 
 .. dfhack-tool::
     :summary: Deletes all free items in the game.
-    :tags: unavailable dev fps items
+    :tags: unavailable
 
 This tool deletes **ALL** items not referred to by units, buildings, or jobs.
 Intended solely for lag investigation.

--- a/docs/devel/prepare-save.rst
+++ b/docs/devel/prepare-save.rst
@@ -3,7 +3,7 @@ devel/prepare-save
 
 .. dfhack-tool::
     :summary: Set internal game state to known values for memory analysis.
-    :tags: unavailable dev
+    :tags: unavailable
 
 .. warning::
 

--- a/docs/devel/print-event.rst
+++ b/docs/devel/print-event.rst
@@ -3,7 +3,7 @@ devel/print-event
 
 .. dfhack-tool::
     :summary: Show historical events.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This tool displays the description of a historical event.
 

--- a/docs/devel/test-perlin.rst
+++ b/docs/devel/test-perlin.rst
@@ -3,7 +3,7 @@ devel/test-perlin
 
 .. dfhack-tool::
     :summary: Generate an image based on perlin noise.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Generates an image using multiple octaves of perlin noise.
 

--- a/docs/devel/unit-path.rst
+++ b/docs/devel/unit-path.rst
@@ -3,7 +3,7 @@ devel/unit-path
 
 .. dfhack-tool::
     :summary: Inspect where a unit is going and how it's getting there.
-    :tags: unavailable dev
+    :tags: unavailable
 
 When run with a unit selected, the path that the unit is currently following is
 highlighted on the map. You can jump between the unit and the destination tile.

--- a/docs/devel/watch-minecarts.rst
+++ b/docs/devel/watch-minecarts.rst
@@ -3,7 +3,7 @@ devel/watch-minecarts
 
 .. dfhack-tool::
     :summary: Inspect minecart coordinates and speeds.
-    :tags: unavailable dev
+    :tags: unavailable
 
 When running, this tool will log minecart coordinates and speeds to the console.
 

--- a/docs/do-job-now.rst
+++ b/docs/do-job-now.rst
@@ -3,7 +3,7 @@ do-job-now
 
 .. dfhack-tool::
     :summary: Mark the job related to what you're looking at as high priority.
-    :tags: unavailable fort productivity jobs
+    :tags: unavailable
 
 The script will try its best to find a job related to the selected entity (which
 can be a job, dwarf, animal, item, building, plant or work order) and then mark

--- a/docs/dwarf-op.rst
+++ b/docs/dwarf-op.rst
@@ -3,7 +3,7 @@ dwarf-op
 
 .. dfhack-tool::
     :summary: Tune units to perform underrepresented job roles in your fortress.
-    :tags: unavailable fort armok units
+    :tags: unavailable
 
 ``dwarf-op`` examines the distribution of skills and attributes across the
 dwarves in your fortress and can rewrite the characteristics of a dwarf (or

--- a/docs/embark-skills.rst
+++ b/docs/embark-skills.rst
@@ -3,7 +3,7 @@ embark-skills
 
 .. dfhack-tool::
     :summary: Adjust dwarves' skills when embarking.
-    :tags: unavailable embark fort armok units
+    :tags: unavailable
 
 When selecting starting skills for your dwarves on the embark screen, this tool
 can manipulate the skill values or adjust the number of points you have

--- a/docs/fix-ster.rst
+++ b/docs/fix-ster.rst
@@ -3,7 +3,7 @@ fix-ster
 
 .. dfhack-tool::
     :summary: Toggle infertility for units.
-    :tags: unavailable fort armok animals
+    :tags: unavailable
 
 Now you can restore fertility to infertile creatures or inflict infertility on
 creatures that you do not want to breed.

--- a/docs/fix/corrupt-equipment.rst
+++ b/docs/fix/corrupt-equipment.rst
@@ -3,7 +3,7 @@ fix/corrupt-equipment
 
 .. dfhack-tool::
     :summary: Fixes some game crashes caused by corrupt military equipment.
-    :tags: unavailable fort bugfix military
+    :tags: unavailable
 
 This fix corrects some kinds of corruption that can occur in equipment lists, as
 in :bug:`11014`. Run this script at least every time a squad comes back from a

--- a/docs/fix/item-occupancy.rst
+++ b/docs/fix/item-occupancy.rst
@@ -3,7 +3,7 @@ fix/item-occupancy
 
 .. dfhack-tool::
     :summary: Fixes errors with phantom items occupying site.
-    :tags: unavailable fort bugfix map
+    :tags: unavailable
 
 This tool diagnoses and fixes issues with nonexistent 'items occupying site',
 usually caused by hacking mishaps with items being improperly moved about.

--- a/docs/fix/population-cap.rst
+++ b/docs/fix/population-cap.rst
@@ -3,7 +3,7 @@ fix/population-cap
 
 .. dfhack-tool::
     :summary: Ensure the population cap is respected.
-    :tags: unavailable fort bugfix units
+    :tags: unavailable
 
 Run this after every migrant wave to ensure your population cap is not exceeded.
 

--- a/docs/fix/tile-occupancy.rst
+++ b/docs/fix/tile-occupancy.rst
@@ -3,7 +3,7 @@ fix/tile-occupancy
 
 .. dfhack-tool::
     :summary: Fix tile occupancy flags.
-    :tags: unavailable fort bugfix map
+    :tags: unavailable
 
 This tool clears bad occupancy flags at the selected tile. It is useful for
 getting rid of phantom "building present" messages when trying to build

--- a/docs/fixnaked.rst
+++ b/docs/fixnaked.rst
@@ -3,7 +3,7 @@ fixnaked
 
 .. dfhack-tool::
     :summary: Removes all unhappy thoughts due to lack of clothing.
-    :tags: unavailable fort armok units
+    :tags: unavailable
 
 If you're having trouble keeping your dwarves properly clothed and the stress is
 mounting, this tool can help you calm things down. ``fixnaked`` will go through

--- a/docs/flashstep.rst
+++ b/docs/flashstep.rst
@@ -3,7 +3,7 @@ flashstep
 
 .. dfhack-tool::
     :summary: Teleport your adventurer to the cursor.
-    :tags: unavailable adventure armok
+    :tags: unavailable
 
 ``flashstep`` is a hotkey-friendly teleport that places your adventurer where
 your cursor is.

--- a/docs/forget-dead-body.rst
+++ b/docs/forget-dead-body.rst
@@ -3,7 +3,7 @@ forget-dead-body
 
 .. dfhack-tool::
     :summary: Removes emotions associated with seeing a dead body.
-    :tags: unavailable fort armok units
+    :tags: unavailable
 
 This tool can help your dwarves recover from seeing a massacre. It removes all
 emotions associated with seeing a dead body. If your dwarves are traumatized and

--- a/docs/forum-dwarves.rst
+++ b/docs/forum-dwarves.rst
@@ -3,7 +3,7 @@ forum-dwarves
 
 .. dfhack-tool::
     :summary: Exports the text you see on the screen for posting to the forums.
-    :tags: unavailable dfhack
+    :tags: unavailable
 
 This tool saves a copy of a text screen, formatted in BBcode for posting to the
 Bay12 Forums. Text color and layout is preserved. See `markdown` if you want to

--- a/docs/ghostly.rst
+++ b/docs/ghostly.rst
@@ -3,7 +3,7 @@ ghostly
 
 .. dfhack-tool::
     :summary: Toggles an adventurer's ghost status.
-    :tags: unavailable adventure armok units
+    :tags: unavailable
 
 This is useful for walking through walls, avoiding attacks, or recovering after
 a death.

--- a/docs/growcrops.rst
+++ b/docs/growcrops.rst
@@ -3,7 +3,7 @@ growcrops
 
 .. dfhack-tool::
     :summary: Instantly grow planted seeds into crops.
-    :tags: unavailable fort armok plants
+    :tags: unavailable
 
 With no parameters, this command lists the seed types currently planted in your
 farming plots. With a seed type, the script will grow those seeds, ready to be

--- a/docs/gui/advfort.rst
+++ b/docs/gui/advfort.rst
@@ -3,7 +3,7 @@ gui/advfort
 
 .. dfhack-tool::
     :summary: Perform fort-like jobs in adventure mode.
-    :tags: unavailable adventure gameplay
+    :tags: unavailable
 
 This script allows performing jobs in adventure mode. For interactive help,
 press :kbd:`?` while the script is running.

--- a/docs/gui/autogems.rst
+++ b/docs/gui/autogems.rst
@@ -4,7 +4,7 @@ gui/autogems
 
 .. dfhack-tool::
     :summary: Automatically cut rough gems.
-    :tags: unavailable fort auto workorders
+    :tags: unavailable
 
 This is a frontend for the `autogems` plugin that allows interactively
 configuring the gem types that you want to be cut.

--- a/docs/gui/choose-weapons.rst
+++ b/docs/gui/choose-weapons.rst
@@ -3,7 +3,7 @@ gui/choose-weapons
 
 .. dfhack-tool::
     :summary: Ensure military dwarves choose appropriate weapons.
-    :tags: unavailable fort productivity military
+    :tags: unavailable
 
 Activate in the :guilabel:`Equip->View/Customize` page of the military screen.
 

--- a/docs/gui/clone-uniform.rst
+++ b/docs/gui/clone-uniform.rst
@@ -3,7 +3,7 @@ gui/clone-uniform
 
 .. dfhack-tool::
     :summary: Duplicate an existing military uniform.
-    :tags: unavailable fort productivity military
+    :tags: unavailable
 
 When invoked, this tool duplicates the currently selected uniform template and
 selects the newly created copy. Activate in the :guilabel:`Uniforms` page of the

--- a/docs/gui/color-schemes.rst
+++ b/docs/gui/color-schemes.rst
@@ -3,7 +3,7 @@ gui/color-schemes
 
 .. dfhack-tool::
     :summary: Modify the colors in the DF UI.
-    :tags: unavailable graphics
+    :tags: unavailable
 
 This is an in-game interface for `color-schemes`, which allows you to modify the
 colors in the Dwarf Fortress interface. This script must be called from either

--- a/docs/gui/companion-order.rst
+++ b/docs/gui/companion-order.rst
@@ -3,7 +3,7 @@ gui/companion-order
 
 .. dfhack-tool::
     :summary: Issue orders to companions.
-    :tags: unavailable adventure interface
+    :tags: unavailable
 
 This tool allows you to issue orders to your adventurer's companions. Select
 which companions to issue orders to with lower case letters (green when

--- a/docs/gui/create-tree.rst
+++ b/docs/gui/create-tree.rst
@@ -3,7 +3,7 @@ gui/create-tree
 
 .. dfhack-tool::
     :summary: Create a tree.
-    :tags: unavailable fort armok plants
+    :tags: unavailable
 
 This tool provides a graphical interface for creating trees.
 

--- a/docs/gui/dfstatus.rst
+++ b/docs/gui/dfstatus.rst
@@ -3,7 +3,7 @@ gui/dfstatus
 
 .. dfhack-tool::
     :summary: Show a quick overview of critical stock quantities.
-    :tags: unavailable fort inspection
+    :tags: unavailable
 
 This tool show a quick overview of stock quantities for:
 

--- a/docs/gui/extended-status.rst
+++ b/docs/gui/extended-status.rst
@@ -3,7 +3,7 @@ gui/extended-status
 
 .. dfhack-tool::
     :summary: Add information on beds and bedrooms to the status screen.
-    :tags: unavailable fort inspection interface
+    :tags: unavailable
 
 Adds an additional page to the ``z`` status screen where you can see information
 about beds, bedrooms, and whether your dwarves have bedrooms of their own.

--- a/docs/gui/family-affairs.rst
+++ b/docs/gui/family-affairs.rst
@@ -3,7 +3,7 @@ gui/family-affairs
 
 .. dfhack-tool::
     :summary: Inspect or meddle with romantic relationships.
-    :tags: unavailable fort armok inspection units
+    :tags: unavailable
 
 This tool provides a user-friendly interface to view romantic relationships,
 with the ability to add, remove, or otherwise change them at your whim -

--- a/docs/gui/guide-path.rst
+++ b/docs/gui/guide-path.rst
@@ -3,7 +3,7 @@ gui/guide-path
 
 .. dfhack-tool::
     :summary: Visualize minecart guide paths.
-    :tags: unavailable fort inspection map
+    :tags: unavailable
 
 This tool displays the cached path that will be used by the minecart guide
 order. The game computes this path when the order is executed for the first

--- a/docs/gui/kitchen-info.rst
+++ b/docs/gui/kitchen-info.rst
@@ -3,7 +3,7 @@ gui/kitchen-info
 
 .. dfhack-tool::
     :summary: Show food item uses in the kitchen status screen.
-    :tags: unavailable fort inspection
+    :tags: unavailable
 
 This tool is an overlay that adds more info to the Kitchen screen, such as the potential
 alternate uses of the items that you could mark for cooking.

--- a/docs/gui/load-screen.rst
+++ b/docs/gui/load-screen.rst
@@ -3,7 +3,7 @@ gui/load-screen
 
 .. dfhack-tool::
     :summary: Replace DF's continue game screen with a searchable list.
-    :tags: unavailable dfhack
+    :tags: unavailable
 
 If you tend to have many ongoing games, this tool can make it much easier to
 load the one you're looking for. It replaces DF's "continue game" screen with

--- a/docs/gui/manager-quantity.rst
+++ b/docs/gui/manager-quantity.rst
@@ -3,7 +3,7 @@ gui/manager-quantity
 
 .. dfhack-tool::
     :summary: Set the quantity of the selected manager workorder.
-    :tags: unavailable fort workorders
+    :tags: unavailable
 
 There is no way in the base DF game to change the quantity for an existing
 manager workorder. Select a workorder on the j-m or u-m screens and run this

--- a/docs/gui/mechanisms.rst
+++ b/docs/gui/mechanisms.rst
@@ -3,7 +3,7 @@ gui/mechanisms
 
 .. dfhack-tool::
     :summary: List mechanisms and links connected to a building.
-    :tags: unavailable fort inspection buildings
+    :tags: unavailable
 
 This convenient tool lists the mechanisms connected to the building and the
 buildings linked via the mechanisms. Navigating the list centers the view on the

--- a/docs/gui/petitions.rst
+++ b/docs/gui/petitions.rst
@@ -3,7 +3,7 @@ gui/petitions
 
 .. dfhack-tool::
     :summary: Show information about your fort's petitions.
-    :tags: unavailable fort inspection
+    :tags: unavailable
 
 Show your fort's petitions, both pending and fulfilled.
 

--- a/docs/gui/power-meter.rst
+++ b/docs/gui/power-meter.rst
@@ -3,7 +3,7 @@ gui/power-meter
 
 .. dfhack-tool::
     :summary: Allow pressure plates to measure power.
-    :tags: unavailable fort gameplay buildings
+    :tags: unavailable
 
 If you run this tool after selecting :guilabel:`Pressure Plate` in the build
 menu, you will build a power meter building instead of a regular pressure plate.

--- a/docs/gui/quantum.rst
+++ b/docs/gui/quantum.rst
@@ -3,7 +3,7 @@ gui/quantum
 
 .. dfhack-tool::
     :summary: Quickly and easily create quantum stockpiles.
-    :tags: unavailable fort productivity stockpiles
+    :tags: unavailable
 
 This tool provides a visual, interactive interface for creating quantum
 stockpiles.

--- a/docs/gui/rename.rst
+++ b/docs/gui/rename.rst
@@ -3,7 +3,7 @@ gui/rename
 
 .. dfhack-tool::
     :summary: Give buildings and units new names, optionally with special chars.
-    :tags: unavailable fort productivity buildings stockpiles units
+    :tags: unavailable
 
 Once you select a target on the game map, this tool allows you to rename it. It
 is more powerful than the in-game rename functionality since it allows you to

--- a/docs/gui/room-list.rst
+++ b/docs/gui/room-list.rst
@@ -3,7 +3,7 @@ gui/room-list
 
 .. dfhack-tool::
     :summary: Manage rooms owned by a dwarf.
-    :tags: unavailable fort inspection
+    :tags: unavailable
 
 When invoked in :kbd:`q` mode with the cursor over an owned room, this tool
 lists other rooms owned by the same owner, or by the unit selected in the assign

--- a/docs/gui/settings-manager.rst
+++ b/docs/gui/settings-manager.rst
@@ -3,7 +3,7 @@ gui/settings-manager
 
 .. dfhack-tool::
     :summary: Dynamically adjust global DF settings.
-    :tags: unavailable dfhack
+    :tags: unavailable
 
 This tool is an in-game editor for settings defined in
 :file:`data/init/init.txt` and :file:`data/init/d_init.txt`. Changes are written

--- a/docs/gui/siege-engine.rst
+++ b/docs/gui/siege-engine.rst
@@ -3,7 +3,7 @@ gui/siege-engine
 
 .. dfhack-tool::
     :summary: Extend the functionality and usability of siege engines.
-    :tags: unavailable fort gameplay buildings
+    :tags: unavailable
 
 This tool is an in-game interface for `siege-engine`, which allows you to link
 siege engines to stockpiles, restrict operation to certain dwarves, fire a

--- a/docs/gui/stamper.rst
+++ b/docs/gui/stamper.rst
@@ -3,7 +3,7 @@ gui/stamper
 
 .. dfhack-tool::
     :summary: Copy, paste, and transform dig designations.
-    :tags: unavailable fort design map
+    :tags: unavailable
 
 This tool allows you to copy and paste blocks of dig designations. You can also
 transform what you have copied by shifting it, reflecting it, rotating it,

--- a/docs/gui/stockpiles.rst
+++ b/docs/gui/stockpiles.rst
@@ -3,7 +3,7 @@ gui/stockpiles
 
 .. dfhack-tool::
     :summary: Import and export stockpile settings.
-    :tags: unavailable fort design stockpiles
+    :tags: unavailable
 
 With a stockpile selected in :kbd:`q` mode, you can use this tool to load
 stockpile settings from a file or save them to a file for later loading, in

--- a/docs/gui/teleport.rst
+++ b/docs/gui/teleport.rst
@@ -3,7 +3,7 @@ gui/teleport
 
 .. dfhack-tool::
     :summary: Teleport a unit anywhere.
-    :tags: unavailable fort armok units
+    :tags: unavailable
 
 This tool is a front-end for the `teleport` tool. It allows you to interactively
 choose a unit to teleport and a destination tile using the in-game cursor.

--- a/docs/gui/unit-info-viewer.rst
+++ b/docs/gui/unit-info-viewer.rst
@@ -3,7 +3,7 @@ gui/unit-info-viewer
 
 .. dfhack-tool::
     :summary: Display detailed information about a unit.
-    :tags: unavailable fort inspection units
+    :tags: unavailable
 
 Displays information about age, birth, maxage, shearing, milking, grazing, egg
 laying, body size, and death for the selected unit.

--- a/docs/gui/workflow.rst
+++ b/docs/gui/workflow.rst
@@ -3,7 +3,7 @@ gui/workflow
 
 .. dfhack-tool::
     :summary: Manage automated item production rules.
-    :tags: unavailable fort auto jobs
+    :tags: unavailable
 
 This tool provides a simple interface to item production constraints managed by
 `workflow`. When a workshop job is selected in :kbd:`q` mode and this tool is

--- a/docs/hotkey-notes.rst
+++ b/docs/hotkey-notes.rst
@@ -3,7 +3,7 @@ hotkey-notes
 
 .. dfhack-tool::
     :summary: Show info on DF map location hotkeys.
-    :tags: unavailable fort inspection
+    :tags: unavailable
 
 This command lists the key (e.g. :kbd:`F1`), name, and jump position of the
 map location hotkeys you set in the :kbd:`H` menu.

--- a/docs/launch.rst
+++ b/docs/launch.rst
@@ -3,7 +3,7 @@ launch
 
 .. dfhack-tool::
     :summary: Thrash your enemies with a flying suplex.
-    :tags: unavailable adventure armok units
+    :tags: unavailable
 
 Attack another unit and then run this command to grab them and fly in a glorious
 parabolic arc to where you have placed the cursor. You'll land safely and your

--- a/docs/linger.rst
+++ b/docs/linger.rst
@@ -3,7 +3,7 @@ linger
 
 .. dfhack-tool::
     :summary: Take control of your adventurer's killer.
-    :tags: unavailable adventure armok
+    :tags: unavailable
 
 Run this script after being presented with the "You are deceased." message to
 abandon your dead adventurer and take control of your adventurer's killer.

--- a/docs/list-waves.rst
+++ b/docs/list-waves.rst
@@ -3,7 +3,7 @@ list-waves
 
 .. dfhack-tool::
     :summary: Show migration wave information for your dwarves.
-    :tags: unavailable fort inspection units
+    :tags: unavailable
 
 This script displays information about migration waves or identifies which wave
 a particular dwarf came from.

--- a/docs/load-save.rst
+++ b/docs/load-save.rst
@@ -3,7 +3,7 @@ load-save
 
 .. dfhack-tool::
     :summary: Load a savegame.
-    :tags: unavailable dfhack
+    :tags: unavailable
 
 When run on the Dwarf Fortress title screen or "load game" screen, this script
 will load the save with the given folder name without requiring interaction.

--- a/docs/make-legendary.rst
+++ b/docs/make-legendary.rst
@@ -3,7 +3,7 @@ make-legendary
 
 .. dfhack-tool::
     :summary: Boost skills of the selected dwarf.
-    :tags: unavailable fort armok units
+    :tags: unavailable
 
 This tool can make the selected dwarf legendary in one skill, a group of skills,
 or all skills.

--- a/docs/markdown.rst
+++ b/docs/markdown.rst
@@ -3,7 +3,7 @@ markdown
 
 .. dfhack-tool::
     :summary: Exports the text you see on the screen for posting online.
-    :tags: unavailable dfhack
+    :tags: unavailable
 
 This tool saves a copy of a text screen, formatted in markdown, for posting to
 Reddit (among other places). See `forum-dwarves` if you want to export BBCode

--- a/docs/max-wave.rst
+++ b/docs/max-wave.rst
@@ -3,7 +3,7 @@ max-wave
 
 .. dfhack-tool::
     :summary: Dynamically limit the next immigration wave.
-    :tags: unavailable fort gameplay
+    :tags: unavailable
 
 Limit the number of migrants that can arrive in the next wave by
 overriding the population cap value from data/init/d_init.txt.

--- a/docs/modtools/anonymous-script.rst
+++ b/docs/modtools/anonymous-script.rst
@@ -3,7 +3,7 @@ modtools/anonymous-script
 
 .. dfhack-tool::
     :summary: Run dynamically generated script code.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This allows running a short simple Lua script passed as an argument instead of
 running a script from a file. This is useful when you want to do something too

--- a/docs/modtools/change-build-menu.rst
+++ b/docs/modtools/change-build-menu.rst
@@ -3,7 +3,7 @@ modtools/change-build-menu
 
 .. dfhack-tool::
     :summary: Add or remove items from the build sidebar menus.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Change the build sidebar menus.
 

--- a/docs/modtools/create-tree.rst
+++ b/docs/modtools/create-tree.rst
@@ -3,7 +3,7 @@ modtools/create-tree
 
 .. dfhack-tool::
     :summary: Spawn trees.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Spawns a tree.
 

--- a/docs/modtools/create-unit.rst
+++ b/docs/modtools/create-unit.rst
@@ -3,7 +3,7 @@ modtools/create-unit
 
 .. dfhack-tool::
     :summary: Create arbitrary units.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Creates a unit.
 

--- a/docs/modtools/equip-item.rst
+++ b/docs/modtools/equip-item.rst
@@ -3,7 +3,7 @@ modtools/equip-item
 
 .. dfhack-tool::
     :summary: Force a unit to equip an item.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Force a unit to equip an item with a particular body part; useful in
 conjunction with the ``create`` scripts above.  See also `forceequip`.

--- a/docs/modtools/extra-gamelog.rst
+++ b/docs/modtools/extra-gamelog.rst
@@ -3,7 +3,7 @@ modtools/extra-gamelog
 
 .. dfhack-tool::
     :summary: Write info to the gamelog for Soundsense.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This script writes extra information to the gamelog.
 This is useful for tools like :forums:`Soundsense <60287>`.

--- a/docs/modtools/fire-rate.rst
+++ b/docs/modtools/fire-rate.rst
@@ -3,7 +3,7 @@ modtools/fire-rate
 
 .. dfhack-tool::
     :summary: Alter the fire rate of ranged weapons.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Allows altering the fire rates of ranged weapons. Each are defined on a per-item
 basis. As this is done in an on-world basis, commands for this should be placed

--- a/docs/modtools/if-entity.rst
+++ b/docs/modtools/if-entity.rst
@@ -3,7 +3,7 @@ modtools/if-entity
 
 .. dfhack-tool::
     :summary: Run DFHack commands based on current civ id.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Run a command if the current entity matches a given ID.
 

--- a/docs/modtools/interaction-trigger.rst
+++ b/docs/modtools/interaction-trigger.rst
@@ -3,7 +3,7 @@ modtools/interaction-trigger
 
 .. dfhack-tool::
     :summary: Run DFHack commands when a unit attacks or defends.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This triggers events when a unit uses an interaction on another. It works by
 scanning the announcements for the correct attack verb, so the attack verb

--- a/docs/modtools/invader-item-destroyer.rst
+++ b/docs/modtools/invader-item-destroyer.rst
@@ -3,7 +3,7 @@ modtools/invader-item-destroyer
 
 .. dfhack-tool::
     :summary: Destroy invader items when they die.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This tool can destroy invader items to prevent clutter or to prevent
 the player from getting tools exclusive to certain races.

--- a/docs/modtools/item-trigger.rst
+++ b/docs/modtools/item-trigger.rst
@@ -3,7 +3,7 @@ modtools/item-trigger
 
 .. dfhack-tool::
     :summary: Run DFHack commands when a unit uses an item.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This powerful tool triggers DFHack commands when a unit equips, unequips, or
 attacks another unit with specified item types, specified item materials, or

--- a/docs/modtools/moddable-gods.rst
+++ b/docs/modtools/moddable-gods.rst
@@ -3,7 +3,7 @@ modtools/moddable-gods
 
 .. dfhack-tool::
     :summary: Create deities.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This is a standardized version of Putnam's moddableGods script. It allows you
 to create gods on the command-line.

--- a/docs/modtools/outside-only.rst
+++ b/docs/modtools/outside-only.rst
@@ -3,7 +3,7 @@ modtools/outside-only
 
 .. dfhack-tool::
     :summary: Set building inside/outside restrictions.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This allows you to specify certain custom buildings as outside only, or inside
 only. If the player attempts to build a building in an inappropriate location,

--- a/docs/modtools/pref-edit.rst
+++ b/docs/modtools/pref-edit.rst
@@ -3,7 +3,7 @@ modtools/pref-edit
 
 .. dfhack-tool::
     :summary: Modify unit preferences.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Add, remove, or edit the preferences of a unit.
 Requires a modifier, a unit argument, and filters.

--- a/docs/modtools/projectile-trigger.rst
+++ b/docs/modtools/projectile-trigger.rst
@@ -3,7 +3,7 @@ modtools/projectile-trigger
 
 .. dfhack-tool::
     :summary: Run DFHack commands when projectiles hit their targets.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This triggers dfhack commands when projectiles hit their targets.
 

--- a/docs/modtools/random-trigger.rst
+++ b/docs/modtools/random-trigger.rst
@@ -3,7 +3,7 @@ modtools/random-trigger
 
 .. dfhack-tool::
     :summary: Randomly select DFHack scripts to run.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Trigger random dfhack commands with specified probabilities.
 Register a few scripts, then tell it to "go" and it will pick one

--- a/docs/modtools/raw-lint.rst
+++ b/docs/modtools/raw-lint.rst
@@ -3,6 +3,6 @@ modtools/raw-lint
 
 .. dfhack-tool::
     :summary: Check for errors in raw files.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Checks for simple issues with raw files. Can be run automatically.

--- a/docs/modtools/reaction-product-trigger.rst
+++ b/docs/modtools/reaction-product-trigger.rst
@@ -3,7 +3,7 @@ modtools/reaction-product-trigger
 
 .. dfhack-tool::
     :summary: Call DFHack commands when reaction products are produced.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This triggers dfhack commands when reaction products are produced, once per
 product.

--- a/docs/modtools/reaction-trigger-transition.rst
+++ b/docs/modtools/reaction-trigger-transition.rst
@@ -3,7 +3,7 @@ modtools/reaction-trigger-transition
 
 .. dfhack-tool::
     :summary: Help create reaction triggers.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Prints useful things to the console and a file to help modders
 transition from ``autoSyndrome`` to `modtools/reaction-trigger`.

--- a/docs/modtools/reaction-trigger.rst
+++ b/docs/modtools/reaction-trigger.rst
@@ -3,7 +3,7 @@ modtools/reaction-trigger
 
 .. dfhack-tool::
     :summary: Run DFHack commands when custom reactions complete.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Triggers dfhack commands when custom reactions complete, regardless of whether
 it produced anything, once per completion.  Arguments::

--- a/docs/modtools/set-belief.rst
+++ b/docs/modtools/set-belief.rst
@@ -3,7 +3,7 @@ modtools/set-belief
 
 .. dfhack-tool::
     :summary: Change the beliefs/values of a unit.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Changes the beliefs (values) of units.
 Requires a belief, modifier, and a target.

--- a/docs/modtools/set-need.rst
+++ b/docs/modtools/set-need.rst
@@ -3,7 +3,7 @@ modtools/set-need
 
 .. dfhack-tool::
     :summary: Change the needs of a unit.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Sets and edits unit needs.
 

--- a/docs/modtools/set-personality.rst
+++ b/docs/modtools/set-personality.rst
@@ -3,7 +3,7 @@ modtools/set-personality
 
 .. dfhack-tool::
     :summary: Change a unit's personality.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Changes the personality of units.
 

--- a/docs/modtools/spawn-flow.rst
+++ b/docs/modtools/spawn-flow.rst
@@ -3,7 +3,7 @@ modtools/spawn-flow
 
 .. dfhack-tool::
     :summary: Creates flows at the specified location.
-    :tags: unavailable dev
+    :tags: unavailable
 
 Creates flows at the specified location.
 

--- a/docs/modtools/syndrome-trigger.rst
+++ b/docs/modtools/syndrome-trigger.rst
@@ -3,7 +3,7 @@ modtools/syndrome-trigger
 
 .. dfhack-tool::
     :summary: Trigger DFHack commands when units acquire syndromes.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This script helps you set up commands that trigger when syndromes are applied to
 units.

--- a/docs/modtools/transform-unit.rst
+++ b/docs/modtools/transform-unit.rst
@@ -3,7 +3,7 @@ modtools/transform-unit
 
 .. dfhack-tool::
     :summary: Transform a unit into another unit type.
-    :tags: unavailable dev
+    :tags: unavailable
 
 This tool transforms a unit into another unit type, either temporarily or
 permanently.

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -3,7 +3,7 @@ names
 
 .. dfhack-tool::
     :summary: Rename units or items with the DF name generator.
-    :tags: unavailable fort productivity units
+    :tags: unavailable
 
 This tool allows you to rename the selected unit or item (including artifacts)
 with the native Dwarf Fortress name generation interface.

--- a/docs/open-legends.rst
+++ b/docs/open-legends.rst
@@ -3,7 +3,7 @@ open-legends
 
 .. dfhack-tool::
     :summary: Open a legends screen from fort or adventure mode.
-    :tags: unavailable legends inspection
+    :tags: unavailable
 
 You can use this tool to open legends mode from a world loaded in fortress or
 adventure mode. You can browse around, or even run `exportlegends` while you're

--- a/docs/pop-control.rst
+++ b/docs/pop-control.rst
@@ -3,7 +3,7 @@ pop-control
 
 .. dfhack-tool::
     :summary: Controls population and migration caps persistently per-fort.
-    :tags: unavailable fort auto gameplay
+    :tags: unavailable
 
 This script controls `hermit` and the various population caps per-fortress.
 It is intended to be run from ``dfhack-config/init/onMapLoad.init`` as

--- a/docs/prefchange.rst
+++ b/docs/prefchange.rst
@@ -3,7 +3,7 @@ prefchange
 
 .. dfhack-tool::
     :summary: Set strange mood preferences.
-    :tags: unavailable fort armok units
+    :tags: unavailable
 
 This tool sets preferences for strange moods to include a weapon type, equipment
 type, and material. If you also wish to trigger a mood, see `strangemood`.

--- a/docs/putontable.rst
+++ b/docs/putontable.rst
@@ -3,7 +3,7 @@ putontable
 
 .. dfhack-tool::
     :summary: Make an item appear on a table.
-    :tags: unavailable fort armok items
+    :tags: unavailable
 
 To use this tool, move an item to the ground on the same tile as a built table.
 Then, place the cursor over the table and item and run this command. The item

--- a/docs/questport.rst
+++ b/docs/questport.rst
@@ -3,7 +3,7 @@ questport
 
 .. dfhack-tool::
     :summary: Teleport to your quest log map cursor.
-    :tags: unavailable adventure armok
+    :tags: unavailable
 
 If you open the quest log map and move the cursor to your target location, you
 can run this command to teleport straight there. This can be done both within

--- a/docs/resurrect-adv.rst
+++ b/docs/resurrect-adv.rst
@@ -3,7 +3,7 @@ resurrect-adv
 
 .. dfhack-tool::
     :summary: Bring a dead adventurer back to life.
-    :tags: unavailable adventure armok
+    :tags: unavailable
 
 Have you ever died, but wish you hadn't? This tool can help : ) When you see the
 "You are deceased" message, run this command to be resurrected and fully healed.

--- a/docs/reveal-adv-map.rst
+++ b/docs/reveal-adv-map.rst
@@ -3,7 +3,7 @@ reveal-adv-map
 
 .. dfhack-tool::
     :summary: Reveal or hide the world map.
-    :tags: unavailable adventure armok map
+    :tags: unavailable
 
 This tool can be used to either reveal or hide all tiles on the world map in
 adventure mode (visible when viewing the quest log or fast traveling).

--- a/docs/season-palette.rst
+++ b/docs/season-palette.rst
@@ -3,7 +3,7 @@ season-palette
 
 .. dfhack-tool::
     :summary: Swap color palettes when the seasons change.
-    :tags: unavailable fort auto graphics
+    :tags: unavailable
 
 For this tool to work you need to add *at least* one color palette file to your
 save raw directory. These files must be in the same format as

--- a/docs/siren.rst
+++ b/docs/siren.rst
@@ -3,7 +3,7 @@ siren
 
 .. dfhack-tool::
     :summary: Wake up sleeping units and stop parties.
-    :tags: unavailable fort armok units
+    :tags: unavailable
 
 Sound the alarm! This tool can shake your sleeping units awake and knock some
 sense into your party animal military dwarves so they can address a siege.

--- a/docs/spawnunit.rst
+++ b/docs/spawnunit.rst
@@ -3,7 +3,7 @@ spawnunit
 
 .. dfhack-tool::
     :summary: Create a unit.
-    :tags: unavailable fort armok units
+    :tags: unavailable
 
 This tool allows you to easily spawn a unit of your choice. It is a simplified
 interface to `modtools/create-unit`, which this tool uses to actually create

--- a/docs/tidlers.rst
+++ b/docs/tidlers.rst
@@ -3,7 +3,7 @@ tidlers
 
 .. dfhack-tool::
     :summary: Change where the idlers count is displayed.
-    :tags: unavailable interface
+    :tags: unavailable
 
 This tool simply cycles the idlers count among the possible positions where the
 idlers count can be placed, including making it disappear entirely.

--- a/docs/timestream.rst
+++ b/docs/timestream.rst
@@ -3,7 +3,7 @@ timestream
 
 .. dfhack-tool::
     :summary: Fix FPS death.
-    :tags: unavailable fort auto fps
+    :tags: unavailable
 
 Do you remember when you first start a new fort, your initial 7 dwarves zip
 around the screen and get things done so quickly? As a player, you never had

--- a/docs/undump-buildings.rst
+++ b/docs/undump-buildings.rst
@@ -3,7 +3,7 @@ undump-buildings
 
 .. dfhack-tool::
     :summary: Undesignate building base materials for dumping.
-    :tags: unavailable fort productivity buildings
+    :tags: unavailable
 
 If you designate a bunch of tiles in dump mode, all the items on those tiles
 will be marked for dumping. Unfortunately, if there are buildings on any of

--- a/docs/uniform-unstick.rst
+++ b/docs/uniform-unstick.rst
@@ -3,7 +3,7 @@ uniform-unstick
 
 .. dfhack-tool::
     :summary: Make military units reevaluate their uniforms.
-    :tags: unavailable fort bugfix military
+    :tags: unavailable
 
 This tool prompts military units to reevaluate their uniform, making them
 remove and drop potentially conflicting worn items.

--- a/docs/unretire-anyone.rst
+++ b/docs/unretire-anyone.rst
@@ -3,7 +3,7 @@ unretire-anyone
 
 .. dfhack-tool::
     :summary: Adventure as any living historical figure.
-    :tags: unavailable adventure embark armok
+    :tags: unavailable
 
 This tool allows you to play as any living (or undead) historical figure (except
 for deities) in adventure mode.

--- a/docs/view-item-info.rst
+++ b/docs/view-item-info.rst
@@ -3,7 +3,7 @@ view-item-info
 
 .. dfhack-tool::
     :summary: Extend item and unit descriptions with more information.
-    :tags: unavailable adventure fort interface
+    :tags: unavailable
 
 This tool extends the item or unit description viewscreen with additional
 information, including a custom description of each item (when available), and

--- a/docs/view-unit-reports.rst
+++ b/docs/view-unit-reports.rst
@@ -3,7 +3,7 @@ view-unit-reports
 
 .. dfhack-tool::
     :summary: Show combat reports for a unit.
-    :tags: unavailable fort inspection military
+    :tags: unavailable
 
 Show combat reports specifically for the selected unit. You can select a unit
 with the cursor in :kbd:`v` mode, from the list in :kbd:`u` mode, or from the

--- a/docs/warn-stealers.rst
+++ b/docs/warn-stealers.rst
@@ -3,7 +3,7 @@ warn-stealers
 
 .. dfhack-tool::
     :summary: Watch for and warn about units that like to steal your stuff.
-    :tags: unavailable fort armok auto units
+    :tags: unavailable
 
 This script will watch for new units entering the map and will make a zoomable
 announcement whenever a creature that can eat food, guzzle drinks, or steal


### PR DESCRIPTION
and just leave `unavailable`. that way they don't clutter up the tag indices, but are still preserved and reachable if necessary.

this was implemented as a script change for the tag syncer at <https://docs.google.com/spreadsheets/d/1hiDlo8M_bB_1jE-5HRs2RrrA_VZ4cRu9VXaTctX_nwk/edit#gid=1532003062>

diff:
```diff
 {printf("%s", "    :tags:")
+if ($2 == "TRUE") { tag(2, "unavailable") } else {
 tag(2, "unavailable")
```
```diff
 tag(29, "workorders")
+}
 printf("\n")}'
```

https://github.com/DFHack/dfhack/issues/3503