### PR TITLE
[gui/blueprint] resolve duplicate key assignment

### DIFF
--- a/gui/blueprint.lua
+++ b/gui/blueprint.lua
@@ -241,7 +241,7 @@ function StartPosPanel:init()
     self:addviews{
         widgets.CycleHotkeyLabel{
             view_id='startpos',
-            key='CUSTOM_P',
+            key='CUSTOM_S',
             label='playback start',
             options={'Unset', 'Setting', 'Set'},
             initial_option=self.start_pos and 'Set' or 'Unset',


### PR DESCRIPTION
In `gui/blueprint` : `p` is used both for the "place" phase and for the "starting position". This changes the latter to `s`.