### PR TITLE
migrate scripts to new persistence API

### DIFF
--- a/autofish.lua
+++ b/autofish.lua
@@ -4,8 +4,6 @@
 --@ enable=true
 --@ module=true
 
-local json = require("json")
-local persist = require("persist-table")
 local argparse = require("argparse")
 local repeatutil = require("repeat-util")
 
@@ -26,16 +24,19 @@ end
 
 --- Save the current state of the script
 local function persist_state()
-    persist.GlobalTable[GLOBAL_KEY] = json.encode({enabled=enabled,
-        s_maxFish=s_maxFish, s_minFish=s_minFish, s_useRaw=s_useRaw,
-        isFishing=isFishing
+    dfhack.persistent.saveSiteData(GLOBAL_KEY, {
+        enabled=enabled,
+        s_maxFish=s_maxFish,
+        s_minFish=s_minFish,
+        s_useRaw=s_useRaw,
+        isFishing=isFishing,
     })
 end
 
 --- Load the saved state of the script
 local function load_state()
     -- load persistent data
-    local persisted_data = json.decode(persist.GlobalTable[GLOBAL_KEY] or "") or {}
+    local persisted_data = dfhack.persistent.getSiteData(GLOBAL_KEY, {})
     enabled = persisted_data.enabled or false
     s_maxFish = persisted_data.s_maxFish or 100
     s_minFish = persisted_data.s_minFish or 75

--- a/control-panel.lua
+++ b/control-panel.lua
@@ -2,8 +2,6 @@
 
 local argparse = require('argparse')
 local common = reqscript('internal/control-panel/common')
-local json = require('json')
-local persist = require('persist-table')
 local registry = reqscript('internal/control-panel/registry')
 local utils = require('utils')
 
@@ -36,11 +34,12 @@ local function apply_autostart_config()
 end
 
 local function apply_fort_loaded_config()
-    if not safe_index(json.decode(persist.GlobalTable[GLOBAL_KEY] or ''), 'autostart_done') then
+    local state = dfhack.persistent.getSiteData(GLOBAL_KEY, {})
+    if not state.autostart_done then
         apply_autostart_config()
-        persist.GlobalTable[GLOBAL_KEY] = json.encode({autostart_done=true})
+        dfhack.persistent.saveSiteData(GLOBAL_KEY, {autostart_done=true})
     end
-    local enabled_repeats = json.decode(persist.GlobalTable[common.REPEATS_GLOBAL_KEY] or '') or {}
+    local enabled_repeats = dfhack.persistent.getSiteData(common.REPEATS_GLOBAL_KEY, {})
     for _, data in ipairs(registry.COMMANDS_BY_IDX) do
         if data.mode == 'repeat' and enabled_repeats[data.command] then
             common.apply_command(data)

--- a/devel/prepare-save.lua
+++ b/devel/prepare-save.lua
@@ -1,19 +1,4 @@
 -- Prepare the current save for devel/find-offsets
---[====[
-
-devel/prepare-save
-==================
-
-.. warning::
-
-    THIS SCRIPT IS STRICTLY FOR DFHACK DEVELOPERS.
-
-This script prepares the current savegame to be used
-with `devel/find-offsets`. It CHANGES THE GAME STATE
-to predefined values, and initiates an immediate
-`quicksave`, thus PERMANENTLY MODIFYING the save.
-
-]====]
 
 local utils = require 'utils'
 
@@ -89,11 +74,7 @@ local yearstr = df.global.cur_year..','..df.global.cur_year_tick
 
 print('Cur year and tick: '..yearstr)
 
-dfhack.persistent.save{
-    key='prepare-save/cur_year',
-    value=yearstr,
-    ints={df.global.cur_year, df.global.cur_year_tick}
-}
+dfhack.persistent.saveSiteDataString('prepare-save/cur_year', yearstr)
 
 -- Save
 

--- a/emigration.lua
+++ b/emigration.lua
@@ -4,9 +4,6 @@
 --@module = true
 --@enable = true
 
-local json = require('json')
-local persist = require('persist-table')
-
 local GLOBAL_KEY = 'emigration' -- used for state change hooks and persistence
 
 enabled = enabled or false
@@ -16,7 +13,7 @@ function isEnabled()
 end
 
 local function persist_state()
-    persist.GlobalTable[GLOBAL_KEY] = json.encode({enabled=enabled})
+    dfhack.persistent.saveSiteData(GLOBAL_KEY, {enabled=enabled})
 end
 
 function desireToStay(unit,method,civ_id)
@@ -215,8 +212,8 @@ dfhack.onStateChange[GLOBAL_KEY] = function(sc)
         return
     end
 
-    local persisted_data = json.decode(persist.GlobalTable[GLOBAL_KEY] or '')
-    enabled = (persisted_data or {enabled=false})['enabled']
+    local persisted_data = dfhack.persistent.getSiteData(GLOBAL_KEY, {enabled=false})
+    enabled = persisted_data.enabled
     event_loop()
 end
 

--- a/fix/protect-nicks.lua
+++ b/fix/protect-nicks.lua
@@ -3,9 +3,6 @@
 --@ enable = true
 --@ module = true
 
-local json = require('json')
-local persist = require('persist-table')
-
 local GLOBAL_KEY = 'fix-protect-nicks'
 
 enabled = enabled or false
@@ -15,7 +12,7 @@ function isEnabled()
 end
 
 local function persist_state()
-    persist.GlobalTable[GLOBAL_KEY] = json.encode({enabled=enabled})
+    dfhack.persistent.saveSiteData(GLOBAL_KEY, {enabled=enabled})
 end
 
 -- Reassign all the units nicknames with "dfhack.units.setNickname"
@@ -42,8 +39,8 @@ dfhack.onStateChange[GLOBAL_KEY] = function(sc)
         return
     end
 
-    local persisted_data = json.decode(persist.GlobalTable[GLOBAL_KEY] or '')
-    enabled = (persisted_data or {enabled=false})['enabled']
+    local persisted_data = dfhack.persistent.getSiteData(GLOBAL_KEY, {enabled=false})
+    enabled = persisted_data.enabled
     event_loop()
 end
 

--- a/hermit.lua
+++ b/hermit.lua
@@ -3,8 +3,6 @@
 --@ module=true
 
 local argparse = require('argparse')
-local json = require('json')
-local persist = require('persist-table')
 local repeatutil = require('repeat-util')
 
 local GLOBAL_KEY = 'hermit'
@@ -22,12 +20,12 @@ function isEnabled()
 end
 
 local function persist_state()
-    persist.GlobalTable[GLOBAL_KEY] = json.encode{enabled=enabled}
+    dfhack.persistent.saveSiteData(GLOBAL_KEY, {enabled=enabled})
 end
 
 local function load_state()
-    local persisted_data = json.decode(persist.GlobalTable[GLOBAL_KEY] or '') or {}
-    enabled = persisted_data.enabled or false
+    local persisted_data = dfhack.persistent.getSiteData(GLOBAL_KEY, {enabled=false})
+    enabled = persisted_data.enabled
 end
 
 function event_loop()

--- a/internal/control-panel/common.lua
+++ b/internal/control-panel/common.lua
@@ -3,7 +3,6 @@
 local helpdb = require('helpdb')
 local json = require('json')
 local migration = reqscript('internal/control-panel/migration')
-local persist = require('persist-table')
 local registry = reqscript('internal/control-panel/registry')
 local repeatUtil = require('repeat-util')
 local utils = require('utils')
@@ -117,7 +116,7 @@ local function persist_enabled_repeats()
             cp_repeats[name] = true
         end
     end
-    persist.GlobalTable[REPEATS_GLOBAL_KEY] = json.encode(cp_repeats)
+    dfhack.persistent.saveSiteData(REPEATS_GLOBAL_KEY, cp_repeats)
 end
 
 function apply_command(data, enabled_map, enabled)

--- a/once-per-save.lua
+++ b/once-per-save.lua
@@ -1,90 +1,40 @@
--- runs dfhack commands unless ran already in this save
+-- runs dfhack commands unless ran already in this save (world)
 
-local HELP = [====[
+local argparse = require('argparse')
 
-once-per-save
-=============
-Runs commands like `multicmd`, but only unless
-not already ran once in current save. You may actually
-want `on-new-fortress`.
+local GLOBAL_KEY = 'once-per-save'
 
-Only successfully ran commands are saved.
+local opts = {
+    help=false,
+    rerun=false,
+    reset=false,
+}
 
-Parameters:
+local positionals = argparse.processArgsGetopt({...}, {
+    {'h', 'help', handler=function() opts.help = true end},
+    {nil, 'rerun', handler=function() opts.rerun = true end},
+    {nil, 'reset', handler=function() opts.reset = true end},
+})
 
---help            display this help
---rerun commands  ignore saved commands
---reset           deletes saved commands
-
-]====]
-
-local STORAGEKEY_PREFIX = 'once-per-save'
-local storagekey = STORAGEKEY_PREFIX .. ':' .. tostring(df.global.plotinfo.site_id)
-
-local args = {...}
-local rerun = false
-
-local utils = require 'utils'
-local arg_help = utils.invert{"?", "-?", "-help", "--help"}
-local arg_rerun = utils.invert{"-rerun", "--rerun"}
-local arg_reset = utils.invert{"-reset", "--reset"}
-if arg_help[args[1]] then
-    print(HELP)
+if opts.help or positionals[1] == 'help' then
+    print(dfhack.script_help())
     return
-elseif arg_rerun[args[1]] then
-    rerun = true
-    table.remove(args, 1)
-elseif arg_reset[args[1]] then
-    while dfhack.persistent.delete(storagekey) do end
-    table.remove(args, 1)
-end
-if #args == 0 then return end
-
-local age = df.global.plotinfo.fortress_age
-local year = df.global.cur_year
-local year_tick = df.global.cur_year_tick
-local year_tick_advmode = df.global.cur_year_tick_advmode
-
-local function is_later(a, b)
-    for i, v in ipairs(a) do
-        if v < b[i] then
-            return true
-        elseif v > b[i] then
-            return false
-        --else: v == b[i] so keep iterating
-        end
-    end
-    return false
 end
 
-local once_run = {}
-if not rerun then
-    local entries = dfhack.persistent.get_all(storagekey) or {}
-    for i, entry in ipairs(entries) do
-        local ints = entry.ints
-        if ints[1] > age
-        or age == 0 and is_later({ints[2], ints[3], ints[4]}, {year, year_tick, year_tick_advmode})
-        then
-            print (dfhack.current_script_name() .. ': unretired fortress, deleting `' .. entry.value .. '`')
-            --printall_recurse(entry) -- debug
-            entry:delete()
-        else
-            once_run[entry.value]=entry
-        end
-    end
+if opts.reset then
+    dfhack.persistent.deleteWorldData(GLOBAL_KEY)
 end
+if #positionals == 0 then return end
 
-local save = dfhack.persistent.save
+local state = dfhack.persistent.getWorldData(GLOBAL_KEY, {})
+
 for cmd in table.concat(args, ' '):gmatch("%s*([^;]+);?%s*") do
-    if not once_run[cmd] then
-        local ok = dfhack.run_command(cmd) == 0
-        if ok then
-            once_run[cmd] = save({key = storagekey,
-                                  value = cmd,
-                                  ints = { age, year, year_tick, year_tick_advmode }},
-                                 true)
-        elseif rerun and once_run[cmd] then
-            once_run[cmd]:delete()
+    cmd = cmd:trim()
+    if not state[cmd] or opts.rerun then
+        if dfhack.run_command(cmd) == CR_OK then
+            state[cmd] = {already_run=true}
         end
     end
 end
+
+dfhack.persistent.saveWorldData(GLOBAL_KEY, state)

--- a/source.lua
+++ b/source.lua
@@ -1,15 +1,12 @@
 --@ module = true
 local repeatUtil = require('repeat-util')
-local json = require('json')
-local persist = require('persist-table')
 
 local GLOBAL_KEY = 'source' -- used for state change hooks and persistence
 
 g_sources_list = g_sources_list or {}
 
-
 local function persist_state(liquidSources)
-    persist.GlobalTable[GLOBAL_KEY] = json.encode(liquidSources)
+    dfhack.persistent.saveSiteData(GLOBAL_KEY, liquidSources)
 end
 
 local function formatPos(pos)
@@ -179,9 +176,7 @@ dfhack.onStateChange[GLOBAL_KEY] = function(sc)
         return
     end
 
-    local persisted_data = json.decode(persist.GlobalTable[GLOBAL_KEY] or '') or {}
-
-    g_sources_list = persisted_data
+    g_sources_list = dfhack.persistent.getSiteData(GLOBAL_KEY, {})
 
     load_liquid_source(g_sources_list)
 end

--- a/source.lua
+++ b/source.lua
@@ -91,7 +91,6 @@ local function delete_liquid_source(pos)
 end
 
 local function clear_liquid_sources()
-    print("Clearing all Sources")
     for k, v in ipairs(g_sources_list) do
         delete_source_at(k)
     end
@@ -178,7 +177,7 @@ dfhack.onStateChange[GLOBAL_KEY] = function(sc)
 
     g_sources_list = dfhack.persistent.getSiteData(GLOBAL_KEY, {})
 
-    load_liquid_source(g_sources_list)
+    load_liquid_source()
 end
 
 if dfhack_flags.module then

--- a/starvingdead.lua
+++ b/starvingdead.lua
@@ -3,8 +3,6 @@
 --@module = true
 
 local argparse = require('argparse')
-local json = require('json')
-local persist = require('persist-table')
 
 local GLOBAL_KEY = 'starvingdead'
 
@@ -15,8 +13,8 @@ function isEnabled()
 end
 
 local function persist_state()
-  persist.GlobalTable[GLOBAL_KEY] = json.encode({
-    enabled = starvingDeadInstance ~= nil,
+  dfhack.persistent.saveSiteData(GLOBAL_KEY, {
+    enabled = isEnabled(),
     decay_rate = starvingDeadInstance and starvingDeadInstance.decay_rate or 1,
     death_threshold = starvingDeadInstance and starvingDeadInstance.death_threshold or 6
   })
@@ -32,7 +30,7 @@ dfhack.onStateChange[GLOBAL_KEY] = function(sc)
       return
   end
 
-  local persisted_data = json.decode(persist.GlobalTable[GLOBAL_KEY] or '{}')
+  local persisted_data = dfhack.persistent.getSiteData(GLOBAL_KEY, {})
 
   if persisted_data.enabled then
     starvingDeadInstance = StarvingDead{

--- a/suspendmanager.lua
+++ b/suspendmanager.lua
@@ -2,8 +2,6 @@
 --@module = true
 --@enable = true
 
-local json = require('json')
-local persist = require('persist-table')
 local argparse = require('argparse')
 local eventful = require('plugins.eventful')
 local utils = require('utils')
@@ -112,7 +110,7 @@ function isKeptSuspended(job)
 end
 
 local function persist_state()
-    persist.GlobalTable[GLOBAL_KEY] = json.encode({
+    dfhack.persistent.saveSiteData(GLOBAL_KEY, {
         enabled=enabled,
         prevent_blocking=Instance.preventBlocking,
     })
@@ -745,9 +743,9 @@ dfhack.onStateChange[GLOBAL_KEY] = function(sc)
         return
     end
 
-    local persisted_data = json.decode(persist.GlobalTable[GLOBAL_KEY] or '')
-    enabled = (persisted_data or {enabled=false})['enabled']
-    Instance.preventBlocking = (persisted_data or {prevent_blocking=true})['prevent_blocking']
+    local persisted_data = dfhack.persistent.getSiteData(GLOBAL_KEY, {enabled=false, prevent_blocking=true})
+    enabled = persisted_data.enabled
+    Instance.preventBlocking = persisted_data.prevent_blocking
     update_triggers()
 end
 

--- a/test/prioritize.lua
+++ b/test/prioritize.lua
@@ -1,5 +1,4 @@
 local eventful = require('plugins.eventful')
-local persist = require('persist-table')
 local prioritize = reqscript('prioritize')
 local utils = require('utils')
 local p = prioritize.unit_test_hooks
@@ -18,7 +17,6 @@ local function get_mock_reactions() return mock_reactions end
 local function test_wrapper(test_fn)
     mock.patch({{eventful, 'onUnload', mock_eventful_onUnload},
                 {eventful, 'onJobInitiated', mock_eventful_onJobInitiated},
-                {persist, 'GlobalTable', {}},
                 {prioritize, 'print', mock_print},
                 {prioritize, 'get_watched_job_matchers',
                  get_mock_watched_job_matchers},


### PR DESCRIPTION
Depends on https://github.com/DFHack/dfhack/pull/4153

most scripts had a straightforward conversion

once-per-save was doing a lot of undocumented stuff that is no longer necessary, so it got largely rewritten

made persistence in `prioritize` more efficient by not confusing the json serializer with a map that looks like a sparse list

changed persistence format of `devel/prepare-save`, but the persistence appears to be for human readability and is not read by the script

warn-stranded had a format change and will lose history. the persistence key name was changed so that old data won't mess up the new formats. this is only the list of stranded units that you are ignoring, though, so the impact to players is low. I wish I had caught the non-standard persistence format in code review : /