### PR TITLE
[confirm] add prompt for re-running embark site finder

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -47,6 +47,7 @@ Template for new versions:
 - `confirm`: added confirmation prompts for irreversible actions on the trade screen
 - `confirm`: added confirmation prompt for deleting a uniform
 - `confirm`: added confirmation prompt for convicting a criminal
+- `confirm`: added confirmation prompt for re-running the embark site finder
 - `gui/autobutcher`: interface redesigned to better support mouse control
 - `gui/launcher`: now persists the most recent 32KB of command output even if you close it and bring it back up
 - `gui/quickcmd`: clickable buttons for command add/remove/edit operations

--- a/internal/confirm/specs.lua
+++ b/internal/confirm/specs.lua
@@ -332,6 +332,19 @@ ConfirmSpec{
     pausable=true,
 }
 
+ConfirmSpec{
+    id='embark-site-finder',
+    title='Re-run finder',
+    message='Are you sure you want to re-run the site finder? Your current map highlights will be lost.',
+    intercept_keys='_MOUSE_L',
+    intercept_frame={r=2, t=36, w=7, h=3},
+    context='choose_start_site/SiteFinder',
+    predicate=function()
+        return dfhack.gui.getDFViewscreen(true).find_results ~= df.viewscreen_choose_start_sitest.T_find_results.None
+    end,
+    pausable=true,
+}
+
 --------------------------
 -- Config file management
 --


### PR DESCRIPTION
as requested on Reddit: https://www.reddit.com/r/dwarffortress/comments/18x651d/comment/kg4omsa/?utm_source=share&utm_medium=web2x&context=3

the confirmation prompt will only come up if there are already results on the map.