### PR TITLE
workorder-detail-fix: Enforce order item details for buggy job types

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -40,6 +40,7 @@ Template for new versions:
 - `warn-stranded`: Update onZoom to use df's centering functionality
 - `ban-cooking`: fix banning creature alcohols resulting in error
 - `confirm`: properly detect clicks on the remove zone button even when the unit selection screen is also open (e.g. the vanilla assign animal to pasture panel)
+- `workorder-detail-fix`: fix item types not being passed properly on some modified work order jobs
 
 ## Misc Improvements
 - `gui/control-panel`: reduce frequency for `warn-stranded` check to once every 2 days

--- a/docs/workorder-detail-fix.rst
+++ b/docs/workorder-detail-fix.rst
@@ -1,0 +1,24 @@
+workorder-detail-fix
+=========
+
+.. dfhack-tool::
+    :summary: Fixes a bug with modified work orders creating incorrect jobs.
+    :tags: fort bugfix workorders
+
+Some work order jobs have a bug when their input item details have been modified.
+
+Example 1: a Stud With Iron order, modified to stud a cabinet, instead creates a job to stud any furniture.
+
+Example 2: a Prepare Meal order, modified to use all plant type ingredients, instead creates a job to use any ingredients.
+
+This fix forces these jobs to properly inherit the item details from their work order.
+
+Usage
+-----
+
+``workorder-detail-fix enable``
+    enables the fix
+``workorder-detail-fix disable``
+    disables the fix
+``workorder-detail-fix status``
+    print fix status

--- a/workorder-detail-fix.lua
+++ b/workorder-detail-fix.lua
@@ -1,0 +1,114 @@
+local script_name = "workorder-detail-fix"
+local eventful = require 'plugins.eventful'
+if not handler_ref then local handler_ref = nil end 
+
+local function get_job_id(match)
+    for val, name in ipairs(df.job_type) do 
+        if name == match then return val end
+    end
+end
+
+-- all jobs with the "any" (-1) type in its default job_items may be a problem
+local offending_jobs = {
+    [get_job_id("EncrustWithGems")] = true,
+    [get_job_id("EncrustWithGlass")] = true,
+    [get_job_id("StudWith")] = true,
+    [get_job_id("PrepareMeal")] = true,
+    [get_job_id("DecorateWith")] = true,
+    [get_job_id("SewImage")] = true,
+    -- list may be incomplete
+}
+
+-- copy order.item fields/flags over to job's job_item
+-- only the essentials: stuff that is editable via gui/job-details
+local function correct_item_details(job_item, order_item)
+    local fields = {'item_type', 'item_subtype', 'mat_type', 'mat_index'}
+    for _, field in pairs(fields) do 
+        job_item[field] = order_item[field] 
+    end
+
+    local flags_names = {'flags1', 'flags2', 'flags3', 'flags4', 'flags5'}
+    for _, flags in pairs(flags_names) do 
+        local order_flags = order_item[flags]
+        if type(order_flags) == "number" then 
+            job_item[flags] = order_flags
+        else -- copy over the flags one by one
+            for o_flag, val in pairs(order_flags) do 
+                job_item[flags][o_flag] = val
+            end
+        end
+    end
+end
+
+-- correct each job as it's initialized 
+-- this is the handler, running after the job is dispatched
+local function enforce_order_details(job)
+    if not job.job_items then return end -- never happens (error here?)
+    local order_id = job.order_id -- only jobs with an ORDER ID 
+    if (order_id == -1) or (order_id == nil) then return end
+
+    -- only jobs with the item type issue. encrusting, sewing, cooking, etc.
+    if not offending_jobs[job.job_type] then return end
+
+    local order = nil -- get the order ref from order id
+    for _, ord in ipairs(df.global.world.manager_orders) do 
+        if ord.id == order_id then order = ord; break end
+    end
+
+    if not order then return end -- oops, no order
+    if not order.items then return end -- no order item details to enforce
+
+    -- copy the item details over when the types don't match
+    for idx, job_item in ipairs(job.job_items) do
+        local order_item = order.items[idx]
+        if not order_item then break end -- never happens (error here?)
+        if job_item.item_type ~= order_item.item_type then
+            -- dfhack's isSuitableItem function will allow the orders we want,
+            -- but disallow insane combinations like meals made of shoes
+            local suitable = dfhack.job.isSuitableItem(
+                job_item, order_item.item_type, order_item.item_subtype )
+            if suitable then 
+                correct_item_details(job_item, order_item)
+            else --[[ error on unsuitable item?]] end
+        end
+    end
+end
+
+local function enable() 
+    print(script_name.." ENABLED")
+    -- set eventful onJobInitiated handler to run every tick (frequency 0)
+    eventful.enableEvent(eventful.eventType.JOB_INITIATED, 0) 
+    eventful.onJobInitiated.workorder_detail_fix = enforce_order_details
+    handler_ref = eventful.onJobInitiated.workorder_detail_fix
+end
+
+local function disable()
+    print(script_name.." DISABLED")
+    eventful.onJobInitiated.workorder_detail_fix = nil
+    handler_ref = nil
+end
+
+local function status()
+    local status = "DISABLED"
+    local handler = eventful.onJobInitiated.workorder_detail_fix
+    if handler ~= nil then
+        -- ensure the handler still matches the one copied back from eventful
+        if handler == handler_ref then 
+            status = "ENABLED"
+        else
+            status = "ERROR: Handler overwritten!"
+            print("why is this here:", handler)
+            print("should be", handler_ref)
+        end
+    end
+    print(script_name.." status: "..status)
+end
+
+args={...}
+
+cmd_table = { ["enable"]=enable, ["disable"]=disable, ["status"]=status }
+
+cmd = cmd_table[args[1]:lower()]
+if cmd then cmd() else
+    print(script_name.." valid cmds: enable, disable, status")
+end


### PR DESCRIPTION
The fix: An 'eventful' handler that checks each job after it's dispatched to a workshop, correcting the details of any job items that have been altered from its parent order's. 

The bug: For certain work orders that have been changed via gui/job-details (or other means), jobs created from the order will revert the changes. This is because a job_item's type doesn't exactly match what is expected for the job. Particularly, the "any" type will pedantically only match other "any" types, so for jobs like PrepareMeal, a "plant" or "liquid" type job_item will trigger a revert when it's dispatched to the workshop. ("plant" =/= "any", technically)

With that fixed, it's easier to order lavish meals of meticulous selection, or silk images sewn specifically on hemp ropes.

One possible issue: Eventful frequency is set to max (every tick) for job initiated event, which will affect every other script using it. 

Before, I had it set up as a 100-tick periodic script, but there was some hassle with active jobs. Eventful's JOB_INITIATED check needs to run frequently enough to ensure that the job is caught before anyone starts gathering items. The items vector can be cleared if caught in time, just not sure if it's wise. I had to go in and manually un-task the cleared job items, and who knows what else could go wrong. Doing it just every 10 ticks might be fine as long as fastdwarf isnt on.