### PR TITLE
move down `local points` assigment on gui/design

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -81,6 +81,7 @@ Template for new versions:
 
 ## Fixes
 - `combine`: prevent stack sizes from growing beyond quantities that you would normally see in vanilla gameplay
+- `gui/design`: Center dragging shapes now track the mouse correctly
 
 ## Misc Improvements
 - `caravan`: enable searching within containers in trade screen when in "trade bin with contents" mode

--- a/gui/design.lua
+++ b/gui/design.lua
@@ -1247,9 +1247,6 @@ function Design:onRenderFrame(dc, rect)
         self.marks[self.placing_mark.index] = mouse_pos
     end
 
-    -- Set main points
-    local points = copyall(self.marks)
-
     -- Set the pos of the currently moving extra point
     if self.placing_extra.active then
         self.extra_points[self.placing_extra.index] = mouse_pos
@@ -1288,7 +1285,10 @@ function Design:onRenderFrame(dc, rect)
 
         self.prev_center = mouse_pos
     end
-
+	
+	-- Set main points
+    local points = copyall(self.marks)
+	
     if self.mirror_point then
         points = self:get_mirrored_points(points)
     end

--- a/gui/design.lua
+++ b/gui/design.lua
@@ -1285,10 +1285,10 @@ function Design:onRenderFrame(dc, rect)
 
         self.prev_center = mouse_pos
     end
-	
-	-- Set main points
+
+    -- Set main points
     local points = copyall(self.marks)
-	
+
     if self.mirror_point then
         points = self:get_mirrored_points(points)
     end


### PR DESCRIPTION
fixes DFHack/dfhack#4202 by moving the assignment of `points` to after the center dragging logic which was manipulating self.marks