### PR TITLE
Add peafowl to gui/control-panel poultry list

### DIFF
--- a/internal/control-panel/registry.lua
+++ b/internal/control-panel/registry.lua
@@ -16,7 +16,7 @@ COMMANDS_BY_IDX = {
     {command='autobutcher target 10 10 14 2 BIRD_CHICKEN', group='automation', mode='run',
         desc='Enable if you usually want to raise chickens.'},
     {command='autobutcher target 10 10 14 2 BIRD_PEAFOWL_BLUE', group='automation', mode='run',
-        desc='Enable if you usually want to raise chickens.'},   
+        desc='Enable if you usually want to raise peafowl.'},   
     {command='autochop', group='automation', mode='enable'},
     {command='autoclothing', group='automation', mode='enable'},
     {command='autofarm', group='automation', mode='enable'},

--- a/internal/control-panel/registry.lua
+++ b/internal/control-panel/registry.lua
@@ -16,7 +16,7 @@ COMMANDS_BY_IDX = {
     {command='autobutcher target 10 10 14 2 BIRD_CHICKEN', group='automation', mode='run',
         desc='Enable if you usually want to raise chickens.'},
     {command='autobutcher target 10 10 14 2 BIRD_PEAFOWL_BLUE', group='automation', mode='run',
-        desc='Enable if you usually want to raise peafowl.'},   
+        desc='Enable if you usually want to raise peafowl.'},
     {command='autochop', group='automation', mode='enable'},
     {command='autoclothing', group='automation', mode='enable'},
     {command='autofarm', group='automation', mode='enable'},

--- a/internal/control-panel/registry.lua
+++ b/internal/control-panel/registry.lua
@@ -15,6 +15,8 @@ COMMANDS_BY_IDX = {
         desc='Enable if you usually want to raise turkeys.'},
     {command='autobutcher target 10 10 14 2 BIRD_CHICKEN', group='automation', mode='run',
         desc='Enable if you usually want to raise chickens.'},
+    {command='autobutcher target 10 10 14 2 BIRD_PEAFOWL_BLUE', group='automation', mode='run',
+        desc='Enable if you usually want to raise chickens.'},   
     {command='autochop', group='automation', mode='enable'},
     {command='autoclothing', group='automation', mode='enable'},
     {command='autofarm', group='automation', mode='enable'},


### PR DESCRIPTION
Adds a control-panel line that sets the targets for peafowl similarly to other poulry.