### PR TITLE
Revert "temporarily revert to not using tab for 50.11 compat"

### DIFF
--- a/docs/gui/launcher.rst
+++ b/docs/gui/launcher.rst
@@ -67,11 +67,10 @@ setting the tag filter with :kbd:`Ctrl`:kbd:`W` or by clicking on the ``Tags``
 button. If the first word of what you've typed matches a valid command, then the
 autocomplete options switch to showing commands that have similar functionality
 to the one that you've typed. Click on an autocomplete list option to select it
-or cycle through them with :kbd:`Shift`:kbd:`Left` and
-:kbd:`Shift`:kbd:`Right`. You can run a command quickly without parameters by
-double-clicking on the tool name in the list. Holding down shift while you
-double-click allows you to run the command and close `gui/launcher` at the same
-time.
+or cycle through them with :kbd:`Tab` and :kbd:`Shift`:kbd:`Tab`. You can run a
+command quickly without parameters by double-clicking on the tool name in the
+list. Holding down shift while you double-click allows you to run the command
+and close `gui/launcher` at the same time.
 
 Context-sensitive help and command output
 -----------------------------------------

--- a/gui/launcher.lua
+++ b/gui/launcher.lua
@@ -354,9 +354,9 @@ function AutocompletePanel:init()
         },
         widgets.Label{
             frame={l=1, t=1},
-            text={{text='Shift+Left', pen=COLOR_LIGHTGREEN},
+            text={{text='Tab', pen=COLOR_LIGHTGREEN},
                   {text='/'},
-                  {text='Shift+Right', pen=COLOR_LIGHTGREEN}}
+                  {text='Shift+Tab', pen=COLOR_LIGHTGREEN}}
         },
         widgets.Label{
             frame={l=0, t=3},
@@ -741,9 +741,9 @@ function MainPanel:onInput(keys)
     elseif keys.CUSTOM_ALT_D then
         toggle_dev_mode()
         self:refresh_autocomplete()
-    elseif keys.KEYBOARD_CURSOR_RIGHT_FAST then
+    elseif keys.CHANGETAB then
         self.subviews.autocomplete:advance(1)
-    elseif keys.KEYBOARD_CURSOR_LEFT_FAST then
+    elseif keys.SEC_CHANGETAB then
         self.subviews.autocomplete:advance(-1)
     else
         return false


### PR DESCRIPTION
This reverts commit 9694a80e3c9595848b8510ebdd411f45e9a767c4 from https://github.com/DFHack/scripts/pull/1009

Do not merge until 50.12 is released