### PR TITLE
[prioritize] add ButcherAnimal to default prioritization list

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -76,6 +76,7 @@ Template for new versions:
 - `gui/notify`: notification panel extended to apply to adventure mode
 - `gui/control-panel`: highlight prefrences that have been changed from the defaults
 - `gui/quickfort`: buildings can now be constructed in a "high priority" state, giving them first dibs on `buildingplan` materials and setting their construction jobs to the highest priority
+- `prioritize`: add ``ButcherAnimal`` to the default prioritization list (``SlaughterAnimal`` was already there, but ``ButcherAnimal`` -- which is different -- was missing)
 
 ## Removed
 - `max-wave`: merged into `pop-control`

--- a/prioritize.lua
+++ b/prioritize.lua
@@ -24,7 +24,7 @@ local DEFAULT_JOB_TYPES = {
     'SeekInfant', 'SetBone', 'Surgery', 'Suture',
     -- ensure prisoners and animals are tended to quickly
     -- (Animal/prisoner storage already covered by 'StoreItemInStockpile' above)
-    'SlaughterAnimal', 'PenLargeAnimal', 'ChainAnimal', 'LoadCageTrap',
+    'SlaughterAnimal', 'ButcherAnimal', 'PenLargeAnimal', 'ChainAnimal', 'LoadCageTrap',
     -- ensure noble tasks never get starved
     'InterrogateSubject', 'ManageWorkOrders', 'ReportCrime', 'TradeAtDepot',
     -- get tasks done quickly that might block the player from getting on to


### PR DESCRIPTION
We had slaughter, but not butcher.

probably because hunting is rarely used and so it didn't come up in testing.