### PR TITLE
[prioritize] refuse to automatically prioritize dig jobs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -43,6 +43,7 @@ Template for new versions:
 - `hide-tutorials`: fix the embark tutorial prompt sometimes not being skipped
 
 ## Misc Improvements
+- `prioritize`: refuse to automatically prioritize dig and smooth/carve job types since it can break the DF job scheduler; instead, print a suggestion that the player use specialized units and vanilla designation priorities
 
 ## Removed
 


### PR DESCRIPTION
since so many jobs can bork the DF job scheduler. print a warning instead.