### PR TITLE
gui/unit-syndromes.lua: isDanger already implies isGreatDanger

### DIFF
--- a/gui/unit-syndromes.lua
+++ b/gui/unit-syndromes.lua
@@ -334,7 +334,7 @@ local function getHostiles()
     local units = {}
 
     for _, unit in pairs(df.global.world.units.active) do
-        if dfhack.units.isDanger(unit) or dfhack.units.isGreatDanger(unit) then
+        if dfhack.units.isDanger(unit) then
             table.insert(units, unit)
         end
     end


### PR DESCRIPTION
`isGreatDanger` check is redundant since `isDanger` already checks it.