### PR TITLE
[fix/stuck-worship] new tool: prevent units getting stuck worshipping

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ Template for new versions:
 # Future
 
 ## New Tools
+- `fix/stuck-worship`: fix prayer so units don't get stuck in uninterruptible "Worship!" states
 
 ## New Features
 
@@ -46,7 +47,6 @@ Template for new versions:
 - `make-legendary`: (reinstated) make a dwarf legendary in specified skills
 - `combat-harden`: (reinstated) set a dwarf's resistence to being affected by visible corpses
 - `add-thought`: (reinstated) add custom thoughts to a dwarf
-- `devel/input-monitor`: interactive UI for debugging input issues
 
 ## Fixes
 - `gui/design`: clicking the center point when there is a design mark behind it will no longer simultaneously enter both mark dragging and center dragging modes. Now you can click once to move the shape, and click twice to move only the mark behind the center point.

--- a/changelog.txt
+++ b/changelog.txt
@@ -47,6 +47,7 @@ Template for new versions:
 - `make-legendary`: (reinstated) make a dwarf legendary in specified skills
 - `combat-harden`: (reinstated) set a dwarf's resistence to being affected by visible corpses
 - `add-thought`: (reinstated) add custom thoughts to a dwarf
+- `devel/input-monitor`: interactive UI for debugging input issues
 
 ## Fixes
 - `gui/design`: clicking the center point when there is a design mark behind it will no longer simultaneously enter both mark dragging and center dragging modes. Now you can click once to move the shape, and click twice to move only the mark behind the center point.

--- a/docs/fix/stuck-worship.rst
+++ b/docs/fix/stuck-worship.rst
@@ -1,0 +1,31 @@
+fix/stuck-worship
+=================
+
+.. dfhack-tool::
+    :summary: Prevent dwarves from getting stuck in Worship! states.
+    :tags: fort bugfix units
+
+Dwarves that need to pray to multiple deities sometimes get stuck in a state
+where they repeatedly fulfill the need to pray/worship one deity but ignore the
+others. The intense need to pray to the other deities causes the dwarf to start
+a purple (uninterruptible) ``Worship!`` activity, but since those needs are
+never satisfied, the dwarf becomes stuck and effectively useless. More info on
+this problem at :bug:`10918`.
+
+This fix analyzes all units that are actively praying/worshipping and detects
+when they have become stuck (or are on the path to becoming stuck). It then
+adjusts the distribution of need so when the dwarf finishes their current
+prayer, a different prayer need will be fulfilled.
+
+This fix will run automatically if it is enabled in the ``Bugfixes`` tab in
+`gui/control-panel`. If it is disabled there, you can still run it as needed.
+You'll know it worked if your units go from ``Worship!`` to a prayer to some
+specific deity or if the unit just stops praying altogether and picks up
+another task.
+
+Usage
+-----
+
+::
+
+    fix/stuck-worship

--- a/fix/stuck-worship.lua
+++ b/fix/stuck-worship.lua
@@ -1,0 +1,93 @@
+local function for_pray_need(needs, fn)
+    for idx, need in ipairs(needs) do
+        if need.id == df.need_type.PrayOrMeditate then
+            fn(idx, need)
+        end
+    end
+end
+
+local function shuffle_prayer_needs(needs, prayer_targets)
+    local idx_of_prayer_target, max_focus_level
+    local idx_of_min_focus_level, min_focus_level
+    for_pray_need(needs, function(idx, need)
+        -- only shuffle if the need for one of the current prayer targets
+        -- is already met
+        if prayer_targets[need.deity_id] and need.focus_level > -1000 and
+            (not max_focus_level or need.focus_level > max_focus_level)
+        then
+            idx_of_prayer_target = idx
+            max_focus_level = need.focus_level
+
+        -- find a need that hasn't been met outside of the current prayer targets
+        elseif not prayer_targets[need.deity_id] and
+            need.focus_level <= -1000 and
+            (not min_focus_level or need.focus_level < min_focus_level)
+        then
+            idx_of_min_focus_level = idx
+            min_focus_level = need.focus_level
+        end
+    end)
+
+    -- if a need inside the prayer group is met and a need outside of the
+    -- prayer group is not met, transfer the credit outside of the prayer group
+    if idx_of_prayer_target and idx_of_min_focus_level then
+        needs[idx_of_min_focus_level].focus_level = needs[idx_of_prayer_target].focus_level
+        needs[idx_of_prayer_target].focus_level = min_focus_level
+        return true
+    end
+
+    if not idx_of_prayer_target then return end
+
+    -- otherwise, if the only unmet needs are inside the prayer group,
+    -- set the credit inside the prayer group to the level of the met need
+    -- we found earlier
+    local modified = false
+    for_pray_need(needs, function(_, need)
+        if prayer_targets[need.deity_id] and need.focus_level <= -1000 then
+            need.focus_level = needs[idx_of_prayer_target].focus_level
+            modified = true
+        end
+    end)
+    return modified
+end
+
+local function get_prayer_targets(unit)
+    for _, sa in ipairs(unit.social_activities) do
+        local ae = df.activity_entry.find(sa)
+        if not ae or ae.type ~= df.activity_entry_type.Prayer then
+            goto next_activity
+        end
+        for _, ev in ipairs(ae.events) do
+            if not df.activity_event_worshipst:is_instance(ev) then
+                goto next_event
+            end
+            for _, hfid in ipairs(ev.participants.histfigs) do
+                local hf = df.historical_figure.find(hfid)
+                if not hf then goto next_hf end
+                local deity_set = {}
+                for _, hf_link in ipairs(hf.histfig_links) do
+                    if df.histfig_hf_link_deityst:is_instance(hf_link) then
+                        deity_set[hf_link.target_hf] = true
+                    end
+                end
+                if next(deity_set) then return deity_set end
+                ::next_hf::
+            end
+            ::next_event::
+        end
+        ::next_activity::
+    end
+end
+
+for _,unit in ipairs(dfhack.units.getCitizens(true)) do
+    local prayer_targets = get_prayer_targets(unit)
+    if not unit.status.current_soul or not prayer_targets then
+        goto next_unit
+    end
+    local needs = unit.status.current_soul.personality.needs
+    if shuffle_prayer_needs(needs, prayer_targets) then
+        print('rebalanced prayer needs for ' ..
+            dfhack.df2console(dfhack.TranslateName(dfhack.units.getVisibleName(unit))))
+    end
+    ::next_unit::
+end

--- a/internal/control-panel/registry.lua
+++ b/internal/control-panel/registry.lua
@@ -68,6 +68,8 @@ COMMANDS_BY_IDX = {
     {command='fix/stuck-instruments', group='bugfix', mode='repeat', default=true,
         desc='Fix activity references on stuck instruments to make them usable again.',
         params={'--time', '1', '--timeUnits', 'days', '--command', '[', 'fix/stuck-instruments', ']'}},
+    {command='fix/stuck-worship', group='bugfix', mode='repeat', default=true,
+        params={'--time', '1', '--timeUnits', 'days', '--command', '[', 'fix/stuck-worship', ']'}},
     {command='flask-contents', help_command='tweak', group='bugfix', mode='tweak', default=true,
         desc='Displays flask contents in the item name, similar to barrels and bins.'},
     {command='preserve-tombs', group='bugfix', mode='enable', default=true},


### PR DESCRIPTION
when they have multiple deities

addresses DF bug https://dwarffortressbugtracker.com/view.php?id=10918