### PR TITLE
rewrite gui/mass-remove to be more user friendly

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -53,6 +53,8 @@ Template for new versions:
 - `gui/autobutcher`: interface redesigned to better support mouse control
 - `gui/launcher`: now persists the most recent 32KB of command output even if you close it and bring it back up
 - `gui/quickcmd`: clickable buttons for command add/remove/edit operations
+- `gui/mass-remove`: can now differentiate planned constructions, stockpiles, and regular buildings
+- `gui/mass-remove`: can now remove zones
 
 ## Removed
 

--- a/docs/gui/mass-remove.rst
+++ b/docs/gui/mass-remove.rst
@@ -2,29 +2,16 @@ gui/mass-remove
 ===============
 
 .. dfhack-tool::
-    :summary: Mass select buildings and constructions to suspend or remove.
+    :summary: Mass select things to remove.
     :tags: fort design productivity buildings stockpiles
 
-This tool lets you remove buildings/constructions or suspend/unsuspend
-construction jobs using a mouse-driven box selection.
+This tool lets you remove buildings, constructions, stockpiles, and/or zones
+using a mouse-driven box selection. You can choose which you want to remove
+with the given filters, then box select to apply to the map.
 
-The following marking modes are available.
-
-:Suspend: Suspend the construction of a planned building/construction.
-:Unsuspend: Resume the construction of a suspended planned
-    building/construction. Note that buildings planned with `buildingplan`
-    that are waiting for items cannot be unsuspended until all pending items
-    are attached.
-:Remove Construction: Designate a construction (wall, floor, etc.) for removal.
-:Unremove Construction: Cancel removal of a construction (wall, floor, etc.).
-:Remove Building: Designate a building (door, workshop, etc) for removal.
-:Unremove Building: Cancel removal of a building (door, workshop, etc.).
-:Remove All: Designate both constructions and buildings for removal, and deletes
-    planned buildings/constructions.
-:Unremove All: Cancel removal designations for both constructions and buildings.
-
-Note: ``Unremove Construction`` and ``Unremove Building`` are not yet available
-for the latest release of Dwarf Fortress.
+Planned buildings, constructions, stockpiles, and zones will be removed
+immediately. Built buildings and constructions will be designated for
+deconstruction.
 
 Usage
 -----


### PR DESCRIPTION
differentiate types of buildings (stockpiles vs. planned constructions vs. regular buildings) and make removal independently configurable for each type

also ensure that nothing is selected before we start removing things -- removing the selected building/zone causes a crash

suspend functionality removed since it didn't seem to fit in with the other options. Also, `suspendmanager` would just immediately undo what was suspended. We might need a better answer to this in the future.

as prompted by the Reddit thread: https://www.reddit.com/r/dwarffortress/comments/18x651d/what_buttons_do_you_wish_had_an_are_you_really/

Fixes: https://github.com/DFHack/dfhack/issues/4084
Fixes: https://github.com/DFHack/dfhack/issues/3369