### PR TITLE
`gui/design` stamp mode candidate

### DIFF
--- a/internal/design/shapes.lua
+++ b/internal/design/shapes.lua
@@ -657,7 +657,30 @@ function FreeForm:point_in_polygon(x, y)
     return inside
 end
 
+
+-- This is not a shape, this is dumb, please help find another way to achieve this.
+Drawing = defclass(Drawing, Shape)
+Drawing.ATTRS {
+    name = "Point Drawing",
+    min_points = 1,
+    max_points = math.huge,
+    drag_corners = { ne = false, nw = false, se = false, sw = false },
+    basic_shape = false
+}
+
+function Drawing:init()
+    
+end
+
+function Drawing:has_point(x, y)
+    top_left, _ = self:get_point_dims()
+    for _, point in ipairs(self.points) do
+        if point.x - top_left.x == x and point.y - top_left.y == y then return true end
+    end
+    return false
+end
+
 -- module users can get shapes through this global, shape option values
 -- persist in these as long as the module is loaded
 -- idk enough lua to know if this is okay to do or not
-all_shapes = { Rectangle {}, Ellipse {}, Rows {}, Diag {}, Line {}, FreeForm {} }
+all_shapes = { Rectangle {}, Ellipse {}, Rows {}, Diag {}, Line {}, FreeForm {}, Drawing{} }


### PR DESCRIPTION
Adds a "Copy Designated Tiles" command(`Ctrl+v`) that creates a shape mimicking the designated tiles under the current shape using a new shape called "Point Drawing", which just returns it's marks as the shape. It then starts "Stamp Mode", which is just center dragging but left click commits the shape instead of putting it down.

The command becomes available only when the user is not placing marks, forcing it to be used only with Auto-Commit off, which I suspect will make it hard to find on it's own, but possibly a way to introduce more users to all the functionalities of `gui/design`.