### PR TITLE
[quickfort] allow constructions to be built on top of constructions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -44,6 +44,7 @@ Template for new versions:
 
 ## Misc Improvements
 - `prioritize`: refuse to automatically prioritize dig and smooth/carve job types since it can break the DF job scheduler; instead, print a suggestion that the player use specialized units and vanilla designation priorities
+- `quickfort`: now allows constructions to be built on top of constructed floors and ramps, just like vanilla. however, to allow blueprints to be safely reapplied to the same area, for example to fill in buildings whose constructions were canceled due to lost items, floors will not be rebuilt on top of floors and ramps will not be rebuilt on top of ramps
 
 ## Removed
 

--- a/docs/gui/quickfort.rst
+++ b/docs/gui/quickfort.rst
@@ -9,9 +9,14 @@ This is the graphical interface for the `quickfort` script. Once you load a
 blueprint, you will see a highlight over the tiles that will be modified. You
 can use the mouse cursor to reposition the blueprint and the hotkeys to
 rotate and repeat the blueprint up or down z-levels. Once you are satisfied,
-click the mouse or hit :kbd:`Enter` to apply the blueprint to the map. You can
-apply the blueprint as many times as you wish to different spots on the map.
-Right click or hit :kbd:`Esc` to stop.
+click the mouse or hit :kbd:`Enter` to apply the blueprint to the map.
+
+You can apply the blueprint as many times as you wish to different spots on the
+map. If a blueprint that you designated was only partially applied (due to job
+cancellations, incomplete dig area, or any other reason) you can apply the
+blueprint a second time to fill in any gaps. Any part of the blueprint that has
+already been completed will be harmlessly skipped. Right click or hit
+:kbd:`Esc` to close the `gui/quickfort` UI.
 
 Usage
 -----


### PR DESCRIPTION
but skip floors being built on top of floors and ramps on top of ramps. this allows blueprints to continue to be idempotent

Fixes https://github.com/DFHack/dfhack/issues/3792