### PR TITLE
[gui/quickfort] don't call partial obstructions errors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -64,6 +64,7 @@ Template for new versions:
 - `gui/unit-info-viewer`: add precise unit size in cc (cubic centimeters) for comparison against the wiki values. you can set your preferred number format for large numbers like this in the preferences of `control-panel` or `gui/control-panel`
 - `gui/quickfort`: delete blueprints from the blueprint load dialog
 - `quickfort`: new ``delete`` command for deleting player-owned blueprints (library and mod-added blueprints cannot be deleted)
+- `gui/quickfort`: allow farm plots, dirt roads, and paved roads to be designated around partial obstructions without callling it an error, matching vanilla behavior
 - `gui/launcher`: refresh default tag filter when mortal mode is toggled in `gui/control-panel` so changes to which tools autocomplete take effect immediately
 - `gui/civ-alert`: you can now register multiple burrows as civilian alert safe spaces
 - `lever`: enable use of ``reqscript`` to access lever pulling functions.

--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -829,6 +829,7 @@ local building_db_raw = {
        no_extents_if_solid=true,
        is_valid_tile_fn=is_valid_tile_dirt,
        is_valid_extent_fn=is_extent_nonempty,
+       ignore_extent_errors=true,
        props_fn=do_farm_props},
     o={label='Paved Road',
        type=df.building_type.RoadPaved, has_extents=true,

--- a/internal/quickfort/building.lua
+++ b/internal/quickfort/building.lua
@@ -528,9 +528,11 @@ function check_tiles_and_extents(ctx, buildings)
                 local pos =
                         xyz2pos(b.pos.x+extent_x-1, b.pos.y+extent_y-1, b.pos.z)
                 local is_valid_tile = db_entry.is_valid_tile_fn(pos,db_entry,b)
+                -- don't mark individual invalid tiles in extent-based buildings
+                -- as invalid; the building can still build around it
                 owns_preview =
                         quickfort_preview.set_preview_tile(ctx, pos,
-                                                           is_valid_tile)
+                            is_valid_tile or db_entry.has_extents)
                 if not is_valid_tile then
                     log('tile not usable: (%d, %d, %d)', pos.x, pos.y, pos.z)
                     col[extent_y] = false
@@ -542,7 +544,7 @@ function check_tiles_and_extents(ctx, buildings)
         if not db_entry.is_valid_extent_fn(b) then
             log('no room for %s at (%d, %d, %d)',
                 db_entry.label, b.pos.x, b.pos.y, b.pos.z)
-            if owns_preview then
+            if owns_preview and not db_entry.ignore_extent_errors then
                 for x=b.pos.x,b.pos.x+b.width-1 do
                     for y=b.pos.y,b.pos.y+b.height-1 do
                         local p = xyz2pos(x, y, b.pos.z)


### PR DESCRIPTION
and don't call farm plot obstructions errors even if it's the entire plot. it's common to lay down grids of farm plots, and it's ok if some don't make it due to stony ground