### PR TITLE
[confirm, gui/notify] use new tooltip enum identifiers

### DIFF
--- a/gui/notify.lua
+++ b/gui/notify.lua
@@ -3,6 +3,7 @@
 local gui = require('gui')
 local notifications = reqscript('internal/notify/notifications')
 local overlay = require('plugins.overlay')
+local utils = require('utils')
 local widgets = require('gui.widgets')
 
 --
@@ -85,6 +86,25 @@ function NotifyOverlay:overlay_onupdate()
     end
     list:setChoices(choices, idx)
     self.visible = #choices > 0
+end
+
+local CONFLICTING_TOOLTIPS = utils.invert{
+    df.main_hover_instruction.InfoUnits,
+    df.main_hover_instruction.InfoJobs,
+    df.main_hover_instruction.InfoPlaces,
+    df.main_hover_instruction.InfoLabors,
+    df.main_hover_instruction.InfoWorkOrders,
+    df.main_hover_instruction.InfoNobles,
+    df.main_hover_instruction.InfoObjects,
+    df.main_hover_instruction.InfoJustice,
+}
+
+local mi = df.global.game.main_interface
+
+function NotifyOverlay:render(dc)
+    if not CONFLICTING_TOOLTIPS[mi.current_hover] then
+        NotifyOverlay.super.render(self, dc)
+    end
 end
 
 OVERLAY_WIDGETS = {

--- a/internal/confirm/specs.lua
+++ b/internal/confirm/specs.lua
@@ -198,7 +198,7 @@ ConfirmSpec{
     message='Are you sure you want to delete this route?',
     intercept_keys='_MOUSE_L',
     context='dwarfmode/Hauling',
-    predicate=function() return mi.current_hover == 180 end,
+    predicate=function() return mi.current_hover == df.main_hover_instruction.RouteRemove end,
     pausable=true,
 }
 
@@ -208,7 +208,7 @@ ConfirmSpec{
     message='Are you sure you want to delete this stop?',
     intercept_keys='_MOUSE_L',
     context='dwarfmode/Hauling',
-    predicate=function() return mi.current_hover == 185 end,
+    predicate=function() return mi.current_hover == df.main_hover_instruction.StopRemove end,
     pausable=true,
 }
 
@@ -219,7 +219,7 @@ ConfirmSpec{
     intercept_keys='_MOUSE_L',
     context='dwarfmode/ViewSheets/BUILDING/TradeDepot',
     predicate=function()
-        return mi.current_hover == 301 and has_caravans()
+        return mi.current_hover == df.main_hover_instruction.BuildingRemove and has_caravans()
     end,
 }
 
@@ -229,7 +229,7 @@ ConfirmSpec{
     message='Are you sure you want to disband this squad?',
     intercept_keys='_MOUSE_L',
     context='dwarfmode/Squads',
-    predicate=function() return mi.current_hover == 343 end,
+    predicate=function() return mi.current_hover == df.main_hover_instruction.SquadDisband end,
     pausable=true,
 }
 
@@ -424,7 +424,7 @@ ConfirmSpec{
     message='Are you sure you want to remove this manager order?',
     intercept_keys='_MOUSE_L',
     context='dwarfmode/Info/WORK_ORDERS/Default',
-    predicate=function() return mi.current_hover == 222 end,
+    predicate=function() return mi.current_hover == df.main_hover_instruction.ManagerOrderRemove end,
     pausable=true,
 }
 
@@ -446,7 +446,8 @@ ConfirmSpec{
     intercept_keys='_MOUSE_L',
     context='dwarfmode/Burrow',
     predicate=function()
-        return mi.current_hover == 171 or mi.current_hover == 168
+        return mi.current_hover == df.main_hover_instruction.BurrowRemove or
+            mi.current_hover == df.main_hover_instruction.BurrowRemovePaint
     end,
     pausable=true,
 }
@@ -457,7 +458,7 @@ ConfirmSpec{
     message='Are you sure you want to remove this stockpile?',
     intercept_keys='_MOUSE_L',
     context='dwarfmode/Stockpile',
-    predicate=function() return mi.current_hover == 118 end,
+    predicate=function() return mi.current_hover == df.main_hover_instruction.StockpileRemove end,
     pausable=true,
 }
 


### PR DESCRIPTION
use tooltip enums in confirm
hide the notification panel when tooltips are shown that would be hidden by the notification panel

Fixes https://github.com/DFHack/dfhack/issues/3773