### PR TITLE
[warn-stranded] don't warn on units going down open hatches

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -42,7 +42,7 @@ Template for new versions:
 ## Fixes
 - `source`: water and magma sources now persist with fort across saves and loads
 - `gui/design`: fix incorrect dimensions being shown when placing stockpiles, but a start coordinate hasn't been selected yet
-- `warn-stranded`: Automatically ignore citizens who are gathering plants or digging to avoid issues with gathering fruit via stepladders and weird issues with digging
+- `warn-stranded`: don't warn for citizens who are only transiently stranded, like those on stepladders gathering plants or digging themselves out of a hole
 - `warn-stranded`: Update onZoom to use df's centering functionality
 - `ban-cooking`: fix banning creature alcohols resulting in error
 - `confirm`: properly detect clicks on the remove zone button even when the unit selection screen is also open (e.g. the vanilla assign animal to pasture panel)


### PR DESCRIPTION
which are their own pathability group for some reason