### PR TITLE
[gui/gm-editor] move from click to edit to double click to edit

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -47,6 +47,7 @@ Template for new versions:
 - `prioritize`: refuse to automatically prioritize dig and smooth/carve job types since it can break the DF job scheduler; instead, print a suggestion that the player use specialized units and vanilla designation priorities
 - `gui/overlay`: filter overlays by current context so there are fewer on the screen at once and you can more easily click on the one you want to reposition
 - `quickfort`: now allows constructions to be built on top of constructed floors and ramps, just like vanilla. however, to allow blueprints to be safely reapplied to the same area, for example to fill in buildings whose constructions were canceled due to lost items, floors will not be rebuilt on top of floors and ramps will not be rebuilt on top of ramps
+- `gui/gm-editor`: change from click to edit to click to select, double-click to edit. this should help prevent accidental modifications to the data and make zoom and hyperlink hotkeys easier to use
 
 ## Removed
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -47,7 +47,7 @@ Template for new versions:
 - `prioritize`: refuse to automatically prioritize dig and smooth/carve job types since it can break the DF job scheduler; instead, print a suggestion that the player use specialized units and vanilla designation priorities
 - `gui/overlay`: filter overlays by current context so there are fewer on the screen at once and you can more easily click on the one you want to reposition
 - `quickfort`: now allows constructions to be built on top of constructed floors and ramps, just like vanilla. however, to allow blueprints to be safely reapplied to the same area, for example to fill in buildings whose constructions were canceled due to lost items, floors will not be rebuilt on top of floors and ramps will not be rebuilt on top of ramps
-- `gui/gm-editor`: change from click to edit to click to select, double-click to edit. this should help prevent accidental modifications to the data and make zoom and hyperlink hotkeys easier to use
+- `gui/gm-editor`: for fields with primitive types, change from click to edit to click to select, double-click to edit. this should help prevent accidental modifications to the data and make hotkeys easier to use (since you have to click on a data item to use a hotkey on it)
 
 ## Removed
 

--- a/docs/gui/gm-editor.rst
+++ b/docs/gui/gm-editor.rst
@@ -8,14 +8,16 @@ gui/gm-editor
 This editor allows you to inspect or modify almost anything in DF. Press
 :kbd:`?` for in-game help.
 
-If you just want to browse without fear of accidentally changing anything, hit
-:kbd:`Ctrl`:kbd:`D` to toggle read-only mode.
+Select a field and hit :kbd:`Enter` or double click to edit, or, for structured
+fields, to inspect their contents. Right click or hit :kbd:`Esc` to go back to
+the previous structure you were inspecting. Right clicking when viewing the
+structure you started with will exit the tool. Hold down :kbd:`Shift` and right
+click to exit, even if you are inspecting a substructure, no matter how deep.
 
-Click on fields to edit them or, for structured fields, to inspect their
-contents. Right click or hit :kbd:`Esc` to go back to the previous structure
-you were inspecting. Right clicking when viewing the structure you started with
-will exit the tool. Hold down :kbd:`Shift` and right click to exit, even if you
-are inspecting a substructure.
+If you just want to browse without fear of accidentally changing anything, hit
+:kbd:`Ctrl`:kbd:`D` to toggle read-only mode. If you want `gui/gm-editor` to
+automatically pick up changes to game data in realtime, hit :kbd:`Alt`:kbd:`A`
+to switch to auto update mode.
 
 Usage
 -----

--- a/docs/gui/gm-editor.rst
+++ b/docs/gui/gm-editor.rst
@@ -9,10 +9,11 @@ This editor allows you to inspect or modify almost anything in DF. Press
 :kbd:`?` for in-game help.
 
 Select a field and hit :kbd:`Enter` or double click to edit, or, for structured
-fields, to inspect their contents. Right click or hit :kbd:`Esc` to go back to
-the previous structure you were inspecting. Right clicking when viewing the
-structure you started with will exit the tool. Hold down :kbd:`Shift` and right
-click to exit, even if you are inspecting a substructure, no matter how deep.
+fields, hit :kbd:`Enter` or single click to inspect their contents. Right click
+or hit :kbd:`Esc` to go back to the previous structure you were inspecting.
+Right clicking when viewing the structure you started with will exit the tool.
+Hold down :kbd:`Shift` and right click to exit, even if you are inspecting a
+substructure, no matter how deep.
 
 If you just want to browse without fear of accidentally changing anything, hit
 :kbd:`Ctrl`:kbd:`D` to toggle read-only mode. If you want `gui/gm-editor` to

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -142,9 +142,8 @@ function GmEditorUi:init(args)
 
     local helpPage=widgets.Panel{
         subviews={widgets.Label{text=helptext,frame = {l=1,t=1,yalign=0}}}}
-    local mainList=widgets.List{view_id="list_main",choices={},frame = {l=1,t=3,yalign=0},on_submit=self:callback("editSelected"),
-        on_submit2=self:callback("editSelectedRaw"),
-        text_pen=COLOR_GREY, cursor_pen=COLOR_YELLOW}
+    local mainList=widgets.List{view_id="list_main",choices={},frame = {l=1,t=3,yalign=0},on_double_click=self:callback("editSelected"),
+        on_double_click2=self:callback("editSelectedRaw"), text_pen=COLOR_GREY, cursor_pen=COLOR_YELLOW}
     local mainPage=widgets.Panel{
         subviews={
             mainList,
@@ -443,7 +442,7 @@ end
 function GmEditorUi:editSelectedRaw(index,choice)
     self:editSelected(index, choice, {raw=true})
 end
-function GmEditorUi:editSelected(index,choice,opts)
+function GmEditorUi:editSelected(index,_,opts)
     if not self:verifyStack() then
         self:updateTarget()
         return
@@ -530,7 +529,9 @@ function GmEditorUi:onInput(keys)
         return false
     end
 
-    if keys[keybindings.toggle_ro.key] then
+    if keys.SELECT then
+        self:editSelected(self.subviews.list_main:getSelected())
+    elseif keys[keybindings.toggle_ro.key] then
         self.read_only = not self.read_only
         self:updateTitles()
         return true

--- a/gui/gm-editor.lua
+++ b/gui/gm-editor.lua
@@ -511,7 +511,17 @@ function GmEditorUi:set(key,input)
     self:updateTarget(true)
 end
 function GmEditorUi:onInput(keys)
-    if GmEditorUi.super.onInput(self, keys) then return true end
+    if GmEditorUi.super.onInput(self, keys) then
+        local index = self.subviews.list_main:getIdxUnderMouse()
+        if keys._MOUSE_L and index then
+            local trg = self:currentTarget()
+            local trg_type = type(trg.target[trg.keys[index]])
+            if trg_type == 'userdata' or trg_type == 'table' then
+                self:editSelected(index)
+            end
+        end
+        return true
+    end
 
     if keys.LEAVESCREEN or keys._MOUSE_R then
         if dfhack.internal.getModifiers().shift then


### PR DESCRIPTION
change from click to edit to click to select, double-click to edit. this should help prevent accidental modifications to the data and make zooming to location and selecting ids for dereferencing easier