### PR TITLE
extinguish.lua: plant_flags.is_burning no longer used

### DIFF
--- a/extinguish.lua
+++ b/extinguish.lua
@@ -111,9 +111,9 @@ function extinguishAll()
     extinguishTile(pos2xyz(campfires[i].pos))
     campfires:erase(i)
   end
-  for _,plant in ipairs(df.global.world.plants.all) do
-    plant.damage_flags.is_burning = false
-  end
+  --[[for _,plant in ipairs(df.global.world.plants.all) do
+    plant.damage_flags.unused_01 = false -- is_burning no longer used
+  end]]
   for _,item in ipairs(df.global.world.items.other.IN_PLAY) do
     extinguishItem(item)
   end


### PR DESCRIPTION
`plant_flags.is_burning` isn't used by DF anymore, renamed `plant_flags.unused_01`. Commented out the code.

Not sure if existing code is sufficient, or something else needs to be done.

DFHack/df-structures/pull/753