### PR TITLE
[settings-manager] save and load difficulty settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -36,6 +36,7 @@ Template for new versions:
 
 ## New Features
 - `uniform-unstick`: add overlay to the squad equipment screen to show a equipment conflict report and give you a one-click button to fix
+- `gui/settings-manager`: save and load (optionally automatically) embark difficulty settings
 
 ## Fixes
 - `source`: water and magma sources now persist with fort across saves and loads

--- a/docs/gui/settings-manager.rst
+++ b/docs/gui/settings-manager.rst
@@ -2,17 +2,13 @@ gui/settings-manager
 ====================
 
 .. dfhack-tool::
-    :summary: Dynamically adjust global DF settings.
-    :tags: unavailable
+    :summary: Save, load, and modify DF settings.
+    :tags: embark interface
 
-This tool is an in-game editor for settings defined in
-:file:`data/init/init.txt` and :file:`data/init/d_init.txt`. Changes are written
-back to the init files so they will be loaded the next time you start DF. For
-settings that can be dynamically adjusted, such as the population cap, the
-active value used by the game is updated immediately.
-
-Editing the population caps will override any modifications made by scripts such
-as `max-wave`.
+This tool provides overlays that allow you to save and load DF settings. When
+run as a command, it also allows you to adjust the colors displayed in ASCII
+mode. After changing the colors, you have to restart DF to see the effects
+in-game.
 
 Usage
 -----
@@ -20,3 +16,11 @@ Usage
 ::
 
     gui/settings-manager
+
+Overlays
+--------
+
+When embarking, if you click on the ``Custom settings`` button for game
+difficulty, you will see a new panel at the top. You can save the current
+difficulty settings and load the saved settings back. You can also toggle an
+option to automatically load the saved settings for new embarks.

--- a/docs/gui/settings-manager.rst
+++ b/docs/gui/settings-manager.rst
@@ -5,17 +5,7 @@ gui/settings-manager
     :summary: Save, load, and modify DF settings.
     :tags: embark interface
 
-This tool provides overlays that allow you to save and load DF settings. When
-run as a command, it also allows you to adjust the colors displayed in ASCII
-mode. After changing the colors, you have to restart DF to see the effects
-in-game.
-
-Usage
------
-
-::
-
-    gui/settings-manager
+This tool provides overlays that allow you to save and load DF settings.
 
 Overlays
 --------


### PR DESCRIPTION
option to auto-apply saved settings for new embarks
widget in both embark difficulty screen and fort settings

Fixes: https://github.com/DFHack/dfhack/issues/4064