### PR TITLE
add `item` bulk forbid/dump/melt tool

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@ Template for new versions:
 - `gui/teleport`: mouse-driven interface for selecting and teleporting units
 - `gui/biomes`: visualize and inspect biome regions on the map
 - `gui/embark-anywhere`: bypass those pesky warnings and embark anywhere you want to
+- `item`: perform bulk operations on groups of items.
 
 ## New Features
 - `uniform-unstick`: add overlay to the squad equipment screen to show a equipment conflict report and give you a one-click button to fix

--- a/docs/item.rst
+++ b/docs/item.rst
@@ -136,7 +136,7 @@ commandline interface with ``dfhack.run_script()`` or via the API functions
 defined in :source-scripts:`item.lua`, available from the return value of
 ``reqscript('item')``:
 
-* ``execute(action, conditions, options)``
+* ``execute(action, conditions, options [, return_items])``
 
 Performs ``action`` (``forbid``, ``melt``, etc.) on all items satisfying
 ``conditions`` (a table containing functions from item to boolean). ``options``
@@ -146,7 +146,7 @@ and ``owned`` which correspond to the (filter) options described above.
 The function ``execute`` performs no output, but returns three values:
 
 1. the number of matching items
-2. a table containing all matched items, if the action is ``count``
+2. a table containing all matched items, if ``return_items`` is provided and true.
 3. a table containing a mapping from numeric item types to their occurrence
    count, if ``options.bytype=true``
 

--- a/docs/item.rst
+++ b/docs/item.rst
@@ -13,7 +13,7 @@ the number of items that matched the filters and were modified.
 Usage
 -----
 
-``item [ count | [un]forbid | [un]dump | [un]melt ] <filter options>``
+``item [ count | [un]forbid | [un]dump | [un]hide | [un]melt ] <filter options>``
 
 Action names should be self explanatory. All actions other than ``help`` and
 ``count`` have implicit filters associated with them. For instance, ``item
@@ -31,8 +31,7 @@ Examples
     flood-fill to create a burrow covering an entire cavern layer).
 
 ``item melt -t weapon -m steel --max-quality 3``
-    Designate all steel weapons whose quality is less than "exceptional" for
-    melting.
+    Designate all steel weapons whose quality is at most superior for melting.
 
 Options
 -------
@@ -66,11 +65,12 @@ Options
     "metal"). Use ``:lua df.dfhack_material_category`` to get a list of all
     material categories.
 
-``-d, --description <string>``
-    Filter by item description (singular form without stack sizes). Example:
-    "cave spider silk web". Note: Due to a bug, this is of limited use for some
-    animal products such as wool, because their description always includes the
-    stack size.
+``-d, --description <pattern>``
+    Filter by item description (singular form without stack sizes). The
+    ``pattern`` is a Lua pattern
+    (cf. https://www.lua.org/manual/5.4/manual.html#6.4.1), so "cave spider
+    silk" will match both "cave spider silk web" as well as "cave spider silk
+    cloth". Use ``^pattern$`` to match the entire description.
 
 ``-a, --include-artifacts``
     Include artifacts in the item list. Regardless of this setting, artifacts
@@ -91,3 +91,18 @@ Options
 ``-Q, --max-quality <integer>``
     Only include items whose quality level is at most ``integer``. Useful
     values are 0 (ordinary) to 5 (masterwork).
+
+``--forbidden``
+    Only include forbidden items.
+
+``--melting``
+    Only include items designated for melting.
+
+``--dumping``
+    only include items designated for dumping.
+
+``--visible``
+    Only include visible items (i.e., ignore hidden items).
+
+``--hidden``
+    Only include hidden items.

--- a/docs/item.rst
+++ b/docs/item.rst
@@ -1,0 +1,93 @@
+item
+====
+
+.. dfhack-tool::
+    :summary: Perform bulk operations on items based on various properties.
+    :tags: fort productivity items
+
+Filter items in you fort by various properties (e.g., item type, material,
+wear-level, quality, ...), and perform the bulk operations forbid, dump, melt,
+and their inverses. By default, the tool does not consider artifacts. Outputs
+the number of items that matched the filters and were modified.
+
+Usage
+-----
+
+``item [ help | count | [un]forbid | [un]dump | [un]melt ] <filter option>``
+
+Action names should be self explanatory. All actions other than ``help`` and
+``count`` have implicit filters associated with them. For instance, ``item
+forbid --unreachable`` will neither report nor test reachability of items that
+are already forbidden.
+
+Examples
+--------
+
+``item forbid --unreachable``
+    Forbid all items that cannot be reached by any of your citizens.
+
+``item unforbid --inside Cavern1 --type wood``
+    Unforbid/reclaim all logs inside the burrow named "Cavern1" (Hint: use 3D
+    flood-fill to create a burrow covering an entire cavern layer)
+
+``item melt -t weapon -m steel --max-quality 3``
+    Designate all steel weapons whose quality is less than "exceptional" for
+    melting.
+
+Options
+-------
+
+``-n, --dry-run``
+    Use get an accurate count of the items that would be affected, including the
+    implicit filters of the selected main action.
+
+``-i, --inside <burrow>``
+    Only include items inside the given burrow.
+
+``-o, --outside <burrow>``
+    Only include items outside the given burrow.
+
+``-r, --reachable``
+    Only include items reachable by one of your citizens.
+
+``-u, --unreachable``
+    Only include items not reachable by one of your citizens.
+
+``-t, --type <string>``
+    Filter by item type (e.g., BOULDER, CORPSE, ...). Also accepts lower case
+    spelling (e.g. "corpse"). Use ``:lua @df.item_type`` to get the list of all
+    item types.
+
+``-m, --material <string>``
+    Filter by material the item is made out of (e.g., "iron").
+
+``-c, --mat-category <string>``
+    Filter by material category of the material item is made out of (e.g.,
+    "metal"). Use ``:lua df.dfhack_material_category`` to get have a list of all
+    material categories.
+
+``-d, --description <string>``
+    Filter by item description (singular form without stack sizes). Example:
+    "cave spider silk web". Note: Due to a bug, this is of limited use for some
+    animal products such as wool, because their description always includes the
+    stack size.
+
+``-a, --include-artifacts``
+    Include artifacts in the item list. Regardless of this setting, artifacts
+    are never dumped or melted
+
+``-w, --min-wear <integer>``
+    Only include items whose wear/damage level is at least ``integer``. Useful
+    values are 0 (pristine) to 3 (XX).
+
+``-W, --max-wear <integer>``
+    Only include items whose wear/damage level is at most ``integer``. Useful
+    values are 0 (pristine) to 3 (XX).
+
+``-q, --min-quality <integer>``
+    Only include items whose quality level is at least ``integer``. Useful
+    values are 0 (standard) to 5 (masterwork).
+
+``-Q, --max-quality <integer>``
+    Only include items whose quality level is at most ``integer``. Useful
+    values are 0 (standard) to 5 (masterwork).

--- a/docs/item.rst
+++ b/docs/item.rst
@@ -58,7 +58,7 @@ Options
     are never dumped or melted.
 
 ``--include-owned``
-    Include items owned by units (e.g., your dwarfs or visitors)
+    Include items owned by units (e.g., your dwarves or visitors)
 
 ``-i, --inside <burrow>``
     Only include items inside the given burrow.
@@ -192,7 +192,7 @@ the filter is described.
 * ``condition_stockpiled(tab, negate)``
     Corresponds to ``--stockpiled``.
 
-* ``condition_[forbid|melt|dump|hidden|owned](tab,negate)``
+* ``condition_[forbid|melt|dump|hidden|owned](tab, negate)``
     Selects items with the respective flag set to ``true`` (e.g.,
     ``condition_forbid`` checks for ``item.flags.forbid``).
 

--- a/docs/item.rst
+++ b/docs/item.rst
@@ -2,11 +2,11 @@ item
 ====
 
 .. dfhack-tool::
-    :summary: Perform bulk operations on items based on various properties.
+    :summary: Perform bulk operations on groups of items.
     :tags: fort productivity items
 
 Filter items in you fort by various properties (e.g., item type, material,
-wear-level, quality, ...), and perform the bulk operations forbid, dump, melt,
+wear-level, quality, ...), and perform bulk operations like forbid, dump, melt,
 and their inverses. By default, the tool does not consider artifacts. Outputs
 the number of items that matched the filters and were modified.
 
@@ -15,10 +15,11 @@ Usage
 
 ``item [ count | [un]forbid | [un]dump | [un]hide | [un]melt ] <filter options>``
 
-Action names should be self explanatory. All actions other than ``help`` and
-``count`` have implicit filters associated with them. For instance, ``item
-forbid --unreachable`` will neither report nor test reachability of items that
-are already forbidden.
+The ``count`` action just counts up the items that would be matched by the
+given filter options. Otherwise, the named property is set (or unset) on all
+the items that the filter options match. The counts reported when you actually
+apply a property might differ from what is output by the ``count`` action if
+some items already have the property set to the desired state.
 
 Examples
 --------
@@ -40,8 +41,9 @@ Options
 -------
 
 ``-n, --dry-run``
-    Get an accurate count of the items that would be affected, including the
-    implicit filters of the selected main action.
+    Get a count of the items that would be modified by an operation, which will be the
+    number returned by the ``count`` action minus the number of items with the desired
+    property already set.
 
 ``-a, --include-artifacts``
     Include artifacts in the item list. Regardless of this setting, artifacts
@@ -69,7 +71,7 @@ Options
 
 ``-c, --mat-category <string>``
     Filter by material category of the material item is made out of (e.g.,
-    "metal"). Use ``:lua df.dfhack_material_category`` to get a list of all
+    "metal"). Use ``:lua @df.dfhack_material_category`` to get a list of all
     material categories.
 
 ``-d, --description <pattern>``
@@ -134,14 +136,14 @@ Performs ``action`` (``forbid``, ``melt``, etc.) on all items satisfying
 is a table containing the boolean flags ``artifact``, ``dryrun``, and
 ``bytype``, which correspond to the (filter) options described above.
 
-The function ``item.execute`` performs no output, while the ``WithPrinting``
+The function ``execute`` performs no output, while the ``WithPrinting``
 variant performs the same output as the ``item`` tool.
 
 The API provides a number of helper functions to aid in the construction of the
 filter table. The first argument ``tab`` is always the table to which the filter
 should be added.
 
-* ``item.condition_burrow(tab,burrow, outside)``
+* ``item.condition_burrow(tab, burrow, outside)``
     Corresponds to ``--inside`` or ``--outside`` (when ``outside=true``). The
     ``burrow`` argument must be a burrow object, not a string.
 
@@ -190,11 +192,11 @@ should be added.
 
  API usage example::
 
-   local item = reqscript('item')
+   local itemtools = reqscript('item')
    local cond = {}
 
-   item.condition_type(cond, "BOULDER")
-   item.execute('unhide', cond, {}) -- reveal all boulders
+   itemtools.condition_type(cond, "BOULDER")
+   itemtools.execute('unhide', cond, {}) -- reveal all boulders
 
-   item.condition_stockpiled(cond, true)
-   item.execute('hide', cond, {})   -- hide all boulders not in stockpiles
+   itemtools.condition_stockpiled(cond, true)
+   itemtools.execute('hide', cond, {})   -- hide all boulders not in stockpiles

--- a/docs/item.rst
+++ b/docs/item.rst
@@ -13,7 +13,7 @@ the number of items that matched the filters and were modified.
 Usage
 -----
 
-``item [ help | count | [un]forbid | [un]dump | [un]melt ] <filter option>``
+``item [ count | [un]forbid | [un]dump | [un]melt ] <filter options>``
 
 Action names should be self explanatory. All actions other than ``help`` and
 ``count`` have implicit filters associated with them. For instance, ``item
@@ -28,7 +28,7 @@ Examples
 
 ``item unforbid --inside Cavern1 --type wood``
     Unforbid/reclaim all logs inside the burrow named "Cavern1" (Hint: use 3D
-    flood-fill to create a burrow covering an entire cavern layer)
+    flood-fill to create a burrow covering an entire cavern layer).
 
 ``item melt -t weapon -m steel --max-quality 3``
     Designate all steel weapons whose quality is less than "exceptional" for
@@ -38,7 +38,7 @@ Options
 -------
 
 ``-n, --dry-run``
-    Use get an accurate count of the items that would be affected, including the
+    Get an accurate count of the items that would be affected, including the
     implicit filters of the selected main action.
 
 ``-i, --inside <burrow>``
@@ -51,7 +51,7 @@ Options
     Only include items reachable by one of your citizens.
 
 ``-u, --unreachable``
-    Only include items not reachable by one of your citizens.
+    Only include items not reachable by any of your citizens.
 
 ``-t, --type <string>``
     Filter by item type (e.g., BOULDER, CORPSE, ...). Also accepts lower case
@@ -63,7 +63,7 @@ Options
 
 ``-c, --mat-category <string>``
     Filter by material category of the material item is made out of (e.g.,
-    "metal"). Use ``:lua df.dfhack_material_category`` to get have a list of all
+    "metal"). Use ``:lua df.dfhack_material_category`` to get a list of all
     material categories.
 
 ``-d, --description <string>``
@@ -74,7 +74,7 @@ Options
 
 ``-a, --include-artifacts``
     Include artifacts in the item list. Regardless of this setting, artifacts
-    are never dumped or melted
+    are never dumped or melted.
 
 ``-w, --min-wear <integer>``
     Only include items whose wear/damage level is at least ``integer``. Useful
@@ -86,8 +86,8 @@ Options
 
 ``-q, --min-quality <integer>``
     Only include items whose quality level is at least ``integer``. Useful
-    values are 0 (standard) to 5 (masterwork).
+    values are 0 (ordinary) to 5 (masterwork).
 
 ``-Q, --max-quality <integer>``
     Only include items whose quality level is at most ``integer``. Useful
-    values are 0 (standard) to 5 (masterwork).
+    values are 0 (ordinary) to 5 (masterwork).

--- a/docs/item.rst
+++ b/docs/item.rst
@@ -33,6 +33,9 @@ Examples
 ``item melt -t weapon -m steel --max-quality 3``
     Designate all steel weapons whose quality is at most superior for melting.
 
+``item hide -t boulder --scattered``
+    Hide all scattered boulders, i.e. those that are not in stockpiles.
+
 Options
 -------
 
@@ -92,6 +95,13 @@ Options
     Only include items whose quality level is at most ``integer``. Useful
     values are 0 (ordinary) to 5 (masterwork).
 
+``--stockpiled``
+    Only include items that are in stockpiles. Does not include empty bins,
+    barrels, and wheelbarrows assigned as storage and transport for stockpiles.
+
+``--scattered``
+    Opposite of ``--stockpiled``
+
 ``--forbidden``
     Only include forbidden items.
 
@@ -99,7 +109,7 @@ Options
     Only include items designated for melting.
 
 ``--dumping``
-    only include items designated for dumping.
+    Only include items designated for dumping.
 
 ``--visible``
     Only include visible items (i.e., ignore hidden items).

--- a/item.lua
+++ b/item.lua
@@ -236,6 +236,8 @@ function execute(action, conditions, options, return_items)
         end
 
         -- check conditions provided via options
+        -- note we use pairs instead of ipairs since the caller could have
+        -- added conditions with non-list keys
         for _, condition in pairs(conditions) do
             if not condition(item) then goto skipitem end
         end

--- a/item.lua
+++ b/item.lua
@@ -45,9 +45,9 @@ end
 --- @param negate { negate : boolean }|nil
 local function addPositiveOrNegative(tab, pred, negate)
     if negate and negate.negate == true then
-	table.insert(tab, function (item) return not pred(item) end)
+        table.insert(tab, function (item) return not pred(item) end)
     else
-	table.insert(tab, pred)
+        table.insert(tab, pred)
     end
 end
 
@@ -72,9 +72,9 @@ end
 function condition_type(tab, match, negate)
     local pred = nil
     if type(match) == "string" then
-	pred = function (item) return df.item_type[item:getType()] == string.upper(match) end
+        pred = function (item) return df.item_type[item:getType()] == string.upper(match) end
     elseif type(match) == "number" then
-	pred = function (item) return item:getType() == type end
+        pred = function (item) return item:getType() == type end
     else error("match argument must be string or number")
     end
     addPositiveOrNegative(tab, pred, negate)
@@ -115,12 +115,12 @@ end
 --- @param negate { negate : boolean }|nil
 function condition_matcat(tab, match, negate)
     if df.dfhack_material_category[match] ~= nil then
-	local pred =
+        local pred =
             function (item)
                 local matinfo = dfhack.matinfo.decode(item)
                 return matinfo:matches{[match]=true}
             end
-	addPositiveOrNegative(tab, pred, negate)
+        addPositiveOrNegative(tab, pred, negate)
     else
         qerror("invalid material category")
     end
@@ -200,8 +200,9 @@ end
 --- @param action "melt"|"unmelt"|"forbid"|"unforbid"|"dump"|"undump"|"count"|"hide"|"unhide"
 --- @param conditions conditions
 --- @param options { help : boolean, artifact : boolean, dryrun : boolean, bytype : boolean, owned : boolean }
+--- @param return_items boolean|nil
 --- @return number, item[], table<number,number>
-function execute(action, conditions, options)
+function execute(action, conditions, options, return_items)
     local count = 0
     local items = {}
     local types = {}
@@ -214,9 +215,9 @@ function execute(action, conditions, options)
             item.flags.in_building or
             item.flags.hostile or
             (item.flags.artifact and not options.artifact) or
-	    item.flags.on_fire or
-	    item.flags.trader or
-	    (item.flags.owned and not options.owned)
+            item.flags.on_fire or
+            item.flags.trader or
+            (item.flags.owned and not options.owned)
         then
             goto skipitem
         end
@@ -269,9 +270,10 @@ function execute(action, conditions, options)
             item.flags.hidden = true
         elseif action == "unhide" and not options.dryrun then
             item.flags.hidden = false
-	elseif action == "count" then
-	    table.insert(items,item)
         end
+
+        if return_items then table.insert(items, item) end
+
         :: skipitem ::
     end
 
@@ -284,11 +286,11 @@ end
 function executeWithPrinting (action, conditions, options)
     local count, _ , types = execute(action, conditions, options)
     if action == "count" then
-	print(count, 'items matched the filter options')
+        print(count, 'items matched the filter options')
     elseif options.dryrun then
-	print(count, 'items would be modified')
+        print(count, 'items would be modified')
     else
-	print(count, 'items were modified')
+        print(count, 'items were modified')
     end
     if options.bytype and count > 0 then
         local sorted = {}
@@ -297,7 +299,7 @@ function executeWithPrinting (action, conditions, options)
         end
         table.sort(sorted, function(a, b) return a.count > b.count end)
         print(("\n%-14s %5s\n"):format("TYPE", "COUNT"))
-        for _, t in pairs(sorted) do
+        for _, t in ipairs(sorted) do
             print(("%-14s %5s"):format(df.item_type[t.type], t.count))
         end
         print()
@@ -328,16 +330,16 @@ local conditions = {}
 local function flagsFilter(args, negate)
     local flags = argparse.stringList(args, "flag list")
     for _,flag in ipairs(flags) do
-	if     flag == 'forbid' then condition_forbid(conditions, negate)
-	elseif flag == 'forbidden' then condition_forbid(conditions, negate) -- be lenient
-	elseif flag == 'dump'   then condition_dump(conditions, negate)
-	elseif flag == 'hidden' then condition_hidden(conditions, negate)
-	elseif flag == 'melt'   then condition_melt(conditions, negate)
-	elseif flag == 'owned'  then
-	    options.owned = true
-	    condition_owned(conditions, negate)
-	else qerror('unkown flag "'..flag..'"')
-	end
+        if     flag == 'forbid' then condition_forbid(conditions, negate)
+        elseif flag == 'forbidden' then condition_forbid(conditions, negate) -- be lenient
+        elseif flag == 'dump'   then condition_dump(conditions, negate)
+        elseif flag == 'hidden' then condition_hidden(conditions, negate)
+        elseif flag == 'melt'   then condition_melt(conditions, negate)
+        elseif flag == 'owned'  then
+            options.owned = true
+            condition_owned(conditions, negate)
+        else qerror('unkown flag "'..flag..'"')
+        end
     end
 end
 

--- a/item.lua
+++ b/item.lua
@@ -296,7 +296,7 @@ function executeWithPrinting (action, conditions, options)
     end
     if options.bytype and count > 0 then
         local sorted = {}
-        for tp, ct in pairs(types) do
+        for tp, ct in ipairs(types) do
             table.insert(sorted, { type = tp, count = ct })
         end
         table.sort(sorted, function(a, b) return a.count > b.count end)

--- a/item.lua
+++ b/item.lua
@@ -233,7 +233,7 @@ function execute(action, conditions, options)
 
         -- item matches the filters
         count = count + 1
-        if options.by_type then
+        if options.bytype then
             local it = item:getType()
             types[it] = (types[it] or 0) + 1
         end
@@ -268,7 +268,7 @@ end
 function executeWithPrinting (action, conditions, options)
     local count, types = execute(action, conditions, options)
     print(count, 'items matched the filter options')
-    if options.by_type and count > 0 then
+    if options.bytype and count > 0 then
         local sorted = {}
         for tp, ct in pairs(types) do
             table.insert(sorted, { type = tp, count = ct })
@@ -299,7 +299,7 @@ local options = {
     help = false,
     artifact = false,
     dryrun = false,
-    by_type = false,
+    bytype = false,
 }
 
 --- @type (fun(item:item):boolean)[]
@@ -309,7 +309,7 @@ local positionals = argparse.processArgsGetopt({ ... }, {
   { 'h', 'help', handler = function() options.help = true end },
   { 'a', 'include-artifacts', handler = function() options.artifact = true end },
   { 'n', 'dry-run', handler = function() options.dryrun = true end },
-  { nil, 'by-type', handler = function() options.by_type = true end },
+  { nil, 'by-type', handler = function() options.bytype = true end },
   { 'i', 'inside', hasArg = true,
     handler = function (name)
         local burrow = dfhack.burrows.findByName(name,true)

--- a/item.lua
+++ b/item.lua
@@ -210,6 +210,7 @@ function execute(action, conditions, options)
         -- never act on items used for constructions/building materials and carried by hostiles
         -- also skip artifacts, unless explicitly told to include them
         if item.flags.construction or
+            item.flags.garbage_collect or
             item.flags.in_building or
             item.flags.hostile or
             (item.flags.artifact and not options.artifact) or

--- a/item.lua
+++ b/item.lua
@@ -1,0 +1,340 @@
+--@module = true
+-----------------------------------------------------------
+-- helper functions
+-----------------------------------------------------------
+
+-- check whether an item is inside a burrow
+local function containsItem(burrow,item)
+    local res = false
+    local x,y,z = dfhack.items.getPosition(item)
+    if x then
+        res = dfhack.burrows.isAssignedTile(burrow, xyz2pos(x,y,z))
+    end
+    return res
+end
+
+-- fast reachability test for items that requires precomputed walkability groups for
+-- all citizens. Returns false for items w/o valid position (e.g., items in inventories).
+--- @param item item
+--- @param wgroups table<integer,boolean>
+--- @return boolean
+function fastReachable(item,wgroups)
+    local x, y, z = dfhack.items.getPosition(item)
+    if x then -- item has a valid position
+        local igroup = dfhack.maps.getWalkableGroup(xyz2pos(x, y, z))
+        return not not wgroups[igroup]
+    else
+        return false
+    end
+end
+
+--- @return table<integer,boolean>
+function citizenWalkabilityGroups()
+    local cgroups = {}
+    for _, unit in pairs(dfhack.units.getCitizens(true)) do
+        local wgroup = dfhack.maps.getWalkableGroup(unit.pos)
+        cgroups[wgroup] = true
+    end
+    cgroups[0] = false -- exclude unwalkable tiles
+    return cgroups
+end
+
+function table.contains (t, val)
+    for _,v in ipairs(t) do
+        if v == val then return true end
+    end
+    return false
+end
+
+
+
+-----------------------------------------------------------------------
+-- external API: helpers to assemble filters and `execute` to execute.
+-----------------------------------------------------------------------
+
+--- @alias conditions (fun(item:item):boolean)[]
+
+--- @param tab conditions
+--- @param burrow burrow
+--- @param outside boolean
+function condition_burrow(tab,burrow, outside)
+    if outside then
+        table.insert(tab, function (item) return not containsItem(burrow, item) end)
+    else
+        table.insert(tab, function (item) return containsItem(burrow, item) end)
+    end
+end
+
+--- @param tab conditions
+--- @param match number|string
+function condition_type(tab, match)
+    if type(match) == "string" then
+        table.insert(
+            tab,
+            function (item) return df.item_type[item:getType()] == string.upper(match) end
+        )
+    elseif type(match) == "number" then
+        table.insert(
+            tab,
+            function (item) return item:getType() == type end
+        )
+    else qerror("match argument must be string or number")
+    end
+end
+
+--- @param tab conditions
+function condition_reachable(tab)
+    local cgroups = citizenWalkabilityGroups()
+    table.insert(tab, function(item) return fastReachable(item, cgroups) end)
+end
+
+--- @param tab conditions
+function condition_unreachable(tab)
+    local cgroups = citizenWalkabilityGroups()
+    table.insert(tab, function (item) return not fastReachable(item,cgroups) end)
+end
+
+-- uses the singular form without stack size (i.e., prickle berry)
+-- Exception: for corpse pieces like "wool", their description always includes stacksize (DF bug)
+--- @param tab conditions
+--- @param desc string
+function condition_description(tab, desc)
+    table.insert(
+        tab,
+        function(item) return dfhack.items.getDescription(item, 1) == desc end)
+end
+
+--- @param tab conditions
+--- @param material string
+function condition_material(tab, material)
+    table.insert(
+        tab,
+        function(item) return dfhack.matinfo.decode(item):toString() == material end)
+end
+
+--- @param tab conditions
+--- @param match string
+function condition_matcat(tab, match)
+    if table.contains(df.dfhack_material_category,match)
+    then
+        table.insert(
+            tab,
+            function (item)
+                local matinfo = dfhack.matinfo.decode(item)
+                return matinfo:matches{[match]=true}
+            end
+        )
+    else
+        qerror("invalid material category")
+    end
+end
+
+--- @param tab conditions
+--- @param lower number # range: 0 (pristine) to 3 (XX)
+--- @param upper number # range: 0 (pristine) to 3 (XX)
+function condition_wear(tab, lower, upper)
+    table.insert(tab,
+                 function(item) return lower <= item.wear and item.wear <= upper end)
+end
+
+--- @param tab conditions
+--- @param lower number # range: 0 (standard) to 5 (masterwork)
+--- @param upper number # range: 0 (standard) to 5 (masterwork)
+function condition_quality(tab, lower, upper)
+    table.insert(tab,
+                 function(item) return lower <= item.quality and item.quality <= upper end)
+end
+
+--- @param tab conditions
+function condition_forbidden(tab)
+    table.insert(tab, function(item) return item.flags.forbid end)
+end
+
+--- @param tab conditions
+function condition_melt(tab)
+    table.insert(tab,function (item) return item.flags.melt end)
+end
+
+--- @param tab conditions
+function condition_dump(tab)
+    table.insert(tab,function (item) return item.flags.dump end)
+end
+
+--- @param action "melt"|"unmelt"|"forbid"|"unforbid"|"dump"|"undump"|"count"
+--- @param conditions conditions
+--- @param options { help : boolean, artifact : boolean, dryrun : boolean, by_type : boolean }
+--- @return number, table<number,number>
+function execute(action, conditions, options)
+    local count = 0
+    local types = {}
+
+    for _, item in pairs(df.global.world.items.other.IN_PLAY) do
+        -- never act on items used for constructions/building materials and carried by hostiles
+        -- also skip artifacts, unless explicitly told to include them
+        if item.flags.construction or
+            item.flags.in_building or
+            item.flags.hostile or
+            (item.flags.artifact and not options.artifact)
+        then
+            goto skipitem
+        end
+
+        -- implicit filters:
+        if action == 'melt' and (item.flags.melt or not dfhack.items.canMelt(item)) or
+            action == 'unmelt' and not item.flags.melt or
+            action == 'forbid' and item.flags.forbid or
+            action == 'unforbid' and not item.flags.forbid or
+            action == 'dump' and (item.flags.dump or item.flags.artifact) or
+            action == 'undump' and not item.flags.dump
+        then
+            goto skipitem
+        end
+
+        -- check conditions provided via options
+        for _, condition in pairs(conditions) do
+            if not condition(item) then goto skipitem end
+        end
+
+        -- skip items that are in unrevealed parts of the map
+        local x, y, z = dfhack.items.getPosition(item)
+        if x and not dfhack.maps.isTileVisible(x, y, z) then
+            goto skipitem
+        end
+
+        -- item matches the filters
+        count = count + 1
+        if options.by_type then
+            local it = item:getType()
+            types[it] = (types[it] or 0) + 1
+        end
+
+        -- carry out the action
+        if action == 'forbid' and not options.dryrun then
+            item.flags.forbid = true
+        elseif action == 'unforbid' and not options.dryrun then
+            item.flags.forbid = false
+        elseif action == 'dump' and not options.dryrun then
+            item.flags.dump = true
+        elseif action == 'undump' and not options.dryrun then
+            item.flags.dump = false
+        elseif action == 'melt' and not options.dryrun then
+            dfhack.items.markForMelting(item)
+        elseif action == 'unmelt' and not options.dryrun then
+            dfhack.items.cancelMelting(item)
+        end
+        :: skipitem ::
+    end
+
+    return count, types
+end
+
+--- @param action "melt"|"unmelt"|"forbid"|"unforbid"|"dump"|"undump"|"count"
+--- @param conditions conditions
+--- @param options { help : boolean, artifact : boolean, dryrun : boolean, by_type : boolean }
+function executeWithPrinting (action, conditions, options)
+    local count, types = execute(action, conditions, options)
+    print(count, 'items matched the filter options')
+    if options.by_type and count > 0 then
+        local sorted = {}
+        for tp, ct in pairs(types) do
+            table.insert(sorted, { type = tp, count = ct })
+        end
+        table.sort(sorted, function(a, b) return a.count > b.count end)
+        print(("\n%-14s %5s\n"):format("TYPE", "COUNT"))
+        for _, t in pairs(sorted) do
+            print(("%-14s %5s"):format(df.item_type[t.type], t.count))
+        end
+        print()
+    end
+    if action == "count" or options.dryrun then
+        print('no items were modified')
+    end
+end
+
+-----------------------------------------------------------------------
+-- script action: check for arguments and main action and run act
+-----------------------------------------------------------------------
+
+if dfhack_flags.module then
+    return
+end
+
+local argparse = require('argparse')
+
+local options = {
+    help = false,
+    artifact = false,
+    dryrun = false,
+    by_type = false,
+}
+
+--- @type (fun(item:item):boolean)[]
+local conditions = {}
+
+local positionals = argparse.processArgsGetopt({ ... }, {
+  { 'h', 'help', handler = function() options.help = true end },
+  { 'a', 'include-artifacts', handler = function() options.artifact = true end },
+  { 'n', 'dry-run', handler = function() options.dryrun = true end },
+  { nil, 'by-type', handler = function() options.by_type = true end },
+  { 'i', 'inside', hasArg = true,
+    handler = function (name)
+        local burrow = dfhack.burrows.findByName(name,true)
+        if burrow then condition_burrow(conditions, burrow, false)
+        else qerror('burrow '..name..' not found') end
+    end
+  },
+  { 'o', 'outside', hasArg = true,
+    handler = function (name)
+        local burrow = dfhack.burrows.findByName(name,true)
+        if burrow then condition_burrow(conditions, burrow, true)
+        else qerror('burrow '..name..' not found') end
+    end
+  },
+  { 'r', 'reachable',
+    handler = function () condition_reachable(conditions) end },
+  { 'u', 'unreachable',
+    handler = function () condition_unreachable(conditions) end },
+  { 't', 'type', hasArg = true,
+    handler = function (type) condition_type(conditions,type) end },
+  { 'd', 'description', hasArg = true,
+    handler = function (desc) condition_description(conditions, desc) end },
+  { 'm', 'material', hasArg = true,
+    handler = function (material) condition_material(conditions, material) end },
+  { 'c', 'mat-category', hasArg = true,
+    handler = function (matcat) condition_matcat(conditions, matcat) end },
+  { 'w', 'min-wear', hasArg = true,
+    handler = function(levelst)
+        local level = argparse.nonnegativeInt(levelst, 'min-wear')
+        condition_wear(conditions, level , 3) end },
+  { 'W', 'max-wear', hasArg = true,
+    handler = function(levelst)
+        local level = argparse.nonnegativeInt(levelst, 'max-wear')
+        condition_wear(conditions, 0, level) end },
+  { 'q', 'min-quality', hasArg = true,
+    handler = function(levelst)
+        local level = argparse.nonnegativeInt(levelst, 'min-quality')
+        condition_quality(conditions, level, 5) end },
+  { 'Q', 'max-quality', hasArg = true,
+    handler = function(levelst)
+        local level = argparse.nonnegativeInt(levelst, 'max-quality')
+        condition_quality(conditions, 0, level) end },
+  { nil, 'forbidden',
+    handler = function () condition_forbidden(conditions) end },
+  { nil, 'melting',
+    handler = function () condition_melt(conditions) end },
+  { nil, 'dumping',
+    handler = function () condition_dump(conditions) end }
+})
+
+if options.help or positionals[1] == 'help' then
+    print(dfhack.script_help())
+    return
+elseif positionals[1] == 'forbid'   then executeWithPrinting('forbid',conditions,options)
+elseif positionals[1] == 'unforbid' then executeWithPrinting('unforbid',conditions,options)
+elseif positionals[1] == 'dump'     then executeWithPrinting('dump',conditions,options)
+elseif positionals[1] == 'undump'   then executeWithPrinting('undump',conditions,options)
+elseif positionals[1] == 'melt'     then executeWithPrinting('melt',conditions,options)
+elseif positionals[1] == 'unmelt'   then executeWithPrinting('unmelt',conditions,options)
+elseif positionals[1] == 'count'    then executeWithPrinting('count',conditions,options)
+else qerror('main action not recognized')
+end


### PR DESCRIPTION
This adds a generic item manipulation tool, allowing to bulk forbid/dump/melt items based on various criteria or remove the aforementioned designations. Also provides an API to serve as backend for other scripts. 