### PR TITLE
update gui/sandbox and gui/create-item for adventure mode

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ Template for new versions:
 # Future
 
 ## New Tools
+- Validated for adventure mode: `gui/sandbox`, `gui/create-item`
 
 ## New Features
 

--- a/docs/gui/create-item.rst
+++ b/docs/gui/create-item.rst
@@ -3,7 +3,7 @@ gui/create-item
 
 .. dfhack-tool::
     :summary: Summon items from the aether.
-    :tags: fort armok items
+    :tags: adventure fort armok items
 
 This tool provides a graphical interface for creating items of your choice. It
 walks you through the creation process with a series of prompts, asking you

--- a/docs/gui/sandbox.rst
+++ b/docs/gui/sandbox.rst
@@ -3,7 +3,7 @@ gui/sandbox
 
 .. dfhack-tool::
     :summary: Create units, trees, or items.
-    :tags: fort armok animals items map plants units
+    :tags: adventure fort armok animals items map plants units
 
 This tool provides a spawning interface for units, trees, and/or items. Units
 can be created with arbitrary skillsets, and trees can be created either as
@@ -28,3 +28,10 @@ Usage
 ::
 
     gui/sandbox
+
+Caveats
+-------
+
+If running from adventure mode, the map will show fort-mode "dig" markers on
+tiles that were within the code of vision of your adventurers. This is visually
+distracting, but it is not an error and can be ignored.

--- a/modtools/create-item.lua
+++ b/modtools/create-item.lua
@@ -287,17 +287,21 @@ local function createItem(mat, itemType, quality, creator, description, amount)
     return items
 end
 
-local function get_first_citizen()
+local function get_default_unit()
     local citizens = dfhack.units.getCitizens(true)
-    if not citizens or not citizens[1] then
-        qerror('Could not choose a creator unit. Please select one in the UI')
+    if citizens and citizens[1] then
+        return citizens[1]
     end
-    return citizens[1]
+    local adventurer = dfhack.world.getAdventurer()
+    if adventurer then
+        return adventurer
+    end
+    qerror('Could not choose a creator unit. Please select one in the UI')
 end
 
 -- returns the list of created items, or nil on error
 function hackWish(accessors, opts)
-    local unit = accessors.get_unit(opts) or get_first_citizen()
+    local unit = accessors.get_unit(opts) or get_default_unit()
     local qualityok, quality = false, df.item_quality.Ordinary
     local itemok, itemtype, itemsubtype = accessors.get_item_type()
     if not itemok then return end


### PR DESCRIPTION
- `gui/sandbox` needed updates to how it initialized/restored the mode from adventure mode
- `gui/create-item` needed help finding the adventurer when there was no unit selected