### PR TITLE
[gui/overlay] filter overlays by context, not just by screen

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -45,6 +45,7 @@ Template for new versions:
 
 ## Misc Improvements
 - `prioritize`: refuse to automatically prioritize dig and smooth/carve job types since it can break the DF job scheduler; instead, print a suggestion that the player use specialized units and vanilla designation priorities
+- `gui/overlay`: filter overlays by current context so there are fewer on the screen at once and you can more easily click on the one you want to reposition
 - `quickfort`: now allows constructions to be built on top of constructed floors and ramps, just like vanilla. however, to allow blueprints to be safely reapplied to the same area, for example to fill in buildings whose constructions were canceled due to lost items, floors will not be rebuilt on top of floors and ramps will not be rebuilt on top of ramps
 
 ## Removed

--- a/gui/overlay.lua
+++ b/gui/overlay.lua
@@ -111,8 +111,7 @@ function OverlayConfig:init()
     -- prevent hotspot widgets from reacting
     overlay.register_trigger_lock_screen(self)
 
-    self.scr_name = overlay.simplify_viewscreen_name(
-            getmetatable(dfhack.gui.getDFViewscreen(true)))
+    local contexts = dfhack.gui.getFocusStrings(dfhack.gui.getDFViewscreen(true))
 
     local main_panel = widgets.Window{
         frame={w=DIALOG_WIDTH, h=LIST_HEIGHT+15},
@@ -123,13 +122,16 @@ function OverlayConfig:init()
     main_panel:addviews{
         widgets.Label{
             frame={t=0, l=0},
-            text={'Current screen: ', {text=self.scr_name, pen=COLOR_CYAN}}},
+            text={
+                'Current contexts: ',
+                {text=table.concat(contexts, ', '), pen=COLOR_CYAN}
+            }},
         widgets.CycleHotkeyLabel{
             view_id='filter',
             frame={t=2, l=0},
             key='CUSTOM_CTRL_O',
             label='Showing:',
-            options={{label='overlays for the current screen', value='cur'},
+            options={{label='overlays for the current contexts', value='cur'},
                      {label='all overlays', value='all'}},
             on_change=self:callback('refresh_list')},
         widgets.FilteredList{
@@ -173,6 +175,7 @@ end
 
 function OverlayConfig:refresh_list(filter)
     local choices = {}
+    local scr = dfhack.gui.getDFViewscreen(true)
     local state = overlay.get_state()
     local list = self.subviews.list
     local make_on_click_fn = function(idx)
@@ -182,16 +185,15 @@ function OverlayConfig:refresh_list(filter)
         local db_entry = state.db[name]
         local widget = db_entry.widget
         if widget.overlay_only then goto continue end
-        if not widget.hotspot and filter ~= 'all' then
-            local matched = false
-            for _,scr in ipairs(overlay.normalize_list(widget.viewscreens)) do
-                if overlay.simplify_viewscreen_name(scr):startswith(self.scr_name) then
-                    matched = true
-                    break
+        if (not widget.hotspot or #widget.viewscreens > 0) and filter ~= 'all' then
+            for _,vs in ipairs(overlay.normalize_list(widget.viewscreens)) do
+                if dfhack.gui.matchFocusString(overlay.simplify_viewscreen_name(vs), scr) then
+                    goto matched
                 end
             end
-            if not matched then goto continue end
+            goto continue
         end
+        ::matched::
         local panel = nil
         panel = DraggablePanel{
                 frame=make_highlight_frame(widget.frame),
@@ -290,12 +292,14 @@ function OverlayConfig:onInput(keys)
             return true
         end
     end
+    if self:inputToSubviews(keys) then
+        return true
+    end
     for _,choice in ipairs(self.subviews.list:getVisibleChoices()) do
         if choice.panel and choice.panel:onInput(keys) then
             return true
         end
     end
-    return self:inputToSubviews(keys)
 end
 
 function OverlayConfig:onRenderFrame(dc, rect)


### PR DESCRIPTION
there are so many overlays now so we need to be more selective

also fix the problem where if there was an overlay behind the gui/overlay window, it would get mouse clicks before the tool window itself.