### PR TITLE
Change items.all to items.other.IN_PLAY for forbid scripts

### DIFF
--- a/forbid.lua
+++ b/forbid.lua
@@ -5,7 +5,7 @@ local argparse = require('argparse')
 local function getForbiddenItems()
     local items = {}
 
-    for _, item in pairs(df.global.world.items.all) do
+    for _, item in pairs(df.global.world.items.other.IN_PLAY) do
         if item.flags.forbid then
             local item_type = df.item_type[item:getType()]
 
@@ -59,7 +59,7 @@ if positionals[1] == "all" then
     print("Forbidding all items on the map...")
 
     local count = 0
-    for _, item in pairs(df.global.world.items.all) do
+    for _, item in pairs(df.global.world.items.other.IN_PLAY) do
         item.flags.forbid = true
         count = count + 1
     end
@@ -73,7 +73,7 @@ if positionals[1] == "unreachable" then
     local citizens = dfhack.units.getCitizens(true)
     local count = 0
 
-    for _, item in pairs(df.global.world.items.all) do
+    for _, item in pairs(df.global.world.items.other.IN_PLAY) do
         if item.flags.construction or item.flags.in_building or item.flags.artifact then
             goto skipitem
         end

--- a/unforbid.lua
+++ b/unforbid.lua
@@ -9,7 +9,7 @@ local function unforbid_all(include_unreachable, quiet, include_worn)
 
     local citizens = dfhack.units.getCitizens(true)
     local count = 0
-    for _, item in pairs(df.global.world.items.all) do
+    for _, item in pairs(df.global.world.items.other.IN_PLAY) do
         if item.flags.forbid then
             if not include_unreachable then
                 local reachable = false


### PR DESCRIPTION
As discussed on Discord there is very little reason for scripts not to use IN_PLAY instead of items.all.

Related:
https://github.com/DFHack/dfhack/issues/4025
https://github.com/DFHack/dfhack/issues/4027