### PR TITLE
move down `local points` assigment on gui/design

### DIFF
--- a/gui/design.lua
+++ b/gui/design.lua
@@ -1247,9 +1247,6 @@ function Design:onRenderFrame(dc, rect)
         self.marks[self.placing_mark.index] = mouse_pos
     end
 
-    -- Set main points
-    local points = copyall(self.marks)
-
     -- Set the pos of the currently moving extra point
     if self.placing_extra.active then
         self.extra_points[self.placing_extra.index] = mouse_pos
@@ -1288,7 +1285,10 @@ function Design:onRenderFrame(dc, rect)
 
         self.prev_center = mouse_pos
     end
-
+	
+	-- Set main points
+    local points = copyall(self.marks)
+	
     if self.mirror_point then
         points = self:get_mirrored_points(points)
     end


### PR DESCRIPTION
fixes DFHack/dfhack#4202 by moving the assignment of `points` to after the center dragging logic which was manipulating self.marks.