### PR TITLE
[gui/control-panel] reduce frequency of warn-stranded check

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@ Template for new versions:
 ## Fixes
 
 ## Misc Improvements
+- `gui/control-panel`: reduce frequency for `warn-stranded` check to once every 2 days
 
 ## Removed
 

--- a/gui/control-panel.lua
+++ b/gui/control-panel.lua
@@ -140,7 +140,7 @@ local REPEATS = {
         command={'--time', '10', '--timeUnits', 'days', '--command', '[', 'warn-starving', ']'}},
     ['warn-stranded']={
         desc='Show a warning dialog when units are stranded from all others.',
-        command={'--time', '0.25', '--timeUnits', 'days', '--command', '[', 'warn-stranded', ']'}},
+        command={'--time', '2', '--timeUnits', 'days', '--command', '[', 'warn-stranded', ']'}},
 }
 local REPEATS_LIST = {}
 for k in pairs(REPEATS) do


### PR DESCRIPTION
since when you *know* they're stranded and you're remedying the situation, but you don't want to permanently ignore them, then 4x a day is too often to dismiss the popup.