### PR TITLE
Fix "seize" typo in confirm, focus_string in gui/teleport

### DIFF
--- a/gui/teleport.lua
+++ b/gui/teleport.lua
@@ -395,7 +395,7 @@ end
 
 TeleportScreen = defclass(TeleportScreen, gui.ZScreen)
 TeleportScreen.ATTRS {
-    focus_path='autodump',
+    focus_path='teleport',
     pass_movement_keys=true,
     pass_mouse_clicks=false,
     force_pause=true,

--- a/internal/confirm/specs.lua
+++ b/internal/confirm/specs.lua
@@ -162,9 +162,9 @@ ConfirmSpec{
 }
 
 ConfirmSpec{
-    id='trade-sieze',
-    title='Sieze merchant goods',
-    message='Are you sure you want size marked merchant goods? This will make the merchant unwilling to trade further and will damage relations with the merchant\'s civilization.',
+    id='trade-seize',
+    title='Seize merchant goods',
+    message='Are you sure you want seize marked merchant goods? This will make the merchant unwilling to trade further and will damage relations with the merchant\'s civilization.',
     intercept_keys='_MOUSE_L',
     intercept_frame={l=0, r=73, b=4, w=11, h=3},
     context='dwarfmode/Trade',


### PR DESCRIPTION
Fixed typos of "seize" in confirm, and focus_string for gui/teleport being "autodump".