### PR TITLE
[quickfort] implement blueprint deletion

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -49,6 +49,8 @@ Template for new versions:
 - `gui/unit-info-viewer`: shows a unit's relative size to its race's average.
 - `caravan`: optional overlay to hide vanilla bring trade goods to depot button (if you prefer to always use the DFHack version and don't want to accidentally click on the vanilla button). enable ``caravan.movegoods_hider`` in `gui/control-panel` UI Overlays tab to use.
 - `gui/design`: significant redesign of UI for much improved usability
+- `gui/quickfort`: delete blueprints from the blueprint load dialog
+- `quickfort`: new ``delete`` command for deleting player-owned blueprints (library and mod-added blueprints cannot be deleted)
 
 ## Removed
 - `max-wave`: merged into `pop-control`

--- a/docs/quickfort.rst
+++ b/docs/quickfort.rst
@@ -39,6 +39,11 @@ Usage
     (e.g. ``-m build``) and/or strings to search for in a path, filename, mode,
     or comment. The id numbers in the reported list may not be contiguous if
     there are hidden or filtered blueprints that are not being shown.
+``quickfort delete <filename> [<filename> ...]``
+    Delete the specified blueprint file(s). Only player-owned blueprints (stored
+    in the ``dfhack-config/blueprints`` directory) can be deleted. Blueprints
+    provided by mods or the standard DFHack library cannot be deleted by this
+    command.
 ``quickfort gui [<filename or search terms>]``
     Invokes the quickfort UI with the specified parameters, giving you an
     interactive blueprint preview to work with before you apply it to the map.

--- a/quickfort.lua
+++ b/quickfort.lua
@@ -83,6 +83,7 @@ local action_switch = {
     set=quickfort_set.do_set,
     reset=do_reset,
     list=quickfort_list.do_list,
+    delete=quickfort_list.do_delete,
     gui=do_gui,
     run=quickfort_command.do_command,
     orders=quickfort_command.do_command,


### PR DESCRIPTION
from both gui and commandline
rewrite blueprint load dialog to use ZScreenModal instead of FramedScreen

depends on https://github.com/DFHack/dfhack/pull/4671 for the deletion confirmation dialog

Fixes: https://github.com/DFHack/dfhack/issues/4480