### PR TITLE
reinstate uniform-unstick

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ Template for new versions:
 - `uniform-unstick`: (reinstated) force squad members to drop items that they picked up in the wrong order so they can get everything equipped properly
 
 ## New Features
+- `uniform-unstick`: add overlay to the squad equipment screen to show a equipment conflict report and give you a one-click button to fix
 
 ## Fixes
 - `warn-stranded`: Automatically ignore citizens who are gathering plants or digging to avoid issues with gathering fruit via stepladders and weird issues with digging

--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ Template for new versions:
 
 ## New Tools
 - `control-panel`: new commandline interface for control panel functions
+- `uniform-unstick`: (reinstated) force squad members to drop items that they picked up in the wrong order so they can get everything equipped properly
 
 ## New Features
 

--- a/docs/uniform-unstick.rst
+++ b/docs/uniform-unstick.rst
@@ -48,3 +48,11 @@ Strategy options
     ground, ready to be claimed.
 ``--multi``
     Attempt to fix issues with uniforms that allow multiple items per body part.
+
+Overlay
+-------
+
+This script adds a small link to the squad equipment page that will run
+``uniform-unstick --all --drop --free`` when clicked. If any items are
+unassigned (they'll turn red on the equipment screen), hit the "Update
+Equipment" button to get everything resolved.

--- a/docs/uniform-unstick.rst
+++ b/docs/uniform-unstick.rst
@@ -3,7 +3,7 @@ uniform-unstick
 
 .. dfhack-tool::
     :summary: Make military units reevaluate their uniforms.
-    :tags: unavailable
+    :tags: fort bugfix military
 
 This tool prompts military units to reevaluate their uniform, making them
 remove and drop potentially conflicting worn items.
@@ -14,6 +14,9 @@ remove clothing (e.g. shoes, trousers) if the unit has yet to claim an armor
 item for that bodypart (e.g. if you're still manufacturing them).
 
 Uniforms that have no issues are being properly worn will not be affected.
+
+Note that this tool cannot fix the case where the same item is assigned to
+multiple squad members.
 
 Usage
 -----
@@ -42,3 +45,5 @@ Strategy options
     Remove to-equip items from containers or other's inventories and place them
     on the ground, ready to be claimed. This is most useful when someone else
     is wearing/holding the required items.
+``--multi``
+    Attempt to fix issues with uniforms that allow multiple items per body part.

--- a/docs/uniform-unstick.rst
+++ b/docs/uniform-unstick.rst
@@ -53,6 +53,9 @@ Overlay
 -------
 
 This script adds a small link to the squad equipment page that will run
-``uniform-unstick --all --drop --free`` when clicked. If any items are
-unassigned (they'll turn red on the equipment screen), hit the "Update
-Equipment" button to get everything resolved.
+``uniform-unstick --all`` and show the report when clicked. After reviewing the
+report, you can right click to exit and do nothing or you can click the "Try to
+resolve conflicts" button, which runs the equivalent of
+``uniform-unstick --all --drop --free``. If any items are unassigned (they'll
+turn red on the equipment screen), hit the "Update Equipment" button to
+reassign equipment.

--- a/docs/uniform-unstick.rst
+++ b/docs/uniform-unstick.rst
@@ -6,7 +6,11 @@ uniform-unstick
     :tags: fort bugfix military
 
 This tool prompts military units to reevaluate their uniform, making them
-remove and drop potentially conflicting worn items.
+remove and drop potentially conflicting worn items. If multiple units claim the
+same item, the item will be unassigned from all units that are not already
+wearing the item. If this happens, you'll have to click the "Update equipment"
+button on the Squads "Equip" screen in order for them to get new equipment
+assigned.
 
 Unlike a "replace clothing" designation, it won't remove additional clothing if
 it's coexisting with a uniform item already on that body part. It also won't
@@ -14,9 +18,6 @@ remove clothing (e.g. shoes, trousers) if the unit has yet to claim an armor
 item for that bodypart (e.g. if you're still manufacturing them).
 
 Uniforms that have no issues are being properly worn will not be affected.
-
-Note that this tool cannot fix the case where the same item is assigned to
-multiple squad members.
 
 Usage
 -----

--- a/docs/uniform-unstick.rst
+++ b/docs/uniform-unstick.rst
@@ -42,8 +42,8 @@ Strategy options
     Force the unit to drop conflicting worn items onto the ground, where they
     can then be reclaimed in the correct order.
 ``--free``
-    Remove to-equip items from containers or other's inventories and place them
-    on the ground, ready to be claimed. This is most useful when someone else
-    is wearing/holding the required items.
+    Remove items from the uniform assignment if someone else has a claim on
+    them. This will also remove items from containers and place them on the
+    ground, ready to be claimed.
 ``--multi``
     Attempt to fix issues with uniforms that allow multiple items per body part.

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -1,279 +1,225 @@
 -- Prompt units to adjust their uniform.
-local help = [====[
-
-uniform-unstick
-===============
-
-Prompt units to reevaluate their uniform, by removing/dropping potentially conflicting worn items.
-
-Unlike a "replace clothing" designation, it won't remove additional clothing
-if it's coexisting with a uniform item already on that body part.
-It also won't remove clothing (e.g. shoes, trousers) if the unit has yet to claim an
-armor item for that bodypart. (e.g. if you're still manufacturing them.)
-
-By default it simply prints info about the currently selected unit,
-to actually drop items, you need to provide it the -drop option.
-
-The default algorithm assumes that there's only one armor item assigned per body part,
-which means that it may miss cases where one piece of armor is blocked but the other
-is present. The -multi option can possibly get around this, but at the cost of ignoring
-left/right distinctions when dropping items.
-
-In some cases, an assigned armor item can't be put on because someone else is wearing/holding it.
-The -free option will cause the assigned item to be removed from the container/dwarven inventory
-and placed onto the ground, ready for pickup.
-
-In no cases should the command cause a uniform item that is being properly worn to be removed/dropped.
-
-Targets:
-
-:(no target): Force the selected dwarf to put on their uniform.
-:-all:        Force the uniform on all military dwarves.
-
-Options:
-
-:(none):      Simply show identified issues (dry-run).
-:-drop:       Cause offending worn items to be placed on ground under unit.
-:-free:       Remove to-equip items from containers or other's inventories, and place on ground.
-:-multi:      Be more agressive in removing items, best for when uniforms have muliple items per body part.
-]====]
-
 local utils = require('utils')
 
 local validArgs = utils.invert({
-  'all',
-  'drop',
-  'free',
-  'multi',
-  'help'
+    'all',
+    'drop',
+    'free',
+    'multi',
+    'help'
 })
 
 -- Functions
 
-function item_description(item)
-  return dfhack.df2console( dfhack.items.getDescription(item, 0, true) )
+local function item_description(item)
+    return dfhack.df2console(dfhack.items.getDescription(item, 0, true))
 end
 
-function get_item_pos(item)
-  local x, y, z = dfhack.items.getPosition(item)
-  if x == nil or y == nil or z == nil then
-    return nil
-  end
+local function get_item_pos(item)
+    local x, y, z = dfhack.items.getPosition(item)
+    if not x or not y or not z then
+        return
+    end
 
-  if not dfhack.maps.isValidTilePos(x,y,z) then
-    print("NOT VALID TILE")
-    return nil
-  end
-  if not dfhack.maps.isTileVisible(x,y,z) then
-    print("NOT VISIBLE TILE")
-    return nil
-  end
-  return xyz2pos(x, y, z)
+    if dfhack.maps.isTileVisible(x, y, z) then
+        return xyz2pos(x, y, z)
+    end
 end
 
-function find_squad_position(unit)
-  for i, squad in pairs( df.global.world.squads.all ) do
-    for i, position in pairs( squad.positions ) do
-      if position.occupant == unit.hist_figure_id then
-        return position
-      end
+local function find_squad_position(unit)
+    for _, squad in ipairs(df.global.world.squads.all) do
+        for _, position in ipairs(squad.positions) do
+            if position.occupant == unit.hist_figure_id then
+                return position
+            end
+        end
     end
-  end
-  return nil
 end
 
-function bodyparts_that_can_wear(unit, item)
+local function bodyparts_that_can_wear(unit, item)
+    local bodyparts = {}
+    local unitparts = df.creature_raw.find(unit.race).caste[unit.caste].body_info.body_parts
 
-  local bodyparts = {}
-  local unitparts = df.creature_raw.find(unit.race).caste[unit.caste].body_info.body_parts
+    if item._type == df.item_helmst then
+        for index, part in ipairs(unitparts) do
+            if part.flags.HEAD then
+                table.insert(bodyparts, index)
+            end
+        end
+    elseif item._type == df.item_armorst then
+        for index, part in ipairs(unitparts) do
+            if part.flags.UPPERBODY then
+                table.insert(bodyparts, index)
+            end
+        end
+    elseif item._type == df.item_glovesst then
+        for index, part in ipairs(unitparts) do
+            if part.flags.GRASP then
+                table.insert(bodyparts, index)
+            end
+        end
+    elseif item._type == df.item_pantsst then
+        for index, part in ipairs(unitparts) do
+            if part.flags.LOWERBODY then
+                table.insert(bodyparts, index)
+            end
+        end
+    elseif item._type == df.item_shoesst then
+        for index, part in ipairs(unitparts) do
+            if part.flags.STANCE then
+                table.insert(bodyparts, index)
+            end
+        end
+    else
+        -- print("Ignoring item type for "..item_description(item) )
+    end
 
-  if item._type == df.item_helmst then
-    for index, part in pairs(unitparts) do
-      if part.flags.HEAD then
-        table.insert(bodyparts, index)
-      end
-    end
-  elseif item._type == df.item_armorst then
-    for index, part in pairs(unitparts) do
-      if part.flags.UPPERBODY then
-        table.insert(bodyparts, index)
-      end
-    end
-  elseif item._type == df.item_glovesst then
-    for index, part in pairs(unitparts) do
-      if part.flags.GRASP then
-        table.insert(bodyparts, index)
-      end
-    end
-  elseif item._type == df.item_pantsst then
-    for index, part in pairs(unitparts) do
-      if part.flags.LOWERBODY then
-        table.insert(bodyparts, index)
-      end
-    end
-  elseif item._type == df.item_shoesst then
-    for index, part in pairs(unitparts) do
-      if part.flags.STANCE then
-        table.insert(bodyparts, index)
-      end
-    end
-  else
-    -- print("Ignoring item type for "..item_description(item) )
-  end
-
-  return bodyparts
+    return bodyparts
 end
 
 -- Will figure out which items need to be moved to the floor, returns an item_id:item map
-function process(unit, args)
-  local silent = args.all -- Don't print details if we're iterating through all dwarves
-  local unit_name = dfhack.df2console( dfhack.TranslateName( dfhack.units.getVisibleName(unit) ) )
+local function process(unit, args)
+    local silent = args.all -- Don't print details if we're iterating through all dwarves
+    local unit_name = dfhack.df2console(dfhack.TranslateName(dfhack.units.getVisibleName(unit)))
 
-  if not silent then
-    print("Processing unit "..unit_name)
-  end
-
-  -- The return value
-  local to_drop = {} -- item id to item object
-
-  -- First get squad position for an early-out for non-military dwarves
-  local squad_position = find_squad_position(unit)
-  if squad_position == nil then
     if not silent then
-      print("Unit "..unit_name.." does not have a military uniform.")
+        print("Processing unit " .. unit_name)
     end
-    return nil
-  end
 
-  -- Find all worn items which may be at issue.
-  local worn_items = {} -- map of item ids to item objects
-  local worn_parts = {} -- map of item ids to body part ids
-  for k, inv_item in pairs(unit.inventory) do
-   local item = inv_item.item
-   if inv_item.mode == df.unit_inventory_item.T_mode.Worn or inv_item.mode == df.unit_inventory_item.T_mode.Weapon then -- Include weapons so we can check we have them later
-     worn_items[ item.id ] = item
-     worn_parts[ item.id ] = inv_item.body_part_id
-   end
-  end
+    -- The return value
+    local to_drop = {} -- item id to item object
 
-  -- Now get info about which items have been assigned as part of the uniform
-  local assigned_items = {} -- assigned item ids mapped to item objects
-  for loc, specs in pairs( squad_position.uniform ) do
-    for i, spec in pairs(specs) do
-      for i, assigned in pairs( spec.assigned ) do
-        -- Include weapon and shield so we can avoid dropping them, or pull them out of container/inventory later
-        assigned_items[ assigned ] = df.item.find( assigned )
-      end
-    end
-  end
-
-  -- Figure out which assigned items are currently not being worn
-
-  local present_ids = {} -- map of item ID to item object
-  local missing_ids = {} -- map of item ID to item object
-  for u_id, item in pairs(assigned_items) do
-    if worn_items[ u_id ] == nil then
-      print("Unit "..unit_name.." is missing an assigned item, object #"..u_id.." '"..item_description(item).."'" )
-      missing_ids[ u_id ] = item
-      if args.free then
-        to_drop[ u_id ] = item
-      end
-    else
-      present_ids[ u_id ] = item
-    end
-  end
-
-  -- Figure out which worn items should be dropped
-
-  -- First, figure out which body parts are covered by the uniform pieces we have.
-  local covered = {} -- map of body part id to true/nil
-  for id, item in pairs( present_ids ) do
-    if item._type ~= df.item_weaponst and item._type ~= df.item_shieldst then -- weapons and shields don't "cover" the bodypart they're assigned to. (Needed to figure out if we're missing gloves.)
-      covered[ worn_parts[ id ] ] = true
-    end
-  end
-
-  if multi then
-    covered = {} -- Don't consider current covers - drop for anything which is missing
-  end
-
-  -- Figure out body parts which should be covered but aren't
-  local uncovered = {}
-  for id, item in pairs(missing_ids) do
-    for i, bp in pairs( bodyparts_that_can_wear(unit, item) ) do
-      if not covered[bp] then
-        uncovered[bp] = true
-      end
-    end
-  end
-
-  -- Drop everything (except uniform pieces) from body parts which should be covered but aren't
-  for w_id, item in pairs(worn_items) do
-    if assigned_items[ w_id ] == nil then -- don't drop uniform pieces (including shields, weapons for hands)
-      if uncovered[ worn_parts[ w_id ] ] then
-        print("Unit "..unit_name.." potentially has object #"..w_id.." '"..item_description(item).."' blocking a missing uniform item.")
-        if args.drop then
-          to_drop[ w_id ] = item
+    -- First get squad position for an early-out for non-military dwarves
+    local squad_position = find_squad_position(unit)
+    if not squad_position then
+        if not silent then
+            print("Unit " .. unit_name .. " does not have a military uniform.")
         end
-      end
+        return
     end
-  end
 
-  return to_drop
+    -- Find all worn items which may be at issue.
+    local worn_items = {} -- map of item ids to item objects
+    local worn_parts = {} -- map of item ids to body part ids
+    for _, inv_item in ipairs(unit.inventory) do
+        local item = inv_item.item
+        -- Include weapons so we can check we have them later
+        if inv_item.mode == df.unit_inventory_item.T_mode.Worn or
+            inv_item.mode == df.unit_inventory_item.T_mode.Weapon
+        then
+            worn_items[item.id] = item
+            worn_parts[item.id] = inv_item.body_part_id
+        end
+    end
+
+    -- Now get info about which items have been assigned as part of the uniform
+    local assigned_items = {} -- assigned item ids mapped to item objects
+    for _, specs in ipairs(squad_position.uniform) do
+        for _, spec in ipairs(specs) do
+            for _, assigned in ipairs(spec.assigned) do
+                -- Include weapon and shield so we can avoid dropping them, or pull them out of container/inventory later
+                assigned_items[assigned] = df.item.find(assigned)
+            end
+        end
+    end
+
+    -- Figure out which assigned items are currently not being worn
+
+    local present_ids = {} -- map of item ID to item object
+    local missing_ids = {} -- map of item ID to item object
+    for u_id, item in pairs(assigned_items) do
+        if not worn_items[u_id] then
+            print("Unit " .. unit_name .. " is missing an assigned item, object #" .. u_id .. " '" ..
+                item_description(item) .. "'")
+            missing_ids[u_id] = item
+            if args.free then
+                to_drop[u_id] = item
+            end
+        else
+            present_ids[u_id] = item
+        end
+    end
+
+    -- Figure out which worn items should be dropped
+
+    -- First, figure out which body parts are covered by the uniform pieces we have.
+    -- unless --multi is specified, in which we don't care
+    local covered = {} -- map of body part id to true/nil
+    if not args.multi then
+        for id, item in pairs(present_ids) do
+            -- weapons and shields don't "cover" the bodypart they're assigned to. (Needed to figure out if we're missing gloves.)
+            if item._type ~= df.item_weaponst and item._type ~= df.item_shieldst then
+                covered[worn_parts[id]] = true
+            end
+        end
+    end
+
+    -- Figure out body parts which should be covered but aren't
+    local uncovered = {}
+    for _, item in pairs(missing_ids) do
+        for _, bp in ipairs(bodyparts_that_can_wear(unit, item)) do
+            if not covered[bp] then
+                uncovered[bp] = true
+            end
+        end
+    end
+
+    -- Drop everything (except uniform pieces) from body parts which should be covered but aren't
+    for w_id, item in pairs(worn_items) do
+        if assigned_items[w_id] == nil then -- don't drop uniform pieces (including shields, weapons for hands)
+            if uncovered[worn_parts[w_id]] then
+                print("Unit " ..
+                    unit_name ..
+                    " potentially has object #" ..
+                    w_id .. " '" .. item_description(item) .. "' blocking a missing uniform item.")
+                if args.drop then
+                    to_drop[w_id] = item
+                end
+            end
+        end
+    end
+
+    return to_drop
 end
 
-
-function do_drop( item_list )
-  if item_list == nil then
-    return nil
-  end
-
-  local mode_swap = false
-  if df.global.plotinfo.main.mode == df.ui_sidebar_mode.ViewUnits then
-    df.global.plotinfo.main.mode = df.ui_sidebar_mode.Default
-    mode_swap = true
-  end
-
-  for id, item in pairs(item_list) do
-    local pos = get_item_pos(item)
-    if pos == nil then
-      dfhack.printerr("Could not find drop location for item #"..id.."  "..item_description(item))
-    else
-      local retval = dfhack.items.moveToGround( item, pos )
-      if retval == false then
-        dfhack.printerr("Could not drop object #"..id.."  "..item_description(item))
-      else
-        print("Dropped item #"..id.." '"..item_description(item).."'")
-      end
+local function do_drop(item_list)
+    if not item_list then
+        return
     end
-  end
 
-  if mode_swap then
-    df.global.plotinfo.main.mode = df.ui_sidebar_mode.ViewUnits
-  end
+    for id, item in pairs(item_list) do
+        local pos = get_item_pos(item)
+        if not pos then
+            dfhack.printerr("Could not find drop location for item #" .. id .. "  " .. item_description(item))
+        else
+            if dfhack.items.moveToGround(item, pos) then
+                print("Dropped item #" .. id .. " '" .. item_description(item) .. "'")
+            else
+                dfhack.printerr("Could not drop object #" .. id .. "  " .. item_description(item))
+            end
+        end
+    end
 end
 
 
 -- Main
 
-local args = utils.processArgs({...}, validArgs)
+local args = utils.processArgs({ ... }, validArgs)
 
 if args.help then
-    print(help)
+    print(dfhack.script_help())
     return
 end
 
 if args.all then
-  for k,unit in ipairs(df.global.world.units.active) do
-    if dfhack.units.isCitizen(unit) then
-      local to_drop = process(unit,args)
-      do_drop( to_drop )
+    for _, unit in ipairs(dfhack.units.getCitizens(false)) do
+        do_drop(process(unit, args))
     end
-  end
 else
-  local unit=dfhack.gui.getSelectedUnit()
-  if unit then
-    local to_drop = process(unit,args)
-    do_drop( to_drop )
-  end
+    local unit = dfhack.gui.getSelectedUnit()
+    if unit then
+        do_drop(process(unit, args))
+    else
+        qerror("Please select a unit if not running with --all")
+    end
 end

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -103,7 +103,8 @@ local function process(unit, args)
         local item = inv_item.item
         -- Include weapons so we can check we have them later
         if inv_item.mode == df.unit_inventory_item.T_mode.Worn or
-            inv_item.mode == df.unit_inventory_item.T_mode.Weapon
+            inv_item.mode == df.unit_inventory_item.T_mode.Weapon or
+            inv_item.mode == df.unit_inventory_item.T_mode.Strapped
         then
             worn_items[item.id] = item
             worn_parts[item.id] = inv_item.body_part_id

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -1,5 +1,6 @@
 --@ module=true
 
+local gui = require('gui')
 local overlay = require('plugins.overlay')
 local utils = require('utils')
 local widgets = require('gui.widgets')
@@ -245,24 +246,98 @@ local function main(args)
     end
 end
 
+ReportWindow = defclass(ReportWindow, widgets.Window)
+ReportWindow.ATTRS {
+    frame_title='Equipment conflict report',
+    frame={w=100, h=45},
+    resizable=true, -- if resizing makes sense for your dialog
+    resize_min={w=50, h=20}, -- try to allow users to shrink your windows
+    autoarrange_subviews=1,
+    autoarrange_gap=1,
+    report=DEFAULT_NIL,
+}
+
+function ReportWindow:init()
+    self:addviews{
+        widgets.HotkeyLabel{
+            frame={t=0, l=0, r=0},
+            label='Try to resolve conflicts',
+            key='CUSTOM_CTRL_T',
+            auto_width=true,
+            on_activate=function()
+                dfhack.run_script('uniform-unstick', '--all', '--drop', '--free')
+                self.parent_view:dismiss()
+            end,
+        },
+        widgets.WrappedLabel{
+            frame={t=2, l=0, r=0},
+            text_pen=COLOR_LIGHTRED,
+            text_to_wrap='After resolving conflicts, be sure to click the "Update equipment" button to reassign new equipment!',
+        },
+        widgets.WrappedLabel{
+            frame={t=4, l=0, r=0},
+            text_to_wrap=self.report,
+        },
+    }
+end
+
+ReportScreen = defclass(ReportScreen, gui.ZScreenModal)
+ReportScreen.ATTRS {
+    focus_path='equipreport',
+    report=DEFAULT_NIL,
+}
+
+function ReportScreen:init()
+    self:addviews{ReportWindow{report=self.report}}
+end
+
 EquipOverlay = defclass(EquipOverlay, overlay.OverlayWidget)
 EquipOverlay.ATTRS{
     desc='Adds a link to the equip screen to fix equipment conflicts.',
-    default_pos={x=-102,y=21},
+    default_pos={x=-101,y=21},
     default_enabled=true,
     viewscreens='dwarfmode/SquadEquipment',
-    frame={w=23, h=1},
+    frame={w=26, h=1},
 }
 
 function EquipOverlay:init()
     self:addviews{
         widgets.TextButton{
+            view_id='button',
             frame={t=0, l=0, r=0, h=1},
-            label='Fix conflicts',
+            label='Detect conflicts',
             key='CUSTOM_CTRL_T',
-            on_activate=function() main{'--all', '--drop', '--free'} end,
+            on_activate=self:callback('run_report'),
+        },
+        widgets.TextButton{
+            view_id='button_good',
+            frame={t=0, l=0, r=0, h=1},
+            label='   All good!    ',
+            text_pen=COLOR_GREEN,
+            key='CUSTOM_CTRL_T',
+            visible=false,
         },
     }
+end
+
+function EquipOverlay:run_report()
+    local output = dfhack.run_command_silent({'uniform-unstick', '--all'})
+    if #output == 0 then
+        self.subviews.button.visible = false
+        self.subviews.button_good.visible = true
+        local end_ms = dfhack.getTickCount() + 5000
+        local function label_reset()
+            if dfhack.getTickCount() < end_ms then
+                dfhack.timeout(10, 'frames', label_reset)
+            else
+                self.subviews.button_good.visible = false
+                self.subviews.button.visible = true
+            end
+        end
+        label_reset()
+    else
+        ReportScreen{report=output}:show()
+    end
 end
 
 OVERLAY_WIDGETS = {overlay=EquipOverlay}

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -79,6 +79,11 @@ local function bodyparts_that_can_wear(unit, item)
     return bodyparts
 end
 
+local function print_bad_labor(unit_name, labor_name)
+    print("WARNING: Unit " .. unit_name .. " has the " .. labor_name ..
+        " labor enabled, which conflicts with military uniforms.")
+end
+
 -- Will figure out which items need to be moved to the floor, returns an item_id:item map
 local function process(unit, args)
     local silent = args.all -- Don't print details if we're iterating through all dwarves
@@ -98,6 +103,14 @@ local function process(unit, args)
             print("Unit " .. unit_name .. " does not have a military uniform.")
         end
         return
+    end
+
+    if unit.status.labors.MINE then
+        print_bad_labor(unit_name, "mining")
+    elseif unit.status.labors.CUTWOOD then
+        print_bad_labor(unit_name, "woodcutting")
+    elseif unit.status.labors.HUNT then
+        print_bad_labor(unit_name, "hunting")
     end
 
     -- Find all worn items which may be at issue.


### PR DESCRIPTION
- reformat and clean up code
- fix handling of --multi option and add docs for it
- remove interaction with pre-v50 sidebar that no longer exists
- remove old in-script docstring
- add check for conflicting enabled labors (mining, woodcutting, hunting)
- add overlay for accessing functionality from the squad equipment screen

Fixes https://github.com/DFHack/dfhack/issues/4105