### PR TITLE
[fix/retrieve-units] *really* prevent duplicate units from being added to the active vector

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -39,6 +39,7 @@ Template for new versions:
 
 ## Fixes
 - `gui/design`: fix clicking the center point when there is a mark behind it entering both mark dragging and center dragging at the same time. Now you can click once to move the shape, and click twice to move only the mark behind the center point.
+- `fix/retrieve-units`: prevent pulling in duplicate units from offscreen
 - `warn-stranded`: when there was at least one truly stuck unit and miners were actively mining, the miners were also confusingly shown in the stuck units list
 - `source`: fix issue where removing sources would make some other sources inactive
 - `caravan`: display book and scroll titles in the goods and trade dialogs instead of generic scroll descriptions

--- a/fix/retrieve-units.lua
+++ b/fix/retrieve-units.lua
@@ -17,19 +17,17 @@ function shouldRetrieve(unit)
 end
 
 function retrieveUnits()
-    for _, unit in pairs(df.global.world.units.all) do
+    for _, unit in ipairs(df.global.world.units.all) do
         if unit.flags1.inactive and shouldRetrieve(unit) then
-            print(("Retrieving from the abyss: %s (%s)"):format(
-                dfhack.df2console(dfhack.TranslateName(dfhack.units.getVisibleName(unit))),
-                df.creature_raw.find(unit.race).name[0]
-            ))
+            print(("Retrieving from the abyss: %s (%d)"):format(
+                dfhack.df2console(dfhack.units.getReadableName(unit)), unit.id))
             unit.flags1.move_state = true
             unit.flags1.inactive = false
             unit.flags1.incoming = false
             unit.flags1.can_swap = true
             unit.flags1.hidden_in_ambush = false
             -- add to active if missing
-            if not utils.linear_index(df.global.world.units.active, unit, 'id') then
+            if not utils.linear_index(df.global.world.units.active, unit.id, 'id') then
                 df.global.world.units.active:insert('#', unit)
             end
         end


### PR DESCRIPTION
for real this time. The first fix was correct in spirit, but had a typo where we need to pass unit.id and instead passed unit