### PR TITLE
[modtools/reaction-trigger] don't enable events until we need them

### DIFF
--- a/modtools/reaction-trigger.lua
+++ b/modtools/reaction-trigger.lua
@@ -2,57 +2,7 @@
 -- author expwnent
 -- replaces autoSyndrome
 --@ module = true
-local usage = [====[
 
-modtools/reaction-trigger
-=========================
-Triggers dfhack commands when custom reactions complete, regardless of whether
-it produced anything, once per completion.  Arguments::
-
-    -clear
-        unregister all reaction hooks
-    -reactionName name
-        specify the name of the reaction
-    -syndrome name
-        specify the name of the syndrome to be applied to valid targets
-    -allowNonworkerTargets
-        allow other units to be targeted if the worker is invalid or ignored
-    -allowMultipleTargets
-        allow all valid targets within range to be affected
-        if absent:
-            if running a script, only one target will be used
-            if applying a syndrome, then only one target will be infected
-    -ignoreWorker
-        ignores the worker when selecting the targets
-    -dontSkipInactive
-        when selecting targets in range, include creatures that are inactive
-        dead creatures count as inactive
-    -range [ x y z ]
-        controls how far elligible targets can be from the workshop
-        defaults to [ 0 0 0 ] (on a workshop tile)
-        negative numbers can be used to ignore outer squares of the workshop
-        line of sight is not respected, and the worker is always within range
-    -resetPolicy policy
-        the policy in the case that the syndrome is already present
-        policy
-            NewInstance (default)
-            DoNothing
-            ResetDuration
-            AddDuration
-    -command [ commandStrs ]
-        specify the command to be run on the target(s)
-        special args
-            \\WORKER_ID
-            \\TARGET_ID
-            \\BUILDING_ID
-            \\LOCATION
-            \\REACTION_NAME
-            \\anything -> \anything
-            anything -> anything
-        when used with -syndrome, the target must be valid for the syndrome
-        otherwise, the command will not be run for that target
-
-]====]
 local eventful = require 'plugins.eventful'
 local syndromeUtil = require 'syndrome-util'
 local utils = require 'utils'
@@ -220,7 +170,6 @@ eventful.onJobCompleted.reactionTrigger = function(job)
   doAction(action)
  end
 end
-eventful.enableEvent(eventful.eventType.JOB_COMPLETED,0) --0 is necessary to catch cancelled jobs and not trigger them
 
 local validArgs = utils.invert({
  'help',
@@ -242,7 +191,7 @@ end
 local args = utils.processArgs({...}, validArgs)
 
 if args.help then
- print(usage)
+ print(dfhack.script_help())
  return
 end
 
@@ -261,5 +210,7 @@ end
 if args.syndrome and not findSyndrome(args.syndrome) then
  error('Could not find syndrome ' .. args.syndrome)
 end
+
+eventful.enableEvent(eventful.eventType.JOB_COMPLETED,0) --0 is necessary to catch cancelled jobs and not trigger them
 
 table.insert(reactionHooks[args.reactionName], args)


### PR DESCRIPTION
this is not a full implementation since the event will stay enabled at frequency 0 even if the reactions are cleared, but at least this will prevent the event from being enabled for users that don't even use the script (which is the majority)