### PR TITLE
[item] fix enumeration of (present) item type ids

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ Template for new versions:
 
 ## Fixes
 - `makeown`: fix error when adopting units that need a historical figure to be created
+- `item`: fix missing item categories when using ``--by-type``
 
 ## Misc Improvements
 

--- a/item.lua
+++ b/item.lua
@@ -296,7 +296,7 @@ function executeWithPrinting (action, conditions, options)
     end
     if options.bytype and count > 0 then
         local sorted = {}
-        for tp, ct in ipairs(types) do
+        for tp, ct in pairs(types) do
             table.insert(sorted, { type = tp, count = ct })
         end
         table.sort(sorted, function(a, b) return a.count > b.count end)


### PR DESCRIPTION
@myk002 Turns out your one-line change breaks things: `types` is not a sequence, the keys are item type ids matching the filters, hardly continuous...