### PR TITLE
Fix `gui/design` conflicting center point behavior

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,7 +19,7 @@ Template for new versions:
 ## Fixes
 - `makeown`: fix error when adopting units that need a historical figure to be created
 - `item`: fix missing item categories when using ``--by-type``
-
+- `gui/design`: fix clicking the center point when there is a mark behind it entering both mark dragging and center dragging at the same time. Now you can click once to move the shape, and click twice to move only the mark behind the center point.
 ## Misc Improvements
 
 ## Removed

--- a/gui/design.lua
+++ b/gui/design.lua
@@ -1475,6 +1475,27 @@ function Design:onInput(keys)
             self.placing_mirror = false
             self.needs_update = true
         else
+            -- Clicking center point
+            if #self.marks > 0 then
+                local center = self.shape:get_center()
+                if pos == center and not self.prev_center then
+                    self.start_center = pos
+                    self.prev_center = pos
+                    return true
+                elseif self.prev_center then
+                    --If there was no movement presume user wanted to click the mark underneath instead and let the flow through.
+                    if pos == self.start_center then
+                        self.start_center = nil
+                        self.prev_center = nil
+                    else
+                    -- Since it moved let's just drop the shape here.
+                        self.start_center = nil
+                        self.prev_center = nil
+                        return true
+                    end
+                end
+            end
+            
             if self.shape.basic_shape and #self.marks == self.shape.max_points then
                 -- Clicking a corner of a basic shape
                 local shape_top_left, shape_bot_right = self.shape:get_point_dims()
@@ -1510,20 +1531,6 @@ function Design:onInput(keys)
                 if pos == self.extra_points[i] then
                     self.placing_extra = { active = true, index = i }
                     self.needs_update = true
-                    return true
-                end
-            end
-
-            -- Clicking center point
-            if #self.marks > 0 then
-                local center = self.shape:get_center()
-                if pos == center and not self.prev_center then
-                    self.start_center = pos
-                    self.prev_center = pos
-                    return true
-                elseif self.prev_center then
-                    self.start_center = nil
-                    self.prev_center = nil
                     return true
                 end
             end

--- a/gui/design.lua
+++ b/gui/design.lua
@@ -1495,7 +1495,7 @@ function Design:onInput(keys)
                     end
                 end
             end
-            
+
             if self.shape.basic_shape and #self.marks == self.shape.max_points then
                 -- Clicking a corner of a basic shape
                 local shape_top_left, shape_bot_right = self.shape:get_point_dims()


### PR DESCRIPTION
This solves #4234 by moving the center dragging logic up and adding a separate check for no movement movement case for dragging marks.

Now clicking on the center mark a second time without moving will let the function flow and enter mark editing mode.

Fixes: https://github.com/DFHack/dfhack/issues/4234