### PR TITLE
[warn-stranded] ignore riders, only warn for ridees

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -61,6 +61,7 @@ Template for new versions:
 - `gui/create-item`: allow creation of adamantine thread, wool, and yarn
 - `gui/notify`: the notification panel no longer responds to the Enter key so Enter key is passed through to the vanilla UI
 - `clear-smoke`: properly tag smoke flows for garbage collection to avoid memory leak
+- `warn-stranded`: don't warn for babies carried by mothers who happen to be gathering fruit from trees
 
 ## Misc Improvements
 - `item`: option for ignoring uncollected spider webs when you search for "silk"

--- a/warn-stranded.lua
+++ b/warn-stranded.lua
@@ -63,6 +63,7 @@ function getStrandedGroups()
     local unitsByWalkGroup, ignoredUnitsByWalkGroup = {}, {}
 
     for _, unit in ipairs(dfhack.units.getCitizens(true)) do
+        if unit.relationship_ids.RiderMount ~= -1 then goto skip end
         local unitPos = xyz2pos(dfhack.units.getPosition(unit))
         local walkGroup = getWalkGroup(unitPos)
 


### PR DESCRIPTION
e.g. mothers carrying babies while they gather fruit from trees or mothers carrying babies while mining in inaccessible areas