### PR TITLE
[open-legends] support --no-autoquit

### DIFF
--- a/docs/open-legends.rst
+++ b/docs/open-legends.rst
@@ -6,16 +6,16 @@ open-legends
     :tags: legends inspection
 
 You can use this tool to open legends mode from a world loaded in fortress or
-adventure mode. You can browse around, or even export legends data while you're
-on the legends screen.
+adventure mode. You can browse around as normal, and even export legends data
+while you're on the legends screen.
 
 However, entering and leaving legends mode from a fort or adventure mode game
 will leave Dwarf Fortress in an inconsistent state. Therefore, entering legends
-mode is a **ONE WAY TRIP**. If you care about your savegame, you *MUST* save
-your game before entering legends mode. `open-legends` will pop up a dialog to
-remind you of this and will give you a link that you can use to trigger an
-Autosave. You can also close the dialog, do a manual save with a name of your
-choice, and run `open-legends` again to continue to legends mode.
+mode via this tool is a **ONE WAY TRIP**. If you care about your savegame, you
+*MUST* save your game before entering legends mode. `open-legends` will pop up
+a dialog to remind you of this and will give you a link that you can use to
+trigger an Autosave. You can also close the dialog, do a manual save with a
+name of your choice, and run `open-legends` again to continue to legends mode.
 
 Usage
 -----
@@ -23,3 +23,22 @@ Usage
 ::
 
     open-legends
+    open-legends --no-autoquit
+
+Options
+-------
+
+The ``--no-autoquit`` option is provided for bypassing the auto-quit in case
+you are doing testing where you want to switch into legends mode, switch back,
+make a few changes, and then hop back into legends mode. However, please note
+that while the game appears playable once you are back in the original mode,
+your world data **is corrupted** in subtle ways that are not easy to detect
+from the UI. Once you are done with your legends browsing, you *must* quit to
+desktop and restart the game to be sure to avoid save corruption issues.
+
+Upon return to the playable game, autosaves will be disabled to avoid
+accidental overwriting of good savegames.
+
+If the ``--no-autoquit`` option is passed and the savegame is already "tainted"
+by previous trips into legends mode, the warning dialog prompting you to save
+your game will be skipped.

--- a/open-legends.lua
+++ b/open-legends.lua
@@ -142,7 +142,8 @@ function LegendsWarning:init()
             text={
                 NEWLINE,
                 'or exit out of this dialog and create a named', NEWLINE,
-                'save of your choice.',
+                'save of your choice.', NEWLINE,
+                NEWLINE,
             },
         },
         widgets.HotkeyLabel{


### PR DESCRIPTION
allow returning to previous game mode, but add behavior changes to minimize chances players will accidentally shoot themselves in the foot:
- disable autosaves
- skip prompt to save game when re-entering legends mode

Fixes https://github.com/DFHack/dfhack/issues/4424