### PR TITLE
[devel/scan-vtables] pick up unique vtable addresses only in g_src

### DIFF
--- a/devel/scan-vtables.lua
+++ b/devel/scan-vtables.lua
@@ -7,7 +7,7 @@ if osType ~= 'linux' then
 end
 
 local df_ranges = {}
-for i,mem in ipairs(dfhack.internal.getMemRanges()) do
+for _, mem in ipairs(dfhack.internal.getMemRanges()) do
     if mem.read and (
         string.match(mem.name,'/dwarfort%.exe$')
         or string.match(mem.name,'/dwarfort$')
@@ -40,44 +40,47 @@ function scan_ranges(g_src)
             goto next_range
         end
 
+        local base = range.name:match('.*/(.*)$')
         local area = memscan.MemoryArea.new(range.start_addr, range.end_addr)
         for i = 1, area.uintptr_t.count - 1 do
             -- take every pointer-aligned value in memory mapped to the DF executable, and see if it is a valid vtable
             -- start by following the logic in Process::doReadClassName() and ensure it doesn't crash
             local vtable = area.uintptr_t:idx2addr(i)
             local typeinfo = area.uintptr_t[i - 1]
-            if is_df_addr(typeinfo + 8) then
-                local typestring = df.reinterpret_cast('uintptr_t', typeinfo + 8)[0]
-                if is_df_addr(typestring) then
-                    -- rule out false positives by checking that the vtable points to a table of valid pointers
-                    -- TODO: check that the pointers are actually function pointers
-                    local vlen = 0
-                    while is_df_addr(vtable + (8*vlen)) and
-                        is_df_addr(df.reinterpret_cast('uintptr_t', vtable + (8*vlen))[0])
-                    do
-                        vlen = vlen + 1
-                        break -- for now, any vtable with one valid pointer is valid enough
-                    end
-                    if vlen > 0 then
-                        -- some false positives can be ruled out if the string.char() call in read_c_string() throws an error for invalid characters
-                        local ok, name = pcall(function()
-                            return memscan.read_c_string(df.reinterpret_cast('char', typestring))
-                        end)
-                        if ok then
-                            -- GCC strips the "_Z" prefix from typeinfo names, so add it back
-                            local demangled_name = dfhack.internal.cxxDemangle('_Z' .. name)
-                            if demangled_name and
-                                not demangled_name:match('[<>]') and
-                                not demangled_name:match('^std::') and
-                                not names[demangled_name]
-                            then
-                                print(("<vtable-address name='%s' value='0x%x'/>"):format(demangled_name, vtable))
-                                names[demangled_name] = true
-                            end
-                        end
-                    end
-                end
+            if not is_df_addr(typeinfo + 8) then goto next_ptr end
+            local typestring = df.reinterpret_cast('uintptr_t', typeinfo + 8)[0]
+            if not is_df_addr(typestring) then goto next_ptr end
+            -- rule out false positives by checking that the vtable points to a table of valid pointers
+            -- TODO: check that the pointers are actually function pointers
+            local vlen = 0
+            while is_df_addr(vtable + (8*vlen)) and
+                is_df_addr(df.reinterpret_cast('uintptr_t', vtable + (8*vlen))[0])
+            do
+                vlen = vlen + 1
+                break -- for now, any vtable with one valid pointer is valid enough
             end
+            if vlen <= 0 then goto next_ptr end
+            -- some false positives can be ruled out if the string.char() call in read_c_string() throws an error for invalid characters
+            local ok, name = pcall(function()
+                return memscan.read_c_string(df.reinterpret_cast('char', typestring))
+            end)
+            if not ok then goto next_ptr end
+            -- GCC strips the "_Z" prefix from typeinfo names, so add it back
+            local demangled_name = dfhack.internal.cxxDemangle('_Z' .. name)
+            if demangled_name and
+                not demangled_name:match('[<>]') and
+                not demangled_name:match('^std::') and
+                not names[demangled_name]
+            then
+                local base_str = ''
+                if g_src then
+                    vtable = vtable - range.base_addr
+                    base_str = (" base='%s'"):format(base)
+                end
+                print(("<vtable-address name='%s' value='0x%x'%s/>"):format(demangled_name, vtable, base_str))
+                names[demangled_name] = true
+            end
+            ::next_ptr::
         end
         ::next_range::
     end

--- a/devel/scan-vtables.lua
+++ b/devel/scan-vtables.lua
@@ -29,43 +29,59 @@ function is_df_addr(a)
     return false
 end
 
-for _, range in ipairs(df_ranges) do
-    if (not range.read) or range.write or range.execute or range.name:match('g_src') then
-        goto next_range
-    end
+local names = {}
 
-    local area = memscan.MemoryArea.new(range.start_addr, range.end_addr)
-    for i = 1, area.uintptr_t.count - 1 do
-        -- take every pointer-aligned value in memory mapped to the DF executable, and see if it is a valid vtable
-        -- start by following the logic in Process::doReadClassName() and ensure it doesn't crash
-        local vtable = area.uintptr_t:idx2addr(i)
-        local typeinfo = area.uintptr_t[i - 1]
-        if is_df_addr(typeinfo + 8) then
-            local typestring = df.reinterpret_cast('uintptr_t', typeinfo + 8)[0]
-            if is_df_addr(typestring) then
-                -- rule out false positives by checking that the vtable points to a table of valid pointers
-                -- TODO: check that the pointers are actually function pointers
-                local vlen = 0
-                while is_df_addr(vtable + (8*vlen)) and is_df_addr(df.reinterpret_cast('uintptr_t', vtable + (8*vlen))[0]) do
-                    vlen = vlen + 1
-                    break -- for now, any vtable with one valid pointer is valid enough
-                end
-                if vlen > 0 then
-                    -- some false positives can be ruled out if the string.char() call in read_c_string() throws an error for invalid characters
-                    local ok, name = pcall(function()
-                        return memscan.read_c_string(df.reinterpret_cast('char', typestring))
-                    end)
-                    if ok then
-                        -- GCC strips the "_Z" prefix from typeinfo names, so add it back
-                        local demangled_name = dfhack.internal.cxxDemangle('_Z' .. name)
-                        if demangled_name and not demangled_name:match('[<>]') and not demangled_name:match('^std::') then
-                            print(("<vtable-address name='%s' value='0x%x'/>"):format(demangled_name, vtable))
+function scan_ranges(g_src)
+    for _, range in ipairs(df_ranges) do
+        if (not range.read) or range.write or range.execute then
+            goto next_range
+        end
+        if not not range.name:match('g_src') ~= g_src then
+            goto next_range
+        end
+
+        local area = memscan.MemoryArea.new(range.start_addr, range.end_addr)
+        for i = 1, area.uintptr_t.count - 1 do
+            -- take every pointer-aligned value in memory mapped to the DF executable, and see if it is a valid vtable
+            -- start by following the logic in Process::doReadClassName() and ensure it doesn't crash
+            local vtable = area.uintptr_t:idx2addr(i)
+            local typeinfo = area.uintptr_t[i - 1]
+            if is_df_addr(typeinfo + 8) then
+                local typestring = df.reinterpret_cast('uintptr_t', typeinfo + 8)[0]
+                if is_df_addr(typestring) then
+                    -- rule out false positives by checking that the vtable points to a table of valid pointers
+                    -- TODO: check that the pointers are actually function pointers
+                    local vlen = 0
+                    while is_df_addr(vtable + (8*vlen)) and
+                        is_df_addr(df.reinterpret_cast('uintptr_t', vtable + (8*vlen))[0])
+                    do
+                        vlen = vlen + 1
+                        break -- for now, any vtable with one valid pointer is valid enough
+                    end
+                    if vlen > 0 then
+                        -- some false positives can be ruled out if the string.char() call in read_c_string() throws an error for invalid characters
+                        local ok, name = pcall(function()
+                            return memscan.read_c_string(df.reinterpret_cast('char', typestring))
+                        end)
+                        if ok then
+                            -- GCC strips the "_Z" prefix from typeinfo names, so add it back
+                            local demangled_name = dfhack.internal.cxxDemangle('_Z' .. name)
+                            if demangled_name and
+                                not demangled_name:match('[<>]') and
+                                not demangled_name:match('^std::') and
+                                not names[demangled_name]
+                            then
+                                print(("<vtable-address name='%s' value='0x%x'/>"):format(demangled_name, vtable))
+                                names[demangled_name] = true
+                            end
                         end
                     end
                 end
             end
         end
-
+        ::next_range::
     end
-    ::next_range::
 end
+
+scan_ranges(false)
+scan_ranges(true)


### PR DESCRIPTION
since there are some symbols that are not in `dwarfort`:

-  `<vtable-address name='enablerst' value='0x7ffff6ce6008'/>`
-  `<vtable-address name='renderer_2d_base' value='0x7ffff6ce6020'/>`
-  `<vtable-address name='renderer_2d' value='0x7ffff6ce6108'/>`
-  `<vtable-address name='enabler_inputst' value='0x7ffff6ce6200'/>`
-  `<vtable-address name='MacroScreenLoad' value='0x7ffff6ce64e0'/>`
-  `<vtable-address name='MacroScreenSave' value='0x7ffff6ce6548'/>`
-  `<vtable-address name='renderer_offscreen' value='0x7ffff6ce65c8'/>`
-  `<vtable-address name='widgets::folder' value='0x7ffff6ce6bc0'/>`
-  `<vtable-address name='widgets::filter' value='0x7ffff6ce6c20'/>`
-  `<vtable-address name='widgets::multifilter::indiv_filter' value='0x7ffff6ce6c88'/>`
-  `<vtable-address name='widgets::multifilter' value='0x7ffff6ce6cf0'/>`
-  `<vtable-address name='widgets::radio_rows' value='0x7ffff6ce6f80'/>`
-  `<vtable-address name='widgets::table' value='0x7ffff6ce6fe0'/>`
-  `<vtable-address name='widgets::better_button' value='0x7ffff6ce70c0'/>`
-  `<vtable-address name='widgets::character' value='0x7ffff6ce72a0'/>`
-  `<vtable-address name='widgets::dropdown' value='0x7ffff6ce75d0'/>`