### PR TITLE
[gui/launcher] swap dev mode hotkey to alt

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -45,6 +45,7 @@ Template for new versions:
 - `caravan`: display book and scroll titles in the goods and trade dialogs instead of generic scroll descriptions
 - `item`: avoid error when scanning items that have no quality rating (like bars and other construction materials)
 - `gui/blueprint`: changed hotkey for setting blueprint origin tile so it doesn't conflict with default map movement keys
+- `gui/launcher`: developer mode hotkey changed from Ctrl-D to Alt-D so as not to conflict with the hotkey for `gui/design`
 
 ## Misc Improvements
 - `exportlegends`: make progress increase smoothly over the entire export and increase precision of progress percentage

--- a/docs/gui/launcher.rst
+++ b/docs/gui/launcher.rst
@@ -108,4 +108,4 @@ Dev mode
 
 By default, commands intended for developers and modders are filtered out of the
 autocomplete list. This includes any tools tagged with ``unavailable``. You can
-toggle this filtering by hitting :kbd:`Ctrl`:kbd:`D` at any time.
+toggle this filtering by hitting :kbd:`Alt`:kbd:`D` at any time.

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -490,7 +490,7 @@ end
 function MainPanel:onInput(keys)
     if MainPanel.super.onInput(self, keys) then
         return true
-    elseif keys.CUSTOM_CTRL_D then
+    elseif keys.CUSTOM_ALT_D then
         dev_mode = not dev_mode
         self.update_autocomplete(get_first_word(self.subviews.editfield.text))
         return true


### PR DESCRIPTION
so as not to conflict with the hotkey for `gui/design`. now that we (correctly) pass focus through, more hotkeys are active when gui/launcher is up