### PR TITLE
Ignore all fruit gatherers when checking stranded

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -31,7 +31,8 @@ Template for new versions:
 ## New Features
 
 ## Fixes
-- `warn-stranded`: Automatically ignore citizens who are gathering plants to avoid issues with gathering fruit via stepladders
+- `warn-stranded`: Automatically ignore citizens who are gathering plants or digging to avoid issues with gathering fruit via stepladders and weird issues with digging
+- `warn-stranded`: Update onZoom to use df's centering functionality
 
 ## Misc Improvements
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `warn-stranded`: Automatically ignore citizens who are gathering plants to avoid issues with gathering fruit via stepladders
 
 ## Misc Improvements
 

--- a/warn-stranded.lua
+++ b/warn-stranded.lua
@@ -333,8 +333,9 @@ local function getStrandedUnits()
                 or getWalkGroup(xyz2pos(unitPos.x+1, unitPos.y+1, unitPos.z))
                 or 0
         end
-
-        if unitIgnored(unit) then
+		
+        -- Ignore units who are gathering plants to avoid errors with stepladders
+        if unitIgnored(unit) or unit.job.current_job.job_type == df.job_type.GatherPlants then
             table.insert(ensure_key(ignoredGroup, walkGroup), unit)
         else
             table.insert(ensure_key(grouped, walkGroup), unit)

--- a/warn-stranded.lua
+++ b/warn-stranded.lua
@@ -269,7 +269,7 @@ function WarningWindow:onZoom()
     local unit = choice.data['unit']
 
     local target = xyz2pos(dfhack.units.getPosition(unit))
-    dfhack.gui.revealInDwarfmodeMap(target, false, true)
+    dfhack.gui.revealInDwarfmodeMap(target, true, true)
 end
 
 function WarningWindow:onToggleGroup()

--- a/warn-stranded.lua
+++ b/warn-stranded.lua
@@ -333,9 +333,9 @@ local function getStrandedUnits()
                 or getWalkGroup(xyz2pos(unitPos.x+1, unitPos.y+1, unitPos.z))
                 or 0
         end
-		
+
         -- Ignore units who are gathering plants to avoid errors with stepladders
-        if unitIgnored(unit) or unit.job.current_job.job_type == df.job_type.GatherPlants then
+        if unitIgnored(unit) or (unit.job.current_job and unit.job.current_job.job_type == df.job_type.GatherPlants) then
             table.insert(ensure_key(ignoredGroup, walkGroup), unit)
         else
             table.insert(ensure_key(grouped, walkGroup), unit)

--- a/warn-stranded.lua
+++ b/warn-stranded.lua
@@ -334,8 +334,10 @@ local function getStrandedUnits()
                 or 0
         end
 
-        -- Ignore units who are gathering plants to avoid errors with stepladders
-        if unitIgnored(unit) or (unit.job.current_job and unit.job.current_job.job_type == df.job_type.GatherPlants) then
+        -- Ignore units who are gathering plants or digging to avoid errors with stepladders and weird digging things
+        if unitIgnored(unit) or (unit.job.current_job and 
+                                    (unit.job.current_job.job_type == df.job_type.GatherPlants or
+                                        df.job_type.attrs[unit.job.current_job.job_type].type == 'Digging')) then
             table.insert(ensure_key(ignoredGroup, walkGroup), unit)
         else
             table.insert(ensure_key(grouped, walkGroup), unit)

--- a/warn-stranded.lua
+++ b/warn-stranded.lua
@@ -335,7 +335,7 @@ local function getStrandedUnits()
         end
 
         -- Ignore units who are gathering plants or digging to avoid errors with stepladders and weird digging things
-        if unitIgnored(unit) or (unit.job.current_job and 
+        if unitIgnored(unit) or (unit.job.current_job and
                                     (unit.job.current_job.job_type == df.job_type.GatherPlants or
                                         df.job_type.attrs[unit.job.current_job.job_type].type == 'Digging')) then
             table.insert(ensure_key(ignoredGroup, walkGroup), unit)


### PR DESCRIPTION
Did some testing on this. It definitely works to ignore citizens gathering fruit. I haven't ran into any issues of false positives so far, but we should still keep an eye on it 