### PR TITLE
Fix creature alcohol in ban-cooking.lua

### DIFF
--- a/ban-cooking.lua
+++ b/ban-cooking.lua
@@ -90,7 +90,7 @@ funcs.booze = function()
     for _, c in ipairs(df.global.world.raws.creatures.all) do
         for _, m in ipairs(c.material) do
             if m.flags.ALCOHOL and m.flags.EDIBLE_COOKED then
-                local matinfo = dfhack.matinfo.find(creature_id.id, m.id)
+                local matinfo = dfhack.matinfo.find(c.creature_id, m.id)
                 ban_cooking(c.name[2] .. ' ' .. m.id, matinfo.type, matinfo.index, df.item_type.DRINK, -1)
             end
         end

--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `ban-cooking`: fix banning creature alcohols resulting in error
 
 ## Misc Improvements
 - `gui/control-panel`: reduce frequency for `warn-stranded` check to once every 2 days


### PR DESCRIPTION
The creature ID is currently nil due to being an uninitialized variable, causing ban-cooking to error if a creature alcohol has the [EDIBLE_COOKED] token. This replaces the uninitialized variable with the one containing the creature ID.