### PR TITLE
Efficiency increase for ban-cooking and change to 'seeds' option

### DIFF
--- a/ban-cooking.lua
+++ b/ban-cooking.lua
@@ -137,17 +137,20 @@ funcs.seeds = function()
         if p.material_defs.type.seed == -1 or p.material_defs.idx.seed == -1 or p.flags.TREE then goto continue end
         ban_cooking(p.name .. ' seeds', p.material_defs.type.seed, p.material_defs.idx.seed, df.item_type.SEEDS, -1)
         for _, m in ipairs(p.material) do
-            if m.id == "STRUCTURAL" and m.flags.EDIBLE_COOKED then
-                local has_drink = false
-                local has_seed = false
-                for _, s in ipairs(m.reaction_product.id) do
-                    has_seed = has_seed or s.value == "SEED_MAT"
-                    has_drink = has_drink or s.value == "DRINK_MAT"
+            if m.id == "STRUCTURAL" then
+                if m.flags.EDIBLE_COOKED then
+                    local has_drink = false
+                    local has_seed = false
+                    for _, s in ipairs(m.reaction_product.id) do
+                        has_seed = has_seed or s.value == "SEED_MAT"
+                        has_drink = has_drink or s.value == "DRINK_MAT"
+                    end
+                    if has_seed and has_drink then
+                        local matinfo = dfhack.matinfo.find(p.id, m.id)
+                        ban_cooking(p.name .. ' ' .. m.id, matinfo.type, matinfo.index, df.item_type.PLANT, -1)
+                    end
                 end
-                if has_seed and has_drink then
-                    local matinfo = dfhack.matinfo.find(p.id, m.id)
-                    ban_cooking(p.name .. ' ' .. m.id, matinfo.type, matinfo.index, df.item_type.PLANT, -1)
-                end
+                break
             end
         end
         for k, g in ipairs(p.growths) do
@@ -174,14 +177,18 @@ funcs.brew = function()
     for _, p in ipairs(df.global.world.raws.plants.all) do
         if p.material_defs.type.drink == -1 or p.material_defs.idx.drink == -1 then goto continue end
         for _, m in ipairs(p.material) do
-            if m.id == "STRUCTURAL" and m.flags.EDIBLE_COOKED then
-                for _, s in ipairs(m.reaction_product.id) do
-                    if s.value == "DRINK_MAT" then
-                        local matinfo = dfhack.matinfo.find(p.id, m.id)
-                        ban_cooking(p.name .. ' ' .. m.id, matinfo.type, matinfo.index, df.item_type.PLANT, -1)
-                        break
+            if m.id == "STRUCTURAL" then
+                if m.flags.EDIBLE_COOKED then
+                    for _, s in ipairs(m.reaction_product.id) do
+                        if s.value == "DRINK_MAT" then
+                            local matinfo = dfhack.matinfo.find(p.id, m.id)
+                            ban_cooking(p.name .. ' ' .. m.id, matinfo.type, matinfo.index, df.item_type.PLANT, -1)
+                            break
+                        end
                     end
                 end
+                -- Stop iterating materials since there is only one STRUCTURAL
+                break
             end
         end
         for k, g in ipairs(p.growths) do
@@ -205,9 +212,12 @@ funcs.mill = function()
     for _, p in ipairs(df.global.world.raws.plants.all) do
         if p.material_defs.idx.mill ~= -1 then
             for _, m in ipairs(p.material) do
-                if m.id == "STRUCTURAL" and m.flags.EDIBLE_COOKED then
-                    local matinfo = dfhack.matinfo.find(p.id, m.id)
-                    ban_cooking(p.name .. ' ' .. m.id, matinfo.type, matinfo.index, df.item_type.PLANT, -1)
+                if m.id == "STRUCTURAL" then
+                    if m.flags.EDIBLE_COOKED then
+                        local matinfo = dfhack.matinfo.find(p.id, m.id)
+                        ban_cooking(p.name .. ' ' .. m.id, matinfo.type, matinfo.index, df.item_type.PLANT, -1)
+                    end
+                    break
                 end
             end
         end
@@ -218,14 +228,17 @@ funcs.thread = function()
     for _, p in ipairs(df.global.world.raws.plants.all) do
         if p.material_defs.idx.thread == -1 then goto continue end
         for _, m in ipairs(p.material) do
-            if m.id == "STRUCTURAL" and m.flags.EDIBLE_COOKED then
-                for _, s in ipairs(m.reaction_product.id) do
-                    if s.value == "THREAD" then
-                        local matinfo = dfhack.matinfo.find(p.id, m.id)
-                        ban_cooking(p.name .. ' ' .. m.id, matinfo.type, matinfo.index, df.item_type.PLANT, -1)
-                        break
+            if m.id == "STRUCTURAL" then
+                if m.flags.EDIBLE_COOKED then
+                    for _, s in ipairs(m.reaction_product.id) do
+                        if s.value == "THREAD" then
+                            local matinfo = dfhack.matinfo.find(p.id, m.id)
+                            ban_cooking(p.name .. ' ' .. m.id, matinfo.type, matinfo.index, df.item_type.PLANT, -1)
+                            break
+                        end
                     end
                 end
+                break
             end
         end
         for k, g in ipairs(p.growths) do

--- a/ban-cooking.lua
+++ b/ban-cooking.lua
@@ -139,13 +139,11 @@ funcs.seeds = function()
         for _, m in ipairs(p.material) do
             if m.id == "STRUCTURAL" then
                 if m.flags.EDIBLE_COOKED then
-                    local has_drink = false
                     local has_seed = false
                     for _, s in ipairs(m.reaction_product.id) do
                         has_seed = has_seed or s.value == "SEED_MAT"
-                        has_drink = has_drink or s.value == "DRINK_MAT"
                     end
-                    if has_seed and has_drink then
+                    if has_seed then
                         local matinfo = dfhack.matinfo.find(p.id, m.id)
                         ban_cooking(p.name .. ' ' .. m.id, matinfo.type, matinfo.index, df.item_type.PLANT, -1)
                     end
@@ -157,13 +155,11 @@ funcs.seeds = function()
             local matinfo = dfhack.matinfo.decode(g)
             local m = matinfo.material
             if m.flags.EDIBLE_COOKED then
-                local has_drink = false
                 local has_seed = false
                 for _, s in ipairs(m.reaction_product.id) do
                     has_seed = has_seed or s.value == "SEED_MAT"
-                    has_drink = has_drink or s.value == "DRINK_MAT"
                 end
-                if has_seed and has_drink then
+                if has_seed then
                     ban_cooking(p.name .. ' ' .. m.id, matinfo.type, matinfo.index, df.item_type.PLANT_GROWTH, k)
                 end
             end

--- a/changelog.txt
+++ b/changelog.txt
@@ -93,7 +93,6 @@ Template for new versions:
 - `clear-smoke`: properly tag smoke flows for garbage collection to avoid memory leak
 - `warn-stranded`: don't warn for babies carried by mothers who happen to be gathering fruit from trees
 - `prioritize`: also boost priority of already-claimed jobs when boosting priority of a job type so those jobs are not interrupted
-- `ban-cooking`: stop iterating through plant materials when the searched-for material is found
 - `ban-cooking`: ban all seed producing items from being cooked when 'seeds' is chosen instead of just brewable seed producing items
 
 ## Misc Improvements

--- a/changelog.txt
+++ b/changelog.txt
@@ -93,6 +93,8 @@ Template for new versions:
 - `clear-smoke`: properly tag smoke flows for garbage collection to avoid memory leak
 - `warn-stranded`: don't warn for babies carried by mothers who happen to be gathering fruit from trees
 - `prioritize`: also boost priority of already-claimed jobs when boosting priority of a job type so those jobs are not interrupted
+- `ban-cooking`: stop iterating through plant materials when the searched-for material is found
+- `ban-cooking`: ban all seed producing items from being cooked when 'seeds' is chosen instead of just brewable seed producing items
 
 ## Misc Improvements
 - `item`: option for ignoring uncollected spider webs when you search for "silk"

--- a/docs/ban-cooking.rst
+++ b/docs/ban-cooking.rst
@@ -45,7 +45,7 @@ Valid types are:
 - ``milk``
 - ``mill`` (millable plants)
 - ``oil``
-- ``seeds`` (plantable seeds)
+- ``seeds`` (plantable seeds and items producing seeds)
 - ``tallow``
 - ``thread``
 


### PR DESCRIPTION
Increase the efficiency of ban-cooking by breaking the iteration of the material search when it finds the material ID being looked for (specifically 'STRUCTURAL' in this case).

The 'seeds' option now bans cooking for all seed producing plants and growths instead of just items that produce seeds and are brewable. The previous method could cause replantability to be lost for plants with cookable seed producing items, affecting milling in vanilla and other industries in mods. It may be a good idea to split this into two functions in the future, since the documentation only mentions that this function bans cooking seeds and not the items that produce them. This is also the only option that affects two significantly different groups of items, which is a bit inconsistent.