### PR TITLE
[quickfort] support labor and skill profile properties

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -35,6 +35,7 @@ Template for new versions:
 ## New Features
 - `gui/settings-manager`: add import, export, and autoload for work details
 - `exterminate`: new "disintegrate" kill method that additionally destroys carried items
+- `quickfort`: allow setting of workshop profile properties (e.g. labor, skill restrictions) from build blueprints
 
 ## Fixes
 - `gui/launcher`: fix history scanning (Up/Down arrow keys) being slow to respond when in minimal mode


### PR DESCRIPTION
now that the `orders` overlay makes the workshop profile state accessible to the player