### PR TITLE
[gui/control-panel] remove some tools from the lists

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -43,6 +43,8 @@ Template for new versions:
 - `warn-stranded`: don't warn for units that are temporarily on unwalkable tiles (e.g. as they pass under a waterfall)
 
 ## Removed
+- `gui/control-panel`: removed always-on system services from the ``System`` tab: `buildingplan`, `confirm`, `logistics`, and `overlay`. The base services should not be turned off by the player. Individual confirmation prompts can be managed via `gui/confirm`, and overlays (including those for `buildingplan` and `logistics`) are managed on the control panel ``Overlays`` tab.
+- `gui/control-panel`: removed `autolabor` from the ``Fort`` and ``Autostart`` tabs. The tool does not function correctly with the new labor types, and is causing confusion. You can still enable `autolabor` from the commandline with ``enable autolabor`` if you understand and accept its limitations.
 
 # 50.11-r2
 

--- a/gui/control-panel.lua
+++ b/gui/control-panel.lua
@@ -20,7 +20,6 @@ local FORT_SERVICES = {
     'autoclothing',
     'autofarm',
     'autofish',
-    'autolabor',
     'autonestbox',
     'autoslab',
     'dwarfvet',
@@ -57,10 +56,6 @@ table.sort(FORT_AUTOSTART)
 
 -- these are re-enabled by the default DFHack init scripts
 local SYSTEM_SERVICES = {
-    'buildingplan',
-    'confirm',
-    'logistics',
-    'overlay',
 }
 -- these are fully controlled by the user
 local SYSTEM_USER_SERVICES = {


### PR DESCRIPTION
remove always-on system tools and `autolabor`
as discussed here: https://discord.com/channels/793331351645323264/807444515194798090/1169034531999862897