### PR TITLE
[confirm] add prompt for exiting the uniform customization page without saving

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -49,6 +49,7 @@ Template for new versions:
 - `confirm`: added confirmation prompt for convicting a criminal
 - `confirm`: added confirmation prompt for re-running the embark site finder
 - `confirm`: added confirmation prompt for reassigning or clearing zoom hotkeys
+- `confirm`: added confirmation prompt for exiting the uniform customization page without saving
 - `gui/autobutcher`: interface redesigned to better support mouse control
 - `gui/launcher`: now persists the most recent 32KB of command output even if you close it and bring it back up
 - `gui/quickcmd`: clickable buttons for command add/remove/edit operations

--- a/confirm.lua
+++ b/confirm.lua
@@ -171,7 +171,7 @@ function ConfirmOverlay:matches_conf(conf, keys, scr)
         mouse_offset = xy2pos(mousex, mousey)
     end
     if not dfhack.gui.matchFocusString(conf.context, scr) then return false end
-    return not conf.predicate or conf.predicate(mouse_offset)
+    return not conf.predicate or conf.predicate(keys, mouse_offset)
 end
 
 function ConfirmOverlay:onInput(keys)
@@ -183,6 +183,9 @@ function ConfirmOverlay:onInput(keys)
         if specs.config.data[id].enabled and self:matches_conf(conf, keys, scr) then
             local mouse_pos = xy2pos(dfhack.screen.getMousePos())
             local propagate_fn = function(pause)
+                if conf.on_propagate then
+                    conf.on_propagate()
+                end
                 if pause then
                     self.paused_conf = conf
                     self.overlay_onupdate_max_freq_seconds = 0

--- a/internal/confirm/specs.lua
+++ b/internal/confirm/specs.lua
@@ -22,6 +22,7 @@ ConfirmSpec.ATTRS{
     debug_frame=false, -- set to true when debugging frame positioning
     context=DEFAULT_NIL,
     predicate=DEFAULT_NIL,
+    on_propagate=DEFAULT_NIL, -- called if prompt is bypassed (Ok clicked or paused)
     pausable=false,
 }
 
@@ -239,7 +240,7 @@ ConfirmSpec{
     intercept_keys='_MOUSE_L',
     intercept_frame={r=131, t=23, w=6, h=27},
     context='dwarfmode/AssignUniform',
-    predicate=function(mouse_offset)
+    predicate=function(_, mouse_offset)
         local num_uniforms = get_num_uniforms()
         if num_uniforms == 0 then return false end
         -- adjust detection area depending on presence of scrollbar
@@ -254,6 +255,83 @@ ConfirmSpec{
     pausable=true,
 }
 
+local se = mi.squad_equipment
+local uniform_starting_state = nil
+
+local function uniform_has_changes()
+    for k, v in pairs(uniform_starting_state or {}) do
+        if type(v) == table then
+            if #v + 1 ~= #se[k] then return true end
+            for k2, v2 in pairs(v) do
+                if v2 ~= se[k][k2] then return true end
+            end
+        else
+            if v ~= se[k] then return true end
+        end
+    end
+    return false
+end
+
+local function ensure_uniform_record()
+    if uniform_starting_state then return end
+    uniform_starting_state = {
+        cs_cat=copyall(se.cs_cat),
+        cs_it_spec_item_id=copyall(se.cs_it_spec_item_id),
+        cs_it_type=copyall(se.cs_it_type),
+        cs_it_subtype=copyall(se.cs_it_subtype),
+        cs_civ_mat=copyall(se.cs_civ_mat),
+        cs_spec_mat=copyall(se.cs_spec_mat),
+        cs_spec_matg=copyall(se.cs_spec_matg),
+        cs_color_pattern_index=copyall(se.cs_color_pattern_index),
+        cs_icp_flag=copyall(se.cs_icp_flag),
+        cs_assigned_item_number=copyall(se.cs_assigned_item_number),
+        cs_assigned_item_id=copyall(se.cs_assigned_item_id),
+        cs_uniform_flag=se.cs_uniform_flag,
+    }
+end
+
+local function clear_uniform_record()
+    uniform_starting_state = nil
+end
+
+local function clicked_on_confirm_button(mouse_offset)
+    -- buttons are all in the top 3 lines
+    if mouse_offset.y > 2 then return false end
+    -- clicking on the Confirm button saves the uniform and closes the panel
+    if mouse_offset.x >= 38 and mouse_offset.x <= 46 then return true end
+    -- the "Confirm and save uniform" button does the same thing, but it is
+    -- only enabled if a name has been entered
+    if #mi.squad_equipment.customizing_squad_uniform_nickname == 0 then
+        return false
+    end
+    return mouse_offset.x >= 74 and mouse_offset.x <= 99
+end
+
+ConfirmSpec{
+    id='uniform-discard-changes',
+    title='Discard uniform changes',
+    message='Are you sure you want to discard changes to this uniform?',
+    intercept_keys={'_MOUSE_L', '_MOUSE_R'},
+    -- sticks out the left side so it can move with the panel
+    -- when the screen is resized too narrow
+    intercept_frame={r=32, t=19, w=101, b=3},
+    debug_frame=true,
+    context='dwarfmode/SquadEquipment/Customizing/Default',
+    predicate=function(keys, mouse_offset)
+        if keys._MOUSE_R then
+            return uniform_has_changes()
+        end
+        if clicked_on_confirm_button(mouse_offset) then
+            print('confirm click detected')
+            clear_uniform_record()
+        else
+            ensure_uniform_record()
+        end
+        return false
+    end,
+    on_propagate=clear_uniform_record,
+}
+
 local hotkey_reset_action = 'reset'
 local num_hotkeys = 16
 ConfirmSpec{
@@ -263,7 +341,7 @@ ConfirmSpec{
     intercept_keys='_MOUSE_L',
     intercept_frame={r=32, t=11, w=12, b=9},
     context='dwarfmode/Hotkey',
-    predicate=function(mouse_offset)
+    predicate=function(_, mouse_offset)
         local _, sh = dfhack.screen.getWindowSize()
         local num_sections = (sh - 20) // 3
         local selected_section = mouse_offset.y // 3
@@ -313,7 +391,7 @@ ConfirmSpec{
     intercept_keys='_MOUSE_L',
     intercept_frame={r=31, t=14, w=11, b=5},
     context='dwarfmode/Info/JUSTICE/Convicting',
-    predicate=function(mouse_offset)
+    predicate=function(_, mouse_offset)
         local justice = mi.info.justice
         local num_choices = #justice.conviction_list
         if num_choices == 0 then return false end


### PR DESCRIPTION
as requested (several times) in the reddit thread: https://www.reddit.com/r/dwarffortress/comments/18x651d/what_buttons_do_you_wish_had_an_are_you_really/

this required a few extensions to the confirm architecture. nothing terrible, but indicative that this is a particularly hard case to handle.