### PR TITLE
control-panel repeats persistence

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -49,6 +49,7 @@ Template for new versions:
 - `makeown`: set target animals to tame and domesticated
 - `gui/sandbox`: created citizens can now be useful military squad members
 - `gui/sandbox`: created undead now have a purple shade (after save and reload)
+- `control-panel`: restore non-default values of per-save enabled/disabled settings for repeat-based commands
 
 ## Misc Improvements
 - `gui/unit-info-viewer`: now displays a unit's weight, relative to either dwarves, elephants or cats

--- a/control-panel.lua
+++ b/control-panel.lua
@@ -39,10 +39,11 @@ local function apply_fort_loaded_config()
         apply_autostart_config()
         dfhack.persistent.saveSiteData(GLOBAL_KEY, {autostart_done=true})
     end
+    local enabled_map = common.get_enabled_map()
     local enabled_repeats = dfhack.persistent.getSiteData(common.REPEATS_GLOBAL_KEY, {})
     for _, data in ipairs(registry.COMMANDS_BY_IDX) do
         if data.mode == 'repeat' then
-            common.apply_command(data)
+            common.apply_command(data, enabled_map, not not enabled_repeats[data.command])
         end
     end
 end

--- a/control-panel.lua
+++ b/control-panel.lua
@@ -41,7 +41,7 @@ local function apply_fort_loaded_config()
     end
     local enabled_repeats = dfhack.persistent.getSiteData(common.REPEATS_GLOBAL_KEY, {})
     for _, data in ipairs(registry.COMMANDS_BY_IDX) do
-        if data.mode == 'repeat' and enabled_repeats[data.command] ~= false then
+        if data.mode == 'repeat' then
             common.apply_command(data)
         end
     end

--- a/control-panel.lua
+++ b/control-panel.lua
@@ -43,7 +43,7 @@ local function apply_fort_loaded_config()
     local enabled_repeats = dfhack.persistent.getSiteData(common.REPEATS_GLOBAL_KEY, {})
     for _, data in ipairs(registry.COMMANDS_BY_IDX) do
         if data.mode == 'repeat' then
-            common.apply_command(data, enabled_map, not not enabled_repeats[data.command])
+            common.apply_command(data, enabled_map, enabled_repeats[data.command])
         end
     end
 end

--- a/internal/control-panel/common.lua
+++ b/internal/control-panel/common.lua
@@ -53,6 +53,10 @@ end
 
 config = config or get_config()
 
+local function munge_repeat_name(name)
+    return 'control-panel/' .. name
+end
+
 local function unmunge_repeat_name(munged_name)
     if munged_name:startswith('control-panel/') then
         return munged_name:sub(15)
@@ -114,7 +118,7 @@ local function persist_repeats()
     local cp_repeats = {}
     for _, data in ipairs(registry.COMMANDS_BY_IDX) do
         if data.mode == 'repeat' then
-            if repeatUtil.repeating['control-panel/' .. data.command] then
+            if repeatUtil.repeating[munge_repeat_name(data.command)] then
                 cp_repeats[data.command] = true
             else
                 cp_repeats[data.command] = false
@@ -150,7 +154,7 @@ function apply_command(data, enabled_map, enabled)
             dfhack.run_command{enabled and 'enable' or 'disable', data.command}
         end
     elseif data.mode == 'repeat' then
-        local munged_name = 'control-panel/' .. data.command
+        local munged_name = munge_repeat_name(data.command)
         if enabled then
             local command_str = ('repeat --name %s %s\n'):
                     format(munged_name, table.concat(data.params, ' '))

--- a/internal/control-panel/common.lua
+++ b/internal/control-panel/common.lua
@@ -110,12 +110,15 @@ function get_description(data)
     return helpdb.is_entry(first_word) and helpdb.get_entry_short_help(first_word) or ''
 end
 
-local function persist_enabled_repeats()
+local function persist_repeats()
     local cp_repeats = {}
-    for munged_name in pairs(repeatUtil.repeating) do
-        local name = unmunge_repeat_name(munged_name)
-        if name then
-            cp_repeats[name] = true
+    for _, data in ipairs(registry.COMMANDS_BY_IDX) do
+        if data.mode == 'repeat' then
+            if repeatUtil.repeating['control-panel/' .. data.command] then
+                cp_repeats[data.command] = true
+            else
+                cp_repeats[data.command] = false
+            end
         end
     end
     dfhack.persistent.saveSiteData(REPEATS_GLOBAL_KEY, cp_repeats)
@@ -155,7 +158,7 @@ function apply_command(data, enabled_map, enabled)
         else
             repeatUtil.cancel(munged_name)
         end
-        persist_enabled_repeats()
+        persist_repeats()
     elseif data.mode == 'run' then
         if enabled then
             dfhack.run_command(data.command)


### PR DESCRIPTION
DF v50.13
DFHack 50.13-r2.1

---

# Scenario

In one of my games, I used the DFHack GUI control-panel to enable the `automilk` and `autoshear` repeating commands. Later, after having saved and resumed, I noticed that milk was not being gathered. Checking the control-panel showed both those repeats disabled. I am new to DF and DFHack (and Lua), so I don't know if this was the expected behavior, but I thought I would investigate.

I do not have anything set to "autostart" (which is for new embarks?). It looks like it also acts as a kind of override to the default-enabled definition when the "default" is requested (nil/missing "enabled" parameter in apply_command calls). An autostart configuration changes the behavior with respect to default-disabled commands: if the user enabled a default-disabled command and configured it for autostart, then it would be enabled after loading, but only due to the autostart configuration—even though that is not an "autostart" situation, as I understand it.

---

Poking through the save data revealed references to some of the repeat commands in one of the files. Making a new save right after enabling `automilk` and `autoshear` showed them in the save data. But they were always disabled when I loaded that save. Later experimentation showed that `fix/dead-units` (an example default-enabled repeat) was affected in the opposite way: it was always enabled after loading even if it was disabled when the save was made.

---

It looks like the intention is to save and restore the enabled/disabled status of these repeat commands, so I started making changes to get that working for me. Each commit is a fairly small change to keep them more focused and hopefully easier to review and discuss. If any/all of them should be squashed instead, I can reroll them that way.

In the following descriptions, a "future" repeat command is one that was not known by the DFHack that made a save, but is known by the DFHack that is loading the save.

# Minimal Change (no persistence changes)

The first two commits (through 5e7fe9310b199c2953f99d51a22d9af26297dc26) accomplish the saving and loading. The code will now treat any repeat command that is not present in the save data as if it were disabled. This means future default-enabled repeat commands would be initially disabled. The user could still enable these future commands and that setting would be subsequently loaded as enabled.

# Larger Change (persistence change)

The rest of the commits make it so that future repeat commands will use the default mechanism (autostart configuration and default definition) when loading a save that does not mention them. The persisted data is changed to include both enabled and disabled repeats (true and false values).

## Possible Extension (prevent some spurious defaulting)

There is a small(?) drawback to the final implementation: since "old" saves did not record disabled repeats, they will be treated as "new/future" repeats and will get their default (or autostart) settings (i.e. a default-enabled repeat that was disabled by the user in an "old" save will be loaded as enabled, but any subsequent changes will be properly handled across new saves and loads). This could be partially worked around by adding another bit of persisted data that indicates how the missing repeat commands should be treated (missing means disabled if flag is not set, otherwise missing means new and use its default). It would only be a partial workaround because loading from an *old* save (prior to the new persistence changes) would still initially disable any "future" default-enabled repeat commands instead of defaulting them to enabled.

This drawback might be acceptable since it is a subset of how the code already handles things (a disabled default-enabled repeat command is loaded as enabled).

---

# Testing 

I tested these changes by extracting a patch against *master* and applying it to the base DFHack 50.13-r2.1 `hack/scripts`. I tried replacing `scripts` as a whole, but there are other changes on *master* that expect new surrounding bits (e.g. the mortal/armok change).

Is there a recommened way to test unreleased DFHack? Use recent CI build and replace some bits?