### PR TITLE
reinstate (read: rewrite) gui/teleport

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ Template for new versions:
 - `control-panel`: new commandline interface for control panel functions
 - `uniform-unstick`: (reinstated) force squad members to drop items that they picked up in the wrong order so they can get everything equipped properly
 - `gui/reveal`: temporarily unhide terrain and then automatically hide it again when you're ready to unpause
+- `gui/teleport`: mouse-driven interface for selecting and teleporting units
 
 ## New Features
 - `uniform-unstick`: add overlay to the squad equipment screen to show a equipment conflict report and give you a one-click button to fix

--- a/docs/gui/teleport.rst
+++ b/docs/gui/teleport.rst
@@ -11,6 +11,11 @@ around them on the map. Double clicking on a destination tile will teleport the 
 If a unit is already selected in the UI when you run `gui/teleport`, it will be
 pre-selected for teleport.
 
+Note that you *can* select enemies that are lying in ambush and are not visible
+on the map yet, so you if you select an area and see a marker that indicates
+that a unit is selected, but you don't see the unit itself, this is likely what
+it is. You can stil teleport these units while they are hidden.
+
 Usage
 -----
 

--- a/docs/gui/teleport.rst
+++ b/docs/gui/teleport.rst
@@ -2,11 +2,14 @@ gui/teleport
 ============
 
 .. dfhack-tool::
-    :summary: Teleport a unit anywhere.
-    :tags: unavailable
+    :summary: Teleport units anywhere.
+    :tags: fort armok units
 
-This tool is a front-end for the `teleport` tool. It allows you to interactively
-choose a unit to teleport and a destination tile using the in-game cursor.
+This tool allows you to interactively select units to teleport by drawing boxes
+around them on the map. Double clicking on a destination tile will teleport the selected units there.
+
+If a unit is already selected in the UI when you run `gui/teleport`, it will be
+pre-selected for teleport.
 
 Usage
 -----

--- a/gui/teleport.lua
+++ b/gui/teleport.lua
@@ -1,116 +1,345 @@
--- A front-end for the teleport script
+local gui = require('gui')
+local guidm = require('gui.dwarfmode')
+local widgets = require('gui.widgets')
 
---[====[
-
-gui/teleport
-============
-
-A front-end for the `teleport` script that allows choosing a unit and destination
-using the in-game cursor.
-
-]====]
-
-guidm = require 'gui.dwarfmode'
-widgets = require 'gui.widgets'
-
-function uiMultipleUnits()
-    return #df.global.game.unit_cursor.list > 1
+local function get_dims(pos1, pos2)
+    local width, height, depth = math.abs(pos1.x - pos2.x) + 1,
+            math.abs(pos1.y - pos2.y) + 1,
+            math.abs(pos1.z - pos2.z) + 1
+    return width, height, depth
 end
 
-TeleportSidebar = defclass(TeleportSidebar, guidm.MenuOverlay)
+local function is_good_unit(unit, include)
+    if not unit then return false end
+    if item.flags.forbid and not include.forbidden then return false end
+    if item.flags.in_job and not include.in_job then return false end
+    if item.flags.trader and not include.trader then return false end
+    return true
+end
 
-TeleportSidebar.ATTRS = {
-    sidebar_mode=df.ui_sidebar_mode.ViewUnits,
+-----------------
+-- Teleport
+--
+
+Teleport = defclass(Teleport, widgets.Window)
+Teleport.ATTRS {
+    frame_title='Teleport',
+    frame={w=48, h=28, r=2, t=18},
+    resizable=true,
+    resize_min={h=10},
+    autoarrange_subviews=true,
+    autoarrange_gap=1,
 }
 
-function TeleportSidebar:init()
+function Teleport:init()
+    self.mark = nil
+    self.prev_help_text = ''
+    self:reset_selected_state() -- sets self.selected_*
+    self:refresh_dump_items() -- sets self.dump_items
+    self:reset_double_click() -- sets self.last_map_click_ms and self.last_map_click_pos
+
     self:addviews{
-        widgets.Label{
-            frame = {b=1, l=1},
-            text = {
-                {key = 'UNITJOB_ZOOM_CRE',
-                    text = ': Zoom to unit, ',
-                    on_activate = self:callback('zoom_unit'),
-                    enabled = function() return self.unit end},
-                {key = 'UNITVIEW_NEXT', text = ': Next',
-                    on_activate = self:callback('next_unit'),
-                    enabled = uiMultipleUnits},
-                NEWLINE,
-                NEWLINE,
-                {key = 'SELECT', text = ': Choose, ', on_activate = self:callback('choose')},
-                {key = 'LEAVESCREEN', text = ': Back', on_activate = self:callback('back')},
-                NEWLINE,
-                {key = 'LEAVESCREEN_ALL', text = ': Exit to map', on_activate = self:callback('dismiss')},
+        widgets.WrappedLabel{
+            frame={l=0},
+            text_to_wrap=self:callback('get_help_text'),
+        },
+        widgets.Panel{
+            frame={h=2},
+            subviews={
+                widgets.Label{
+                    frame={l=0, t=0},
+                    text={
+                        'Selected area: ',
+                        {text=self:callback('get_selection_area_text')}
+                    },
+                },
+            },
+            visible=function() return self.mark end,
+        },
+        widgets.HotkeyLabel{
+            frame={l=0},
+            label='Teleport to tile under mouse cursor',
+            key='CUSTOM_CTRL_T',
+            auto_width=true,
+            on_activate=self:callback('do_teleport'),
+            enabled=function() return dfhack.gui.getMousePos() end,
+        },
+        widgets.ResizingPanel{
+            autoarrange_subviews=true,
+            subviews={
+                widgets.ToggleHotkeyLabel{
+                    view_id='include_citizens',
+                    frame={l=0},
+                    label='Include citizen units',
+                    key='CUSTOM_CTRL_U',
+                    auto_width=true,
+                    initial_option=true,
+                },
+                widgets.ToggleHotkeyLabel{
+                    view_id='include_friendly',
+                    frame={l=0},
+                    label='Include friendly units',
+                    key='CUSTOM_CTRL_F',
+                    auto_width=true,
+                    initial_option=true,
+                },
+                widgets.ToggleHotkeyLabel{
+                    view_id='include_hostile',
+                    frame={l=0},
+                    label='Include hostile units',
+                    key='CUSTOM_CTRL_H',
+                    auto_width=true,
+                    initial_option=true,
+                },
             },
         },
+        widgets.Label{
+            text={
+                {text=function() return #self.selected_units.list end}
+                ' selected units:'
+            },
+        },
+        widgets.List{
+            view_id='list',
+            frame={l=0, r=0, b=2}
+        },
+        widgets.HotkeyLabel{
+            frame={l=0},
+            key='CUSTOM_R',
+            label='Remove selected unit from list',
+            auto_width=true,
+            on_activate=self:callback('remove_unit'),
+            enabled=function() return #self.selected_items.list > 0 end,
+        },
+        widgets.HotkeyLabel{
+            frame={l=0},
+            key='CUSTOM_SHIFT_R',
+            label='Remove all selected units',
+            auto_width=true,
+            on_activate=self:callback('reset_selected_state'),
+            enabled=function() return #self.selected_items.list > 0 end,
+        },
+}
+end
+
+function Teleport:reset_double_click()
+    self.last_map_click_ms = 0
+    self.last_map_click_pos = {}
+end
+
+function Teleport:reset_selected_state()
+    self.selected_items = {list={}, set={}}
+    self.selected_coords = {} -- z -> y -> x -> true
+    self.selected_bounds = {} -- z -> bounds rect
+    if next(self.subviews) then
+        self:updateLayout()
+    end
+end
+
+function Teleport:get_include()
+    local include = {forbidden=false, in_job=false, trader=false}
+    if next(self.subviews) then
+        include.forbidden = self.subviews.include_forbidden:getOptionValue()
+        include.in_job = self.subviews.include_in_job:getOptionValue()
+        include.trader = self.subviews.include_trader:getOptionValue()
+    end
+    return include
+end
+
+function Teleport:refresh_dump_items()
+    local dump_items = {}
+    local include = self:get_include()
+    for _,item in ipairs(df.global.world.items.all) do
+        if not is_good_item(item, include) then goto continue end
+        if item.flags.dump then
+            table.insert(dump_items, item)
+        end
+        ::continue::
+    end
+    self.dump_items = dump_items
+    if next(self.subviews) then
+        self:updateLayout()
+    end
+end
+
+function Teleport:get_help_text()
+    local ret = 'Double click on a tile to teleport'
+    if #self.selected_items.list > 0 then
+        ret = ('%s %d highlighted item(s).'):format(ret, #self.selected_items.list)
+    else
+        ret = ('%s %d item(s) marked for dumping.'):format(ret, #self.dump_items)
+    end
+    if ret ~= self.prev_help_text then
+        self.prev_help_text = ret
+    end
+    return ret
+end
+
+function Teleport:get_selection_area_text()
+    local mark = self.mark
+    if not mark then return '' end
+    local cursor = dfhack.gui.getMousePos() or {x=mark.x, y=mark.y, z=df.global.window_z}
+    return ('%dx%dx%d'):format(get_dims(mark, cursor))
+end
+
+function Teleport:get_bounds(cursor, mark)
+    cursor = cursor or self.mark
+    mark = mark or self.mark or cursor
+    if not mark then return end
+
+    return {
+        x1=math.min(cursor.x, mark.x),
+        x2=math.max(cursor.x, mark.x),
+        y1=math.min(cursor.y, mark.y),
+        y2=math.max(cursor.y, mark.y),
+        z1=math.min(cursor.z, mark.z),
+        z2=math.max(cursor.z, mark.z)
     }
-    self.in_pick_pos = false
 end
 
-function TeleportSidebar:choose()
-    if not self.in_pick_pos then
-        self.in_pick_pos = true
-    else
-        dfhack.units.teleport(self.unit, xyz2pos(pos2xyz(df.global.cursor)))
-        self:dismiss()
-    end
-end
-
-function TeleportSidebar:back()
-    if self.in_pick_pos then
-        self.in_pick_pos = false
-    else
-        self:dismiss()
-    end
-end
-
-function TeleportSidebar:zoom_unit()
-    df.global.cursor:assign(xyz2pos(pos2xyz(self.unit.pos)))
-    self:getViewport():centerOn(self.unit.pos):set()
-end
-
-function TeleportSidebar:next_unit()
-    self:sendInputToParent('UNITVIEW_NEXT')
-end
-
-function TeleportSidebar:onRenderBody(p)
-    p:seek(1, 1):pen(COLOR_WHITE)
-    if self.in_pick_pos then
-        p:string('Select destination'):newline(1):newline(1)
-
-        local cursor = df.global.cursor
-        local block = dfhack.maps.getTileBlock(pos2xyz(cursor))
-        if block then
-            p:string(df.tiletype[block.tiletype[cursor.x % 16][cursor.y % 16]], COLOR_CYAN)
-        else
-            p:string('Unknown tile', COLOR_RED)
+function Teleport:select_items_in_block(block, bounds)
+    local include = self:get_include()
+    for _,item_id in ipairs(block.items) do
+        local item = df.item.find(item_id)
+        if not is_good_item(item, include) then
+            goto continue
         end
-    else
-        self.unit = dfhack.gui.getAnyUnit(self._native.parent)
-        p:string('Select unit:'):newline(1):newline(1)
-        if self.unit then
-            local name = dfhack.TranslateName(dfhack.units.getVisibleName(self.unit))
-            p:string(name)
-            if name ~= '' then p:newline(1) end
-            p:string(dfhack.units.getProfessionName(self.unit), dfhack.units.getProfessionColor(self.unit))
-            p:newline(1)
-        else
-            p:string('No unit selected', COLOR_LIGHTRED)
+        local x, y, z = dfhack.items.getPosition(item)
+        if not x then goto continue end
+        if not self.selected_items.set[item_id] and
+                x >= bounds.x1 and x <= bounds.x2 and
+                y >= bounds.y1 and y <= bounds.y2 then
+            self.selected_items.set[item_id] = true
+            table.insert(self.selected_items.list, item)
+            ensure_key(ensure_key(self.selected_coords, z), y)[x] = true
+            local selected_bounds = ensure_key(self.selected_bounds, z,
+                    {x1=x, x2=x, y1=y, y2=y})
+            selected_bounds.x1 = math.min(selected_bounds.x1, x)
+            selected_bounds.x2 = math.max(selected_bounds.x2, x)
+            selected_bounds.y1 = math.min(selected_bounds.y1, y)
+            selected_bounds.y2 = math.max(selected_bounds.y2, y)
+        end
+        ::continue::
+    end
+end
+
+function Teleport:select_box(bounds)
+    if not bounds then return end
+    local seen_blocks = {}
+    for z=bounds.z1,bounds.z2 do
+        for y=bounds.y1,bounds.y2 do
+            for x=bounds.x1,bounds.x2 do
+                local block = dfhack.maps.getTileBlock(xyz2pos(x, y, z))
+                local block_str = tostring(block)
+                if not seen_blocks[block_str] then
+                    seen_blocks[block_str] = true
+                    self:select_items_in_block(block, bounds)
+                end
+            end
         end
     end
 end
 
-function TeleportSidebar:onInput(keys)
-    TeleportSidebar.super.onInput(self, keys)
-    TeleportSidebar.super.propagateMoveKeys(self, keys)
+function Teleport:onInput(keys)
+    if Teleport.super.onInput(self, keys) then return true end
+    if keys._MOUSE_R and self.mark then
+        self.mark = nil
+        self:updateLayout()
+        return true
+    elseif keys._MOUSE_L then
+        if self:getMouseFramePos() then return true end
+        local pos = dfhack.gui.getMousePos()
+        if not pos then
+            self:reset_double_click()
+            return false
+        end
+        local now_ms = dfhack.getTickCount()
+        if same_xyz(pos, self.last_map_click_pos) and
+                now_ms - self.last_map_click_ms <= widgets.DOUBLE_CLICK_MS then
+            self:reset_double_click()
+            self:do_teleport(pos)
+            self.mark = nil
+            self:updateLayout()
+            return true
+        end
+        self.last_map_click_ms = now_ms
+        self.last_map_click_pos = pos
+        if self.mark then
+            self:select_box(self:get_bounds(pos))
+            self:reset_double_click()
+            self.mark = nil
+            self:updateLayout()
+            return true
+        end
+        self.mark = pos
+        self:updateLayout()
+        return true
+    end
 end
 
-function TeleportSidebar:onGetSelectedUnit()
-    return self.unit
+local to_pen = dfhack.pen.parse
+local CURSOR_PEN = to_pen{ch='o', fg=COLOR_BLUE,
+                         tile=dfhack.screen.findGraphicsTile('CURSORS', 5, 22)}
+local BOX_PEN = to_pen{ch='X', fg=COLOR_GREEN,
+                       tile=dfhack.screen.findGraphicsTile('CURSORS', 0, 0)}
+local SELECTED_PEN = to_pen{ch='I', fg=COLOR_GREEN,
+                       tile=dfhack.screen.findGraphicsTile('CURSORS', 1, 2)}
+
+function Teleport:onRenderFrame(dc, rect)
+    Teleport.super.onRenderFrame(self, dc, rect)
+
+    local highlight_coords = self.selected_coords[df.global.window_z]
+    if highlight_coords then
+        local function get_overlay_pen(pos)
+            if safe_index(highlight_coords, pos.y, pos.x) then
+                return SELECTED_PEN
+            end
+        end
+        guidm.renderMapOverlay(get_overlay_pen, self.selected_bounds[df.global.window_z])
+    end
+
+    -- draw selection box and cursor (blinking when in ascii mode)
+    local cursor = dfhack.gui.getMousePos()
+    local selection_bounds = self:get_bounds(cursor)
+    if selection_bounds and (dfhack.screen.inGraphicsMode() or gui.blink_visible(500)) then
+        guidm.renderMapOverlay(
+            function() return self.mark and BOX_PEN or CURSOR_PEN end,
+            selection_bounds)
+    end
 end
 
-if not dfhack.isMapLoaded() then
-    qerror('This script requires a fortress map to be loaded')
+function Teleport:do_teleport(pos)
+    pos = pos or dfhack.gui.getMousePos()
+    if not pos then return end
+    print(('teleporting %d units'):format(#self.unit_ids))
+    for _,unid in ipairs(self.unit_ids) do
+        local unit = df.unit.find(unid)
+        if unit then
+            dfhack.units.teleport(unit, pos)
+        end
+    end
+    self.unit_ids = {}
+    self:reset_selected_state()
+    self:updateLayout()
 end
 
-TeleportSidebar():show()
+-----------------
+-- TeleportScreen
+--
+
+TeleportScreen = defclass(TeleportScreen, gui.ZScreen)
+TeleportScreen.ATTRS {
+    focus_path='autodump',
+    pass_movement_keys=true,
+    pass_mouse_clicks=false,
+}
+
+function TeleportScreen:init()
+    self:addviews{Teleport{}}
+end
+
+function TeleportScreen:onDismiss()
+    view = nil
+end
+
+view = view and view:raise() or TeleportScreen{}:show()


### PR DESCRIPTION
mouse driven box selection
if a unit is already selected in the UI, will act on that unit by default
visual marker of selected units (same approach as `gui/autodump`)
can remove units from the selected list
filterable by citizens, hostiles, and non-citizen friendlies
double click to teleport to tile
filter settings are saved across invocations

![image](https://github.com/DFHack/scripts/assets/977482/5e0ec508-d80f-4c1a-ae6a-b7b29df2e502)