### PR TITLE
`gui/probe` candidate

### DIFF
--- a/gui/probe.lua
+++ b/gui/probe.lua
@@ -1,0 +1,71 @@
+-- Shows the info given by `probe` in a friendly display
+
+local gui = require('gui')
+local guidm = require('gui.dwarfmode')
+local widgets = require('gui.widgets')
+local overlay = require('plugins.overlay')
+
+Probe = defclass(Probe, widgets.Window)
+Probe.ATTRS{
+    frame = {
+        w = 40,
+        h = 45,
+        r = 2,
+        t = 18,
+    },
+    resizable=true,
+    frame_title='Probe',
+}
+
+function Probe:init()
+    self:addviews{
+		widgets.ToggleHotkeyLabel{
+            view_id='lock',
+            frame={t=0, l=0},
+            key='CUSTOM_CTRL_F',
+            label='Lock on tile:',
+            initial_option=false,
+        },
+        widgets.Label{
+            view_id='report',
+            frame={t=2, l=0},
+        },
+    }
+end
+
+function Probe:onRenderBody()
+	if self.subviews.lock:getOptionValue() then return end
+	guidm.setCursorPos(dfhack.gui.getMousePos())
+    local report = dfhack.run_command_silent('probe')
+    self.subviews.report:setText(report)
+    self:updateLayout()
+end
+
+function Probe:onInput(keys)
+    if Probe.super.onInput(self, keys) then
+        return true
+    end
+    if keys._MOUSE_L and not self:getMouseFramePos() then
+        self.subviews.lock:cycle()
+        return true
+    end
+end
+
+ProbeScreen = defclass(ProbeScreen, gui.ZScreenModal)
+ProbeScreen.ATTRS{
+    focus_string='probe-screen',
+}
+
+function ProbeScreen:init()
+    self:addviews{Probe{}}
+end
+
+function ProbeScreen:onDismiss()
+    view = nil
+end
+
+if not dfhack.isMapLoaded() then
+    qerror("This script requires a fortress map to be loaded")
+end
+
+view = view and view:raise() or ProbeScreen {}:show()


### PR DESCRIPTION
I tempted some vengeful deity by mentioning work downtime and got swamped this week. This creates a tool that will run probe on the position of the mouse and show it in a window in the right corner of the screen. Left click locks on a tile.

I chose the same window that `gui/design` uses, it feels comfortable there. I'm not sure about pausing the game, maybe someone could be trying to check something changing in realtime?

I should probably let the map movement keys go through, someone might be trying to check something on multiple z-levels.

Probe spits out a lot of lines, which is fine because the widgets have auto scrollbar feature for big elements. Sadly, updating the frame resets the scrolling position. So every time I move the mouse to check another tile it will snap back to the top and I have to scroll down again to see the light tags and such.

Outside of ASCII mode it is actually kind of difficult to discern where a tile ends and another begins sometimes, definitely add a transparent or blinking cursor to help pinpoint which tile is being probed, specially if locked on a tile.

It works fine as is, but I'll keep committing to this while the PR is open.