### PR TITLE
[warn-stranded] don't warn for units on unwalkable tiles

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -34,6 +34,7 @@ Template for new versions:
 - `gui/unit-syndromes`: show the syndrome names properly in the UI
 
 ## Misc Improvements
+- `warn-stranded`: don't warn for units that are temporarily on unwalkable tiles (e.g. as they pass under a waterfall)
 
 ## Removed
 


### PR DESCRIPTION
if an adjacent tile is walkable. this avoids warning for, for example, units walking under waterfalls or through variable depth water