### PR TITLE
[timestream] simplify code by ensuring we hit every season tick

### DIFF
--- a/docs/timestream.rst
+++ b/docs/timestream.rst
@@ -50,8 +50,8 @@ Examples
 
 ``timestream set calendar-rate 0.5``
     Make the days twice as long and allow dwarves to accomplish twice as much
-    per day (as long as the target FPS is sufficiently above the FPS the game
-    is actually running at).
+    per day (requires that your target FPS is set at least 2x higher than the
+    FPS the game is actually running at).
 
 ``timestream reset``
     Reset settings to defaults: the vanilla FPS cap with no calendar speed
@@ -75,14 +75,6 @@ Settings
     configured target ``fps`` setting for the ``calendar-rate`` setting to take
     effect.
 
-:max-frame-skip: Set the maximum number of ticks that can be skipped in one
-    step. Dwarves can perform at most one action per step, and if too many
-    frames are skipped in one step, dwarves will "lose time" compared to the
-    movement of the calendar. The default is 4, which allows a target FPS of up
-    to 4x your actual FPS while still allowing dwarves to walk at full speed.
-    Raise this value if speed of the simulation is more important to you than
-    its accuracy and smoothness.
-
 Technical details
 -----------------
 
@@ -102,9 +94,9 @@ it all in fewer "steps".
 
 That's essentially what ``timestream`` is doing to the game. All "actions" in
 DF have counters associated with them. For example, when a dwarf wants to walk
-to the next tile, a counter is initialized to 500. Every "tick" of the game
-(the "frame" in FPS) decrements that counter by by a certain amount. When the
-counter gets to zero, the dwarf appears on the next tile.
+to the next tile, a counter is initialized to 8. Every "tick" of the game (the
+"frame" in FPS) decrements that counter by 1. When the counter gets to zero,
+the dwarf appears on the next tile.
 
 When ``timestream`` is active, it monitors all those counters and makes them
 decrement more per tick. It then balances things out by proportionally
@@ -112,16 +104,11 @@ advancing the in-game calendar. Therefore, more "happens" per step, and DF has
 to simulate fewer "steps" for the same amount of work to get done.
 
 The cost of this simplification is that the world becomes less "smooth". As the
-discrepancy between the "natural" and simulated FPS grows, more and more
-dwarves will move to their next tiles at *exactly* the same time. Moreover, the
-rate of action completion per unit is effectively capped at the granularity of
-the simulation, so very fast units will lose some of their advantage. In the
-extreme case, with the computer struggling to run at 1 FPS and ``timestream``
-simulating thousands of FPS (and the ``max-frame-skip`` cap increased to 20),
-all units will perform exactly one action per frame. This would make the game
-look robotic. With default settings, it will never get this bad, but you can
-always choose to alter the ``timestream`` configuration to your preferred
-balance of speed vs. accuracy.
+discrepancy between the actual and simulated FPS grows, more and more dwarves
+will move to their next tiles at *exactly* the same time. Moreover, the rate of
+action completion per unit is effectively capped at the granularity of the
+simulation, so very fast units (say, those in a martial trance) will lose some
+of their advantage.
 
 Limitations
 -----------
@@ -130,8 +117,8 @@ Right now, not all aspects of the game are perfectly adjusted. For example,
 armies on world map will move at the same (real-time) rate regardless of
 changes that ``timestream`` is making to the calendar.
 
-Here is a (likely incomplete) list of game elements that are not affected by
-``timestream``:
+Here is a (likely incomplete) list of game elements that are not adjusted by
+``timestream`` and will appear "slow" in-game:
 
 - Army movement across the world map (including raids sent out from the fort)
 - Liquid movement and evaporation

--- a/docs/timestream.rst
+++ b/docs/timestream.rst
@@ -113,11 +113,17 @@ of their advantage.
 Limitations
 -----------
 
-Right now, not all aspects of the game are perfectly adjusted. For example,
+DF does critial game tasks every 10 ticks that must not be skipped, so
+`timestream` cannot advance more than 9 ticks at a time. This means that, with
+the default target of 100 FPS, the game will start showing signs of slowdown if
+the real FPS drops below about 15. The interface will also become less
+responsive to mouse gestures as the real FPS drops.
+
+Finally, not all aspects of the game are perfectly adjusted. For example,
 armies on world map will move at the same (real-time) rate regardless of
 changes that ``timestream`` is making to the calendar.
 
-Here is a (likely incomplete) list of game elements that are not adjusted by
+Here is a (possibly incomplete) list of game elements that are not adjusted by
 ``timestream`` and will appear "slow" in-game:
 
 - Army movement across the world map (including raids sent out from the fort)

--- a/timestream.lua
+++ b/timestream.lua
@@ -143,11 +143,19 @@ local function on_tick()
     local timeskip = math.floor(clamp_timeskip(desired_timeskip))
 
     -- add some jitter so we don't fall into a constant pattern
-    -- to reduce the risk of repeatedly missing an unknown threshold
-    timeskip = math.random(timeskip - 1, timeskip)
+    -- this reduces the risk of repeatedly missing an unknown threshold
+    -- also keeps the game from looking robotic at lower frame rates
+    local jitter_category = math.random(1, 10)
+    if jitter_category <= 1 then
+        timeskip = math.random(0, timeskip)
+    elseif jitter_category <= 3 then
+        timeskip = math.random(math.max(0, timeskip-2), timeskip)
+    elseif jitter_category <= 5 then
+        timeskip = math.random(math.max(0, timeskip-4), timeskip)
+    end
 
-    -- no need to let our deficit grow beyond the maximum single-step jump
-    timeskip_deficit = math.min(desired_timeskip - timeskip, 9.0)
+    -- no need to let our deficit grow unbounded
+    timeskip_deficit = math.min(desired_timeskip - timeskip, 100.0)
 
     if timeskip <= 0 then return end
 

--- a/timestream.lua
+++ b/timestream.lua
@@ -30,12 +30,6 @@ local SETTINGS = {
         end,
         default=1.0,
     },
-    {
-        name='max-frame-skip',
-        internal_name='max_frame_skip',
-        validate=function(arg) return argparse.positiveInt(arg, 'max-frame-skip') end,
-        default=4,
-    },
 }
 
 local function get_default_state()
@@ -62,44 +56,26 @@ end
 ------------------------------------
 -- business logic
 
-local TICKS_PER_DAY = 1200
-local TICKS_PER_WEEK = 7 * TICKS_PER_DAY
-
--- determined from reverse engineering; don't skip these tick thresholds
--- something important happens when tick % <mod> == <rem>
--- please keep remainder list elements in **descending** order
-local SEASON_TICK_TRIGGERS = {
-    {mod=TICKS_PER_DAY//10, rem={0x6e, 0x50, 0x46, 0x3c, 0x32, 0x28, 0x14, 10, 0}},
-    {mod=TICKS_PER_WEEK//10, rem={0x32, 0x1e}},
-}
-local YEAR_TICK_TRIGGERS = {
-    {mod=100, rem={0}}, -- crop growth
+-- ensure we never skip over cur_year_tick values that match this list
+local TICK_TRIGGERS = {
+    {mod=10, rem={0}}, -- season ticks and (mod=100) crop growth
 }
 
--- additional ticks we would like to skip at the next opportunity
+-- "owed" ticks we would like to skip at the next opportunity
 local timeskip_deficit, calendar_timeskip_deficit = 0.0, 0.0
 
 local function get_desired_timeskip(real_fps, desired_fps)
+    -- minus 1 to account for the current frame
     return (desired_fps / real_fps) - 1
 end
 
-local function get_next_timed_event_season_tick()
-    local next_event_tick = math.huge
-    for _, event in ipairs(df.global.timed_events) do
-        if event.season == df.global.cur_season then
-            next_event_tick = math.min(next_event_tick, event.season_ticks)
-        end
-    end
-    return next_event_tick
-end
-
-local function get_next_trigger_tick(triggers, next_tick, is_tick_boundary)
+local function get_next_trigger_year_tick(next_tick)
     local next_trigger_tick = math.huge
-    for _, trigger in ipairs(triggers) do
+    for _, trigger in ipairs(TICK_TRIGGERS) do
         local cur_rem = next_tick % trigger.mod
         for _, rem in ipairs(trigger.rem) do
-            if cur_rem < rem or (cur_rem == rem and is_tick_boundary) then
-                    next_trigger_tick = math.min(next_trigger_tick, next_tick + (rem - cur_rem))
+            if cur_rem <= rem then
+                next_trigger_tick = math.min(next_trigger_tick, next_tick + (rem - cur_rem))
                 goto continue
             end
         end
@@ -109,22 +85,10 @@ local function get_next_trigger_tick(triggers, next_tick, is_tick_boundary)
     return next_trigger_tick
 end
 
-local function get_next_trigger_year_tick()
-    return get_next_trigger_tick(YEAR_TICK_TRIGGERS, df.global.cur_year_tick + 1, true)
-end
-
-local function get_next_trigger_season_tick()
-    local is_season_tick = (df.global.cur_year_tick+1) % 10 == 0
-    local next_season_tick = df.global.cur_season_tick + (is_season_tick and 1 or 0)
-    return get_next_trigger_tick(SEASON_TICK_TRIGGERS, next_season_tick, is_season_tick)
-end
-
 local function clamp_timeskip(timeskip)
     if timeskip <= 0 then return 0 end
-    local next_important_season_tick = math.min(get_next_timed_event_season_tick(), get_next_trigger_season_tick())
-    return math.min(timeskip,
-        get_next_trigger_year_tick()-df.global.cur_year_tick-1,
-        df.global.cur_year_tick - (df.global.cur_year_tick % 10 + 1) + (next_important_season_tick - df.global.cur_season_tick)*10)
+    local next_tick = df.global.cur_year_tick + 1
+    return math.min(timeskip, get_next_trigger_year_tick(next_tick)-next_tick)
 end
 
 local function has_caste_flag(unit, flag)
@@ -168,35 +132,6 @@ local function adjust_armies(timeskip)
     -- TODO
 end
 
-local function adjust_caravans(season_timeskip)
-    for i, caravan in ipairs(df.global.plotinfo.caravans) do
-        if caravan.trade_state == df.caravan_state.T_trade_state.Approaching or
-            caravan.trade_state == df.caravan_state.T_trade_state.AtDepot
-        then
-            local was_before_message_threshold = caravan.time_remaining >= 501
-            caravan.time_remaining = caravan.time_remaining - season_timeskip
-            if was_before_message_threshold and caravan.time_remaining <= 500 then
-                caravan.time_remaining = 501
-                need_season_tick = true
-            end
-        end
-        if caravan.time_remaining <= 0 then
-            caravan.time_remaining = 0
-            dfhack.run_script('caravan', 'leave', tostring(i))
-        end
-    end
-end
-
-local noble_cooldowns = {'manager_cooldown', 'bookkeeper_cooldown'}
-local function adjust_nobles(season_timeskip)
-    for _, field in ipairs(noble_cooldowns) do
-        df.global.plotinfo.nobles[field] = df.global.plotinfo.nobles[field] - season_timeskip
-        if df.global.plotinfo.nobles[field] < 0 then
-            df.global.plotinfo.nobles[field] = 0
-        end
-    end
-end
-
 local function on_tick()
     local real_fps = math.max(1, df.global.enabler.calculated_fps)
     if real_fps >= state.settings.fps then
@@ -205,34 +140,25 @@ local function on_tick()
     end
 
     local desired_timeskip = get_desired_timeskip(real_fps, state.settings.fps) + timeskip_deficit
-    local timeskip = math.min(math.floor(clamp_timeskip(desired_timeskip)), state.settings.max_frame_skip)
-    timeskip_deficit = math.min(desired_timeskip - timeskip, state.settings.max_frame_skip)
+    local timeskip = math.floor(clamp_timeskip(desired_timeskip))
+
+    -- add some jitter so we don't fall into a constant pattern
+    -- to reduce the risk of repeatedly missing an unknown threshold
+    timeskip = math.random(timeskip - 1, timeskip)
+
+    -- no need to let our deficit grow beyond the maximum single-step jump
+    timeskip_deficit = math.min(desired_timeskip - timeskip, 9.0)
+
     if timeskip <= 0 then return end
 
     local desired_calendar_timeskip = (timeskip * state.settings.calendar_rate) + calendar_timeskip_deficit
     local calendar_timeskip = math.max(1, math.floor(desired_calendar_timeskip))
-    if need_season_tick then
-        local old_ones = df.global.cur_year_tick % 10
-        local new_ones = (df.global.cur_year_tick + calendar_timeskip) % 10
-        if new_ones == 9 then
-            need_season_tick = false
-        elseif old_ones + calendar_timeskip >= 10 then
-            calendar_timeskip = 9 - old_ones
-            need_season_tick = false
-        end
-    end
     calendar_timeskip_deficit = math.max(0, desired_calendar_timeskip - calendar_timeskip)
 
-    local new_cur_year_tick = df.global.cur_year_tick + calendar_timeskip
-    local season_timeskip = new_cur_year_tick//10 - df.global.cur_year_tick//10
-
-    df.global.cur_season_tick = df.global.cur_season_tick + season_timeskip
-    df.global.cur_year_tick = new_cur_year_tick
+    df.global.cur_year_tick = df.global.cur_year_tick + calendar_timeskip
 
     adjust_units(timeskip)
     adjust_armies(timeskip)
-    adjust_caravans(season_timeskip)
-    adjust_nobles(season_timeskip)
 end
 
 ------------------------------------
@@ -240,7 +166,6 @@ end
 
 local function do_enable()
     timeskip_deficit, calendar_timeskip_deficit = 0.0, 0.0
-    need_season_tick = false
     state.enabled = true
     repeatutil.scheduleEvery(GLOBAL_KEY, 1, 'ticks', on_tick)
 end


### PR DESCRIPTION
this allows us to remove special processing for noble counters, caravans, and all the individual season ticks that we were previously watching out for