### PR TITLE
Fix gui/autodump dumping into walls, etc.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -38,7 +38,7 @@ Template for new versions:
 - `prioritize`: fix incorrect loading of persisted data on some OS types
 - `list-waves`: no longer gets confused by units that leave the map and then return (e.g. squads who go out on raids)
 - `fix/dead-units`: fix error when removing dead units from burrows and the unit with the greatest ID was dead
-- `gui/autodump`: fix dumping into invalid tiles, creating item projectiles that get destroyed
+- `gui/autodump`: prevent dumping into walls or invalid map area, set proper projectile flags to prevent items from being destroyed
 
 ## Misc Improvements
 - `build-now`: if `suspendmanager` is running, run an unsuspend cycle immediately before scanning for buildings to build

--- a/changelog.txt
+++ b/changelog.txt
@@ -38,6 +38,7 @@ Template for new versions:
 - `prioritize`: fix incorrect loading of persisted data on some OS types
 - `list-waves`: no longer gets confused by units that leave the map and then return (e.g. squads who go out on raids)
 - `fix/dead-units`: fix error when removing dead units from burrows and the unit with the greatest ID was dead
+- `gui/autodump`: fix dumping into invalid tiles, creating item projectiles that get destroyed
 
 ## Misc Improvements
 - `build-now`: if `suspendmanager` is running, run an unsuspend cycle immediately before scanning for buildings to build

--- a/changelog.txt
+++ b/changelog.txt
@@ -38,7 +38,8 @@ Template for new versions:
 - `prioritize`: fix incorrect loading of persisted data on some OS types
 - `list-waves`: no longer gets confused by units that leave the map and then return (e.g. squads who go out on raids)
 - `fix/dead-units`: fix error when removing dead units from burrows and the unit with the greatest ID was dead
-- `gui/autodump`: prevent dumping into walls or invalid map area, set proper projectile flags to prevent items from being destroyed
+- `gui/autodump`: prevent dumping into walls or invalid map area, as well as selecting in unallocated blocks
+- `gui/autodump`: set proper projectile flags to prevent items from being destroyed
 
 ## Misc Improvements
 - `build-now`: if `suspendmanager` is running, run an unsuspend cycle immediately before scanning for buildings to build

--- a/docs/gui/autodump.rst
+++ b/docs/gui/autodump.rst
@@ -11,7 +11,7 @@ you draw boxes around items on the map, it will act on the selected items
 instead. Double-click anywhere on the map to teleport the items there. Be wary
 (or excited) that if you teleport the items into an unsupported position
 (e.g., mid-air), then they will become projectiles and fall. Items may not be
-teleported into walls or fortifications.
+teleported into walls.
 
 There are options to include or exclude forbidden items, items that are
 currently tagged as being used by an active job, and items dropped by traders.

--- a/docs/gui/autodump.rst
+++ b/docs/gui/autodump.rst
@@ -11,7 +11,7 @@ you draw boxes around items on the map, it will act on the selected items
 instead. Double-click anywhere on the map to teleport the items there. Be wary
 (or excited) that if you teleport the items into an unsupported position
 (e.g., mid-air), then they will become projectiles and fall. Items may not be
-teleported into walls.
+teleported into walls or hidden tiles.
 
 There are options to include or exclude forbidden items, items that are
 currently tagged as being used by an active job, and items dropped by traders.

--- a/docs/gui/autodump.rst
+++ b/docs/gui/autodump.rst
@@ -9,8 +9,11 @@ This is a general point and click interface for teleporting or destroying
 items. By default, it will teleport items you have marked for dumping, but if
 you draw boxes around items on the map, it will act on the selected items
 instead. Double-click anywhere on the map to teleport the items there. Be wary
-(or excited) that if you teleport the items into an unsupported position (e.g.
-mid-air), then they will become projectiles and fall.
+(or excited) that if you teleport the items into an unsupported position
+(e.g., mid-air), then they will become projectiles and fall. Items may not be
+teleported into walls or fortifications. They may also not be teleported into
+projectile-blocking mid-air buildings (such as water wheels), as this can
+result in unintended item destruction.
 
 There are options to include or exclude forbidden items, items that are
 currently tagged as being used by an active job, and items dropped by traders.

--- a/docs/gui/autodump.rst
+++ b/docs/gui/autodump.rst
@@ -11,9 +11,7 @@ you draw boxes around items on the map, it will act on the selected items
 instead. Double-click anywhere on the map to teleport the items there. Be wary
 (or excited) that if you teleport the items into an unsupported position
 (e.g., mid-air), then they will become projectiles and fall. Items may not be
-teleported into walls or fortifications. They may also not be teleported into
-projectile-blocking mid-air buildings (such as water wheels), as this can
-result in unintended item destruction.
+teleported into walls or fortifications.
 
 There are options to include or exclude forbidden items, items that are
 currently tagged as being used by an active job, and items dropped by traders.

--- a/gui/autodump.lua
+++ b/gui/autodump.lua
@@ -229,7 +229,7 @@ function Autodump:select_box(bounds)
             for x=bounds.x1,bounds.x2 do
                 local block = dfhack.maps.getTileBlock(xyz2pos(x, y, z))
                 local block_str = tostring(block)
-                if not seen_blocks[block_str] then
+                if block and not seen_blocks[block_str] then
                     seen_blocks[block_str] = true
                     self:select_items_in_block(block, bounds)
                 end
@@ -309,7 +309,7 @@ end
 function Autodump:do_dump(pos)
     pos = pos or dfhack.gui.getMousePos()
     if not pos then --We check this before calling
-        dfhack.printerr('Autodump:do_dump called with bad pos!')
+        qerror('Autodump:do_dump called with bad pos!')
     end
 
     local tt = dfhack.maps.getTileType(pos)
@@ -319,11 +319,12 @@ function Autodump:do_dump(pos)
     end
 
     local on_ground
-    local shape_attrs = df.tiletype_shape.attrs[df.tiletype.attrs[tt].shape]
-    if shape_attrs.walkable then
-        on_ground = true --Floor, stair, or ramp
+    local shape = df.tiletype.attrs[tt].shape
+    local shape_attrs = df.tiletype_shape.attrs[shape]
+    if shape_attrs.walkable or shape == df.tiletype_shape.FORTIFICATION then
+        on_ground = true --Floor, stair, ramp, or fortification
     elseif shape_attrs.basic_shape == df.tiletype_shape_basic.Wall then
-        dfhack.printerr('Dump tile blocked! Can\'t dump inside walls or fortifications.')
+        dfhack.printerr('Dump tile blocked! Can\'t dump inside walls.') --Wall or brook bed
         return
     end
 

--- a/gui/autodump.lua
+++ b/gui/autodump.lua
@@ -308,10 +308,7 @@ end
 
 function Autodump:do_dump(pos)
     pos = pos or dfhack.gui.getMousePos()
-    if not pos then
-        dfhack.printerr('Please hover mouse cursor over a target tile to dump to!')
-        return
-    end
+    if not pos then return end --Shouldn't happen since button would be disabled
 
     local tt = dfhack.maps.getTileType(pos)
     if not (tt and dfhack.maps.isTileVisible(pos)) then

--- a/gui/autodump.lua
+++ b/gui/autodump.lua
@@ -339,14 +339,14 @@ function Autodump:do_dump(pos)
     end
 
     local tt = dfhack.maps.getTileType(pos)
-    if not tt or !dfhack.maps.isTileVisible(pos) then
+    if not (tt and dfhack.maps.isTileVisible(pos)) then
         dfhack.printerr('Dump tile not visible! Must be in a revealed area of map.')
         return
     end
 
     local on_ground, in_air = tile_props(pos, tt)
     if not (on_ground or in_air) then
-        dfhack.printerr('Dump tile blocked! Can\'t dump on walls, fortifications, or certain midair buildings.')
+        dfhack.printerr('Dump tile blocked! Can\'t dump on walls, fortifications, or certain mid-air buildings.')
         return
     end
 

--- a/gui/autodump.lua
+++ b/gui/autodump.lua
@@ -324,7 +324,7 @@ function Autodump:do_dump(pos)
     if shape_attrs.walkable then
         on_ground = true --Floor, stair, or ramp
     elseif shape_attrs.basic_shape == df.tiletype_shape_basic.Wall then
-        dfhack.printerr('Dump tile blocked! Can\'t dump on walls or fortifications.')
+        dfhack.printerr('Dump tile blocked! Can\'t dump inside walls or fortifications.')
         return
     end
 
@@ -346,12 +346,14 @@ function Autodump:do_dump(pos)
             end
             if not on_ground then
                 local proj = dfhack.items.makeProjectile(item)
-                proj.flags.no_impact_destroy = true
-                proj.flags.bouncing = true
-                proj.flags.piercing = true
-                proj.flags.parabolic = true
-                proj.flags.no_adv_pause = true
-                proj.flags.no_collide = true
+                if proj then
+                    proj.flags.no_impact_destroy = true
+                    proj.flags.bouncing = true
+                    proj.flags.piercing = true
+                    proj.flags.parabolic = true
+                    proj.flags.no_adv_pause = true
+                    proj.flags.no_collide = true
+                end
             end
         else
             print(('Could not move item: %s from (%d, %d, %d)'):format(

--- a/gui/autodump.lua
+++ b/gui/autodump.lua
@@ -308,7 +308,9 @@ end
 
 function Autodump:do_dump(pos)
     pos = pos or dfhack.gui.getMousePos()
-    if not pos then return end --Shouldn't happen since button would be disabled
+    if not pos then --We check this before calling
+        dfhack.printerr('Autodump:do_dump called with bad pos!')
+    end
 
     local tt = dfhack.maps.getTileType(pos)
     if not (tt and dfhack.maps.isTileVisible(pos)) then

--- a/gui/autodump.lua
+++ b/gui/autodump.lua
@@ -308,7 +308,7 @@ end
 
 local function tile_props(pos, tt) --Returns is_ground, is_open_air
     local shape_attrs = df.tiletype_shape.attrs[df.tiletype.attrs[tt].shape]
-    if shape_attrs.walkable then --TODO: don't dump on statues, etc.?
+    if shape_attrs.walkable then
         return true, false --Floor, stair, or ramp
     elseif shape_attrs.basic_shape == df.tiletype_shape_basic.Wall then
         return false, false --Wall or fortification
@@ -334,19 +334,19 @@ end
 function Autodump:do_dump(pos)
     pos = pos or dfhack.gui.getMousePos()
     if not pos then
-        print('No cursor')
+        dfhack.printerr('Please hover mouse cursor over a target tile to dump to!')
         return
     end
 
     local tt = dfhack.maps.getTileType(pos)
-    if not tt then
-        print('No map block')
+    if not tt or !dfhack.maps.isTileVisible(pos) then
+        dfhack.printerr('Dump tile not visible! Must be in a revealed area of map.')
         return
     end
 
     local on_ground, in_air = tile_props(pos, tt)
     if not (on_ground or in_air) then
-        print('Dump tile blocked')
+        dfhack.printerr('Dump tile blocked! Can\'t dump on walls, fortifications, or certain midair buildings.')
         return
     end
 

--- a/gui/autodump.lua
+++ b/gui/autodump.lua
@@ -323,12 +323,12 @@ local function tile_props(pos, tt) --Returns is_ground, is_open_air
     elseif occ.building == df.tile_building_occ.Floored then
         return true, false --Lowered bridge, forbidden hatch, etc.
     elseif occ.building == df.tile_building_occ.Dynamic then
-        local bld = dfhack.buildings.findAtTile(pos) --Unforbidden closed hatch, etc.
+        local bld = dfhack.buildings.findAtTile(pos) --Unforbidden hatch, etc.
         return (bld and (bld._type == df.building_hatchst or
             bld._type == df.building_grate_floorst or
             bld._type == df.building_bars_floorst)), false
     end
-    return false, false
+    return false, false --Don't trust it
 end
 
 function Autodump:do_dump(pos)


### PR DESCRIPTION
Prevent `gui/autodump` from attempting to dump into or select within unallocated tiles (e.g., below HFS), which causes a script error. Also prevent dumping into hidden tiles.

Prevent dumping into walls. Set proper projectile flags so falling items don't get destroyed on impact.