### PR TITLE
Add trackstop and rollers overlays

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ Template for new versions:
 
 ## New Tools
 - `sync-windmills`: synchronize or randomize movement of active windmills
+- `trackstop`: new overlay to allow changing track stop dump direction and friction after construction
 
 ## New Features
 - `gui/design`: show selected dimensions next to the mouse cursor when designating with vanilla tools, for example when painting a burrow or designating digging

--- a/changelog.txt
+++ b/changelog.txt
@@ -28,7 +28,7 @@ Template for new versions:
 
 ## New Tools
 - `sync-windmills`: synchronize or randomize movement of active windmills
-- `trackstop`: new overlay to allow changing track stop dump direction and friction after construction
+- `trackstop`: new overlay to allow changing track stop dump direction and friction and roller direction and speed after construction
 
 ## New Features
 - `gui/design`: show selected dimensions next to the mouse cursor when designating with vanilla tools, for example when painting a burrow or designating digging

--- a/docs/trackstop.rst
+++ b/docs/trackstop.rst
@@ -2,9 +2,9 @@ trackstop
 =========
 
 .. dfhack-tool::
-    :summary: Overlay to allow changing track stop friction and dump direction and roller direction and speed after construction.
-    :tags: fort gameplay buildings interface
+    :summary: Add dynamic configuration options for track stops.
+    :tags: fort buildings interface
 
-This script provides 2 overlays that are managed by the `overlay` framework.
+This script provides 2 overlays that are managed by the `overlay` framework. The script does nothing when executed.
 The trackstop overlay allows the player to change the friction and dump direction of a selected track stop after it has been constructed.
-The rollers overlay allows the player to change the roller direction and speed of a selected track stop after it has been constructed.
+The rollers overlay allows the player to change the roller direction and speed of a selected roller after it has been constructed.

--- a/docs/trackstop.rst
+++ b/docs/trackstop.rst
@@ -1,0 +1,9 @@
+trackstop
+=========
+
+.. dfhack-tool::
+    :summary: Overlay to allow changing track stop friction and dump direction after construction
+    :tags: fort gameplay buildings interface
+
+This script provides an overlay that is managed by the `overlay` framework.
+The overlay allows the player to change the friction and dump direction of a selected track stop after it has been constructed.

--- a/docs/trackstop.rst
+++ b/docs/trackstop.rst
@@ -2,8 +2,9 @@ trackstop
 =========
 
 .. dfhack-tool::
-    :summary: Overlay to allow changing track stop friction and dump direction after construction
+    :summary: Overlay to allow changing track stop friction and dump direction and roller direction and speed after construction.
     :tags: fort gameplay buildings interface
 
-This script provides an overlay that is managed by the `overlay` framework.
-The overlay allows the player to change the friction and dump direction of a selected track stop after it has been constructed.
+This script provides 2 overlays that are managed by the `overlay` framework.
+The trackstop overlay allows the player to change the friction and dump direction of a selected track stop after it has been constructed.
+The rollers overlay allows the player to change the roller direction and speed of a selected track stop after it has been constructed.

--- a/trackstop.lua
+++ b/trackstop.lua
@@ -1,0 +1,160 @@
+-- Overlay to allow changing track stop friction and dump direction after construction
+--@ module = true
+local gui = require('gui')
+local widgets = require('gui.widgets')
+local overlay = require('plugins.overlay')
+
+local NORTH = 'North'
+local EAST = 'East'
+local SOUTH = 'South'
+local WEST = 'West'
+
+local LOW = 'Low'
+local MEDIUM = 'Medium'
+local HIGH = 'High'
+local MAX = 'Max'
+
+local NONE = 'None'
+
+local FRICTION_MAP = {
+  [NONE] = 10,
+  [LOW] = 50,
+  [MEDIUM] = 500,
+  [HIGH] = 10000,
+  [MAX] = 50000,
+}
+
+local FRICTION_MAP_REVERSE = {}
+for k, v in pairs(FRICTION_MAP) do
+  FRICTION_MAP_REVERSE[v] = k
+end
+
+TrackStopOverlay = defclass(TrackStopOverlay, overlay.OverlayWidget)
+TrackStopOverlay.ATTRS{
+  default_pos={x=-71, y=29},
+  default_enabled=true,
+  viewscreens='dwarfmode/ViewSheets/BUILDING/Trap',
+  frame={w=27, h=4},
+  frame_style=gui.MEDIUM_FRAME,
+  frame_background=gui.CLEAR_PEN,
+}
+
+function TrackStopOverlay:getFriction()
+  return dfhack.gui.getSelectedBuilding().friction
+end
+
+function TrackStopOverlay:setFriction(friction)
+  local building = dfhack.gui.getSelectedBuilding()
+
+  building.friction = FRICTION_MAP[friction]
+end
+
+function TrackStopOverlay:getDumpDirection()
+  local building = dfhack.gui.getSelectedBuilding()
+  local use_dump = building.use_dump
+  local dump_x_shift = building.dump_x_shift
+  local dump_y_shift = building.dump_y_shift
+
+  if use_dump == 0 then
+    return NONE
+  else
+    if dump_x_shift == 0 and dump_y_shift == -1 then
+      return NORTH
+    elseif dump_x_shift == 1 and dump_y_shift == 0 then
+      return EAST
+    elseif dump_x_shift == 0 and dump_y_shift == 1 then
+      return SOUTH
+    elseif dump_x_shift == -1 and dump_y_shift == 0 then
+      return WEST
+    end
+  end
+end
+
+function TrackStopOverlay:setDumpDirection(direction)
+  local building = dfhack.gui.getSelectedBuilding()
+
+  if direction == NONE then
+    building.use_dump = 0
+    building.dump_x_shift = 0
+    building.dump_y_shift = 0
+  elseif direction == NORTH then
+    building.use_dump = 1
+    building.dump_x_shift = 0
+    building.dump_y_shift = -1
+  elseif direction == EAST then
+    building.use_dump = 1
+    building.dump_x_shift = 1
+    building.dump_y_shift = 0
+  elseif direction == SOUTH then
+    building.use_dump = 1
+    building.dump_x_shift = 0
+    building.dump_y_shift = 1
+  elseif direction == WEST then
+    building.use_dump = 1
+    building.dump_x_shift = -1
+    building.dump_y_shift = 0
+  end
+end
+
+function TrackStopOverlay:render(dc)
+  if not self:shouldRender() then
+    return
+  end
+
+  local building = dfhack.gui.getSelectedBuilding()
+  local friction = building.friction
+  local friction_cycle = self.subviews.friction
+
+  friction_cycle:setOption(FRICTION_MAP_REVERSE[friction])
+
+  self.subviews.dump_direction:setOption(self:getDumpDirection())
+
+  TrackStopOverlay.super.render(self, dc)
+end
+
+function TrackStopOverlay:shouldRender()
+  local building = dfhack.gui.getSelectedBuilding()
+  return building and building.trap_type == df.trap_type.TrackStop
+end
+
+function TrackStopOverlay:onInput(keys)
+  if not self:shouldRender() then
+    return
+  end
+  TrackStopOverlay.super.onInput(self, keys)
+end
+
+function TrackStopOverlay:init()
+  self:addviews{
+    widgets.Label{
+      frame={t=0, l=0},
+      text='Dump',
+    },
+    widgets.CycleHotkeyLabel{
+      frame={t=0, l=9},
+      key='CUSTOM_CTRL_X',
+      options={NONE, NORTH, EAST, SOUTH, WEST},
+      view_id='dump_direction',
+      on_change=function(val) self:setDumpDirection(val) end,
+    },
+    widgets.Label{
+      frame={t=1, l=0},
+      text='Friction',
+    },
+    widgets.CycleHotkeyLabel{
+      frame={t=1, l=9},
+      key='CUSTOM_CTRL_F',
+      options={NONE, LOW, MEDIUM, HIGH, MAX},
+      view_id='friction',
+      on_change=function(val) self:setFriction(val) end,
+    },
+  }
+end
+
+OVERLAY_WIDGETS = {
+  trackstop=TrackStopOverlay
+}
+
+if not dfhack_flags.module then
+  main{...}
+end

--- a/trackstop.lua
+++ b/trackstop.lua
@@ -56,7 +56,7 @@ TrackStopOverlay = defclass(TrackStopOverlay, overlay.OverlayWidget)
 TrackStopOverlay.ATTRS{
   default_pos={x=-73, y=29},
   default_enabled=true,
-  viewscreens='dwarfmode/ViewSheets/BUILDING/Trap',
+  viewscreens='dwarfmode/ViewSheets/BUILDING/Trap/TrackStop',
   frame={w=25, h=4},
   frame_style=gui.MEDIUM_FRAME,
   frame_background=gui.CLEAR_PEN,
@@ -120,10 +120,6 @@ function TrackStopOverlay:setDumpDirection(direction)
 end
 
 function TrackStopOverlay:render(dc)
-  if not self:shouldRender() then
-    return
-  end
-
   local building = dfhack.gui.getSelectedBuilding()
   local friction = building.friction
   local friction_cycle = self.subviews.friction
@@ -133,18 +129,6 @@ function TrackStopOverlay:render(dc)
   self.subviews.dump_direction:setOption(self:getDumpDirection())
 
   TrackStopOverlay.super.render(self, dc)
-end
-
-function TrackStopOverlay:shouldRender()
-  local building = dfhack.gui.getSelectedBuilding()
-  return building and building.trap_type == df.trap_type.TrackStop
-end
-
-function TrackStopOverlay:onInput(keys)
-  if not self:shouldRender() then
-    return
-  end
-  TrackStopOverlay.super.onInput(self, keys)
 end
 
 function TrackStopOverlay:init()


### PR DESCRIPTION
Add overlay for changing dump direction and friction of track stops after construction. If this is accepted, I can do a follow-up to remove the old trackstop.cpp stuff.


https://github.com/DFHack/scripts/assets/2104555/8390e43f-b9cf-472f-8529-fcc43422137e

Some screenshots showing how it looks with various suspend manager/building plan states:

![image](https://github.com/DFHack/scripts/assets/2104555/4783bbd1-66e8-4488-a356-5c2b2e474691)

![image](https://github.com/DFHack/scripts/assets/2104555/92e1b334-4ee1-4eb5-818e-a97d2d6ddbc1)

Also adds rollers overlay (same position, size, most of the same options):

https://github.com/DFHack/scripts/assets/2104555/7778ef61-b9b3-443f-ba91-6102ab34d81a

The directions _appear_ to be flipped here but I double checked them against freshly built ones. When you press the arrow up and build the result is "FromSouth" and so on.
