### PR TITLE
[gui/launcher] keep persistent scrollback buffer

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -45,6 +45,7 @@ Template for new versions:
 - `confirm`: updated confirmation dialogs to use clickable widgets and draggable windows
 - `confirm`: added confirmation dialog for right clicking out of the trade agreement screen (so your trade agreement selections aren't lost)
 - `gui/autobutcher`: interface redesigned to better support mouse control
+- `gui/launcher`: now persists the most recent 32KB of command output even if you close it and bring it back up
 
 ## Removed
 

--- a/docs/gui/launcher.rst
+++ b/docs/gui/launcher.rst
@@ -85,8 +85,11 @@ Once you run a command, the lower panel will switch to command output mode,
 where you can see any text the command printed to the screen. If you want to
 see more help text as you run further commands, you can switch the lower panel
 back to help mode with :kbd:`Ctrl`:kbd:`T`. The output text is kept for all the
-commands you run while the launcher window is open, but is cleared if you
-dismiss the launcher window and bring it back up.
+commands you run while the launcher window is open (up to 256KB of text), but
+only the most recent 32KB of text is saved if you dismiss the launcher window
+and bring it back up. Command output is also printed to the external DFHack
+console (the one you can show with `show` on Windows) or the parent terminal on
+Unix-based systems if you need a longer history of the output.
 
 Command history
 ---------------


### PR DESCRIPTION
but not too large so it doesn't bog down. only most recent 32k

if we kept the full scrollback buffer of 256k, then every command would take a second longer to run because of text processing and buffer copying. 32k seems like a good compromise.

From suggestion on reddit: https://www.reddit.com/r/dwarffortress/comments/18x651d/comment/kg3q55n/?utm_source=share&utm_medium=web2x&context=3