### PR TITLE
[emtpy-bin] fix emptying carried containers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -46,6 +46,7 @@ Template for new versions:
 - `confirm`: properly detect clicks on the remove zone button even when the unit selection screen is also open (e.g. the vanilla assign animal to pasture panel)
 - `quickfort`: if a blueprint specifies an up/down stair, but the tile the blueprint is applied to cannot make an up stair (e.g. it has already been dug out), still designate a down stair if possible
 - `suspendmanager`: correctly handle building collisions with smoothing designations when the building is on the edge of the map
+- `empty-bin`: now correctly sends ammunition in carried quivers to the tile underneath the unit instead of teleporting them to an invalid (or possibly just far away) location
 
 ## Misc Improvements
 - `gui/control-panel`: reduce frequency for `warn-stranded` check to once every 2 days

--- a/empty-bin.lua
+++ b/empty-bin.lua
@@ -19,7 +19,7 @@ if #items > 0 then
     print('Emptying ' .. dfhack.items.getDescription(bin, 0))
     for _, item in pairs(items) do
         print('  ' .. dfhack.items.getDescription(item, 0))
-        dfhack.items.moveToGround(item, bin.pos)
+        dfhack.items.moveToGround(item, xyz2pos(dfhack.items.getPosition(bin)))
     end
 else
     print('No contained items')


### PR DESCRIPTION
it was using the container position directly instead of calling dfhack.items.getPosition, so carried items (which may have incorrect or invalid positions) was messing up the logic.

as referenced on Reddit: https://www.reddit.com/r/dwarffortress/comments/195llnp/comment/khwp7xq/?utm_source=share&utm_medium=web2x&context=3