### PR TITLE
[quickfort] fix stockpile label merge logic

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -37,6 +37,7 @@ Template for new versions:
 - `item`: don't match uncollected spider webs when you search for "silk"
 - `assign-profile`: fix handling of unit option for setting target unit id
 - `gui/gm-unit`: correctly display skill levels above Legendary+5
+- `quickfort`: fix merge logic for disjoint stockpiles that are given the same label
 
 ## Misc Improvements
 - `gui/unit-info-viewer`: now displays a unit's weight, relative to either dwarves, elephants or cats

--- a/internal/quickfort/place.lua
+++ b/internal/quickfort/place.lua
@@ -169,6 +169,7 @@ local function custom_stockpile(_, keys)
     if not db_entry then return nil end
     if token_and_label.label then
         db_entry.label = ('%s/%s'):format(db_entry.label, token_and_label.label)
+        db_entry.global_label = db_entry.label
     end
     if next(adjustments) then
         db_entry.adjustments[adjustments] = true


### PR DESCRIPTION
implemented for zones and forgot to implement for stockpiles.