### PR TITLE
[gui/launcher] fix up/down arrow keys being captured in minimal mode by unrendered widgets when in minimal mode

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -34,9 +34,11 @@ Template for new versions:
 
 ## Fixes
 - `gui/notify`: persist notification settings when toggled in the UI
+- `gui/launcher`: fix history scanning (Up/Down arrow keys) being slow to respond when in minimal mode
 
 ## Misc Improvements
 - `gui/launcher`: add interface for browsing and filtering commands by tags
+- `gui/launcher`: add support for history search (Alt-s hotkey) when in minimal mode
 
 ## Removed
 


### PR DESCRIPTION
and show history search edit field when history search is active in minimal mode

Fixes: https://github.com/DFHack/dfhack/issues/4326