### PR TITLE
[quickfort] better chop designation behavior

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -32,6 +32,7 @@ Template for new versions:
 
 ## Fixes
 - `modtools/create-item`: adjust for API changes, tolerate ``reaction-gloves`` tweak being active
+- `quickfort`: don't designate multiple tiles of the same tree for chopping when applying a tree chopping blueprint to a multi-tile tree
 
 ## Misc Improvements
 - `gui/autobutcher`: add functionality to butcher and unbutcher all animals

--- a/internal/quickfort/dig.lua
+++ b/internal/quickfort/dig.lua
@@ -112,6 +112,7 @@ end
 
 local values_run = {
     dig_default=df.tile_dig_designation.Default,
+    dig_chop=dfhack.designations.markPlant,
     dig_channel=df.tile_dig_designation.Channel,
     dig_upstair=df.tile_dig_designation.UpStair,
     dig_downstair=df.tile_dig_designation.DownStair,
@@ -140,6 +141,7 @@ local values_run = {
 -- if there is demand, though.
 local values_undo = {
     dig_default=df.tile_dig_designation.No,
+    dig_chop=dfhack.designations.unmarkPlant,
     dig_channel=df.tile_dig_designation.No,
     dig_upstair=df.tile_dig_designation.No,
     dig_downstair=df.tile_dig_designation.No,
@@ -181,7 +183,10 @@ end
 local function do_chop(digctx)
     if digctx.flags.hidden then return nil end
     if is_tree(digctx.tileattrs) then
-        return function() digctx.flags.dig = values.dig_default end
+        return function()
+            local plant = dfhack.maps.getPlantAtTile(digctx.pos)
+            if plant then values.dig_chop(plant) end
+        end
     end
     return function() end -- noop, but not an error
 end


### PR DESCRIPTION
only designate one canonical tile of a multi-tile tree for chopping when designating a multi-tile tree