### PR TITLE
Add table of contents to Gui/journal

### DIFF
--- a/docs/gui/journal.rst
+++ b/docs/gui/journal.rst
@@ -47,7 +47,7 @@ Supported Features
   - replace selected text, if available
   - If no text is selected, paste text in the cursor position
 - Scrolling behaviour for long text build-in
-- Table of contests (:kbd:`Ctrl` + :kbd:`T`), with headers line prefixed by `#`, e.g. `# Fort history`, `## Year 1`
+- Table of contests (:kbd:`Ctrl` + :kbd:`O`), with headers line prefixed by `#`, e.g. `# Fort history`, `## Year 1`
 
 Usage
 -----

--- a/docs/gui/journal.rst
+++ b/docs/gui/journal.rst
@@ -20,7 +20,7 @@ Supported Features
 ------------------
 
 - Cursor Control: Navigate through text using arrow keys (left, right, up, down) for precise cursor placement.
-- Fast Rewind: Use :kbd:`Shift` + :kbd:`Left` / :kbd:`Ctrl` + :kbd:`B` and :kbd:`Shift` + :kbd:`Right` / :kbd:`Ctrl` + :kbd:`F` to move the cursor one word back or forward.
+- Fast Rewind: Use :kbd:`Ctrl` + :kbd:`Left` / :kbd:`Ctrl` + :kbd:`B` and :kbd:`Ctrl` + :kbd:`Right` / :kbd:`Ctrl` + :kbd:`F` to move the cursor one word back or forward.
 - Longest X Position Memory: The cursor remembers the longest x position when moving up or down, making vertical navigation more intuitive.
 - Mouse Control: Use the mouse to position the cursor within the text, providing an alternative to keyboard navigation.
 - New Lines: Easily insert new lines using the :kbd:`Enter` key, supporting multiline text input.
@@ -47,7 +47,7 @@ Supported Features
   - replace selected text, if available
   - If no text is selected, paste text in the cursor position
 - Scrolling behaviour for long text build-in
-- Table of contests (:kbd:`Ctrl` + :kbd:`O`), with headers line prefixed by '#', e.g. '# Fort history', '## Year 1'
+- Table of contents (:kbd:`Ctrl` + :kbd:`O`), with headers line prefixed by '#', e.g. '# Fort history', '## Year 1'
 
 Usage
 -----

--- a/docs/gui/journal.rst
+++ b/docs/gui/journal.rst
@@ -48,6 +48,7 @@ Supported Features
   - If no text is selected, paste text in the cursor position
 - Scrolling behaviour for long text build-in
 - Table of contents (:kbd:`Ctrl` + :kbd:`O`), with headers line prefixed by '#', e.g. '# Fort history', '## Year 1'
+- Table of contents navigation: jump to previous/next section by :kbd:`Ctrl` + :kbd:`Up` / :kbd:`Ctrl` + :kbd:`Down`
 
 Usage
 -----

--- a/docs/gui/journal.rst
+++ b/docs/gui/journal.rst
@@ -46,6 +46,7 @@ Supported Features
   - replace selected text, if available
   - If no text is selected, paste text in the cursor position
 - Scrolling behaviour for long text build-in
+- Table of contests (:kbd:`Ctrl` + :kbd:`T`), with headers line prefixed by `#`, e.g. `# Fort history`, `## Year 1`
 
 Usage
 -----

--- a/docs/gui/journal.rst
+++ b/docs/gui/journal.rst
@@ -47,7 +47,7 @@ Supported Features
   - replace selected text, if available
   - If no text is selected, paste text in the cursor position
 - Scrolling behaviour for long text build-in
-- Table of contests (:kbd:`Ctrl` + :kbd:`O`), with headers line prefixed by `#`, e.g. `# Fort history`, `## Year 1`
+- Table of contests (:kbd:`Ctrl` + :kbd:`O`), with headers line prefixed by '#', e.g. '# Fort history', '## Year 1'
 
 Usage
 -----

--- a/docs/gui/journal.rst
+++ b/docs/gui/journal.rst
@@ -35,6 +35,7 @@ Supported Features
 - Jump to Beginning/End: Quickly move the cursor to the beginning or end of the text using :kbd:`Shift` + :kbd:`Up` and :kbd:`Shift` + :kbd:`Down`.
 - Select Word/Line: Use double click to select current word, or triple click to select current line
 - Select All: Select entire text by :kbd:`Ctrl` + :kbd:`A`
+- Undo/Redo: Undo/Redo changes by :kbd:`Ctrl` + :kbd:`Z` / :kbd:`Ctrl` + :kbd:`Y`
 - Clipboard Operations: Perform OS clipboard cut, copy, and paste operations on selected text, allowing you to paste the copied content into other applications.
 - Copy Text: Use :kbd:`Ctrl` + :kbd:`C` to copy selected text.
   - copy selected text, if available

--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -82,7 +82,7 @@ function JournalWindow:init()
             view_id='journal_editor',
             frame={t=3, b=0, l=31, r=0},
             resize_min={w=30, h=10},
-            frame_inset={r=1},
+            frame_inset={r=0},
             init_text=self.init_text,
             init_cursor=self.init_cursor,
             on_text_change=function(text) self:onTextChange(text) end,

--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -42,7 +42,7 @@ function JournalWindow:init()
     self:addviews({
         widgets.Panel{
             view_id='table_of_contents_panel',
-            frame={l=0, w=toc_width, t=1, b=1},
+            frame={l=0, w=toc_width, t=0, b=1},
             visible=toc_visible,
 
             resize_min={w=20},

--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -187,10 +187,12 @@ function JournalWindow:loadConfig()
     end
 
     local window_frame = copyall(journal_config.data.frame or {})
-    local table_of_contents = copyall(journal_config.data.toc or {
-        width=20,
-        visible=false
-    })
+    window_frame.w = window_frame.w or 80
+    window_frame.h = window_frame.h or 50
+
+    local table_of_contents = copyall(journal_config.data.toc or {})
+    table_of_contents.width = table_of_contents.width or 20
+    table_of_contents.visible = table_of_contents.visible or false
 
     return window_frame, table_of_contents.visible or false, table_of_contents.width or 25
 end

--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -81,7 +81,7 @@ function JournalWindow:toggleToCVisibililty()
     self.subviews.table_of_contents_panel.visible =
         not self.subviews.table_of_contents_panel.visible
 
-    self:reloadTableOfContents(self.subviews.journal_editor:text())
+    self:reloadTableOfContents(self.subviews.journal_editor:getText())
     self:updateLayout()
 end
 
@@ -120,6 +120,18 @@ end
 
 function JournalWindow:onPanelResizeEnd()
     self.resizing_panels = false
+
+    self:esnurePanelsRelSize()
+    self:updateLayout()
+end
+
+function JournalWindow:onRenderBody(painter)
+    if self.resizing_panels then
+        self:esnurePanelsRelSize()
+        self:updateLayout()
+    end
+
+    return JournalWindow.super.onRenderBody(painter)
 end
 
 function JournalWindow:esnurePanelsRelSize()
@@ -192,7 +204,7 @@ function JournalScreen:init(options)
             resize_min={w=50, h=20},
             resizable=true,
             frame_inset=0,
-            content=content,
+            init_text=content,
             on_text_change=self:callback('onTextChange')
         },
     }

--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -118,11 +118,31 @@ end
 
 function JournalWindow:onInput(keys)
     if (keys.A_MOVE_N_DOWN) then
-        print('works N')
+        local curr_cursor = self.subviews.journal_editor:getCursor()
+        local section_index, section = self.subviews.table_of_contents_panel:cursorSection(
+            curr_cursor
+        )
+
+        if section.line_cursor == curr_cursor then
+            self.subviews.table_of_contents_panel:setSelectedSection(
+                section_index - 1
+            )
+            self.subviews.table_of_contents_panel:submit()
+        else
+            self:onTableOfContentsSubmit(section_index, section)
+        end
+
         return false
-    end
-    if (keys.A_MOVE_S_DOWN) then
-        print('works S')
+    elseif (keys.A_MOVE_S_DOWN) then
+        local section_index = self.subviews.table_of_contents_panel:cursorSection(
+            self.subviews.journal_editor:getCursor()
+        )
+        self.subviews.table_of_contents_panel:setSelectedSection(
+            section_index + 1
+        )
+        self.subviews.table_of_contents_panel:submit()
+
+        return false
     end
 
     return JournalWindow.super.onInput(self, keys)
@@ -223,7 +243,7 @@ function JournalWindow:postUpdateLayout()
 end
 
 function JournalWindow:onCursorChange(cursor)
-    local section_index, cursor_section = self.subviews.table_of_contents_panel:cursorSection(
+    local section_index = self.subviews.table_of_contents_panel:cursorSection(
         cursor
     )
     self.subviews.table_of_contents_panel:setSelectedSection(section_index)
@@ -241,9 +261,9 @@ function JournalWindow:onTextChange(text)
     end
 end
 
-function JournalWindow:onTableOfContentsSubmit(ind, choice)
-    self.subviews.journal_editor:setCursor(choice.line_cursor)
-    self.subviews.journal_editor:scrollToCursor(choice.line_cursor)
+function JournalWindow:onTableOfContentsSubmit(ind, section)
+    self.subviews.journal_editor:setCursor(section.line_cursor)
+    self.subviews.journal_editor:scrollToCursor(section.line_cursor)
 end
 
 JournalScreen = defclass(JournalScreen, gui.ZScreen)

--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -40,7 +40,7 @@ function JournalWindow:init()
             view_id='table_of_contents_panel',
             frame={l=0, w=toc_width, t=0, b=1},
             visible=toc_visible,
-            frame_inset={l=0, t=1, b=1, r=1},
+            frame_inset={l=1, t=0, b=1, r=1},
 
             resize_min={w=20},
             resizable=true,
@@ -61,7 +61,8 @@ function JournalWindow:init()
 
                 if not colllapsed then
                     self.subviews.table_of_contents_panel:reload(
-                        self.subviews.journal_editor:getText()
+                        self.subviews.journal_editor:getText(),
+                        self.subviews.journal_editor:getCursor()
                     )
                 end
 
@@ -107,39 +108,10 @@ function JournalWindow:init()
         }
     })
 
-    self.subviews.table_of_contents_panel:reload(self.init_text)
-end
-
-function JournalWindow:onInput(keys)
-    if (keys.A_MOVE_N_DOWN) then
-        local curr_cursor = self.subviews.journal_editor:getCursor()
-        local section_index, section = self.subviews.table_of_contents_panel:cursorSection(
-            curr_cursor
-        )
-
-        if section.line_cursor == curr_cursor then
-            self.subviews.table_of_contents_panel:setSelectedSection(
-                section_index - 1
-            )
-            self.subviews.table_of_contents_panel:submit()
-        else
-            self:onTableOfContentsSubmit(section_index, section)
-        end
-
-        return false
-    elseif (keys.A_MOVE_S_DOWN) then
-        local section_index = self.subviews.table_of_contents_panel:cursorSection(
-            self.subviews.journal_editor:getCursor()
-        )
-        self.subviews.table_of_contents_panel:setSelectedSection(
-            section_index + 1
-        )
-        self.subviews.table_of_contents_panel:submit()
-
-        return false
-    end
-
-    return JournalWindow.super.onInput(self, keys)
+    self.subviews.table_of_contents_panel:reload(
+        self.init_text,
+        self.subviews.journal_editor:getCursor() or self.init_cursor
+    )
 end
 
 function JournalWindow:sanitizeFrame(frame)
@@ -239,9 +211,8 @@ function JournalWindow:postUpdateLayout()
 end
 
 function JournalWindow:onCursorChange(cursor)
-    local section_index = self.subviews.table_of_contents_panel:cursorSection(
-        cursor
-    )
+    self.subviews.table_of_contents_panel:setCursor(cursor)
+    local section_index = self.subviews.table_of_contents_panel:currentSection()
     self.subviews.table_of_contents_panel:setSelectedSection(section_index)
 
     if self.on_cursor_change ~= nil then
@@ -250,7 +221,10 @@ function JournalWindow:onCursorChange(cursor)
 end
 
 function JournalWindow:onTextChange(text)
-    self.subviews.table_of_contents_panel:reload(text)
+    self.subviews.table_of_contents_panel:reload(
+        text,
+        self.subviews.journal_editor:getCursor()
+    )
 
     if self.on_text_change ~= nil then
         self.on_text_change(text)

--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -19,7 +19,7 @@ JournalWindow.ATTRS {
     resizable=true,
     resize_min=RESIZE_MIN,
     frame_inset=0,
-    content='',
+    init_text='',
     on_text_change=DEFAULT_NIL
 }
 
@@ -69,7 +69,7 @@ function JournalWindow:init()
             frame={t=3, b=0, l=31, r=0},
             resize_min={w=30, h=10},
             frame_inset={r=1},
-            text=self.content,
+            init_text=self.init_text,
             on_change=function(text) self:onTextChange(text) end
         },
     })
@@ -78,7 +78,10 @@ function JournalWindow:init()
 end
 
 function JournalWindow:toggleToCVisibililty()
-    self.subviews.table_of_contents_panel.visible = not self.subviews.table_of_contents_panel.visible
+    self.subviews.table_of_contents_panel.visible =
+        not self.subviews.table_of_contents_panel.visible
+
+    self:reloadTableOfContents(self.subviews.journal_editor:text())
     self:updateLayout()
 end
 
@@ -146,6 +149,10 @@ function JournalWindow:onTextChange(text)
 end
 
 function JournalWindow:reloadTableOfContents(text)
+    if not self.subviews.table_of_contents_panel.visible then
+        return
+    end
+
     local sections = {}
 
     local line_cursor = 1

--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -13,11 +13,6 @@ local RESIZE_MIN = {w=32, h=10}
 
 JOURNAL_PERSIST_KEY = 'journal'
 
-local INVISIBLE_FRAME = {
-    frame_pen=gui.CLEAR_PEN,
-    signature_pen=false,
-}
-
 journal_config = journal_config or json.open('dfhack-config/journal.json')
 
 JournalWindow = defclass(JournalWindow, widgets.Window)
@@ -88,7 +83,6 @@ function JournalWindow:init()
 
             interior_b=true,
             frame_style_t=false,
-            frmae_style=INVISIBLE_FRAME,
         },
         text_editor.TextEditor{
             view_id='journal_editor',

--- a/internal/journal/shifter.lua
+++ b/internal/journal/shifter.lua
@@ -1,0 +1,55 @@
+-- >> / << toggle button
+--@ module = true
+
+local widgets = require 'gui.widgets'
+
+local TO_THE_RIGHT = string.char(16)
+local TO_THE_LEFT = string.char(17)
+
+function get_shifter_text(state)
+    local ch = state and TO_THE_RIGHT or TO_THE_LEFT
+    return {
+        ' ', NEWLINE,
+        ch, NEWLINE,
+        ch, NEWLINE,
+        ' ', NEWLINE,
+    }
+end
+
+Shifter = defclass(Shifter, widgets.Widget)
+Shifter.ATTRS {
+    frame={l=0, w=1, t=0, b=0},
+    collapsed=false,
+    on_changed=DEFAULT_NIL,
+}
+
+function Shifter:init()
+    self:addviews{
+        widgets.Label{
+            view_id='shifter_label',
+            frame={l=0, r=0, t=0, b=0},
+            text=get_shifter_text(self.collapsed),
+            on_click=function ()
+                self:toggle(not self.collapsed)
+            end
+        }
+    }
+end
+
+function Shifter:toggle(state)
+    if state == nil then
+        self.collapsed = not self.collapsed
+    else
+        self.collapsed = state
+    end
+
+    self.subviews.shifter_label:setText(
+        get_shifter_text(self.collapsed)
+    )
+
+    self:updateLayout()
+
+    if self.on_changed then
+        self.on_changed(self.collapsed)
+    end
+end

--- a/internal/journal/table_of_contents.lua
+++ b/internal/journal/table_of_contents.lua
@@ -35,7 +35,14 @@ function TableOfContents:cursorSection(cursor)
 end
 
 function TableOfContents:setSelectedSection(section_index)
-    self.subviews.table_of_contents:setSelected(section_index)
+    local curr_sel = self.subviews.table_of_contents:getSelected()
+    if curr_sel ~= section_index then
+        self.subviews.table_of_contents:setSelected(section_index)
+    end
+end
+
+function TableOfContents:submit()
+    return self.subviews.table_of_contents:submit()
 end
 
 function TableOfContents:reload(text)

--- a/internal/journal/table_of_contents.lua
+++ b/internal/journal/table_of_contents.lua
@@ -3,6 +3,8 @@
 local gui = require 'gui'
 local widgets = require 'gui.widgets'
 
+local df_major_version = tonumber(dfhack.getCompiledDFVersion():match('%d+'))
+
 local INVISIBLE_FRAME = {
     frame_pen=gui.CLEAR_PEN,
     signature_pen=false,
@@ -17,13 +19,23 @@ TableOfContents.ATTRS {
 }
 
 function TableOfContents:init()
-    self:addviews({
+    self:addviews{
         widgets.List{
             frame={l=0, t=0, r=0, b=3},
             view_id='table_of_contents',
             choices={},
             on_submit=self.on_submit
         },
+    }
+
+    if df_major_version < 51 then
+        -- widgets below this line require DF 51
+        -- TODO: remove this check once DF 51 is stable and DFHack is no longer
+        -- releasing new versions for DF 50
+        return
+    end
+
+    self:addviews{
         widgets.HotkeyLabel{
             frame={b=0},
             key='A_MOVE_N_DOWN',
@@ -36,7 +48,7 @@ function TableOfContents:init()
             label='Next Section',
             on_activate=self:callback('nextSection'),
         }
-    })
+    }
 end
 
 function TableOfContents:previousSection()

--- a/internal/journal/table_of_contents.lua
+++ b/internal/journal/table_of_contents.lua
@@ -3,6 +3,11 @@
 local gui = require 'gui'
 local widgets = require 'gui.widgets'
 
+local INVISIBLE_FRAME = {
+    frame_pen=gui.CLEAR_PEN,
+    signature_pen=false,
+}
+
 TableOfContents = defclass(TableOfContents, widgets.Panel)
 TableOfContents.ATTRS {
     frame_style=INVISIBLE_FRAME,

--- a/internal/journal/table_of_contents.lua
+++ b/internal/journal/table_of_contents.lua
@@ -1,0 +1,62 @@
+--@ module = true
+
+local gui = require 'gui'
+local widgets = require 'gui.widgets'
+
+TableOfContents = defclass(TableOfContents, widgets.Panel)
+TableOfContents.ATTRS {
+    frame_style=INVISIBLE_FRAME,
+    frame_background = gui.CLEAR_PEN,
+    on_submit=DEFAULT_NIL
+}
+
+function TableOfContents:init()
+    self:addviews({
+        widgets.List{
+            frame={l=1, t=0, r=1, b=0},
+            view_id='table_of_contents',
+            choices={},
+            on_submit=self.on_submit
+        },
+    })
+end
+
+function TableOfContents:cursorSection(cursor)
+    local section_ind = nil
+
+    for ind, choice in ipairs(self.subviews.table_of_contents.choices) do
+        if choice.line_cursor > cursor then
+            break
+        end
+        section_ind = ind
+    end
+
+    return section_ind, self.subviews.table_of_contents.choices[section_ind]
+end
+
+function TableOfContents:setSelectedSection(section_index)
+    self.subviews.table_of_contents:setSelected(section_index)
+end
+
+function TableOfContents:reload(text)
+    if not self.visible then
+        return
+    end
+
+    local sections = {}
+
+    local line_cursor = 1
+    for line in text:gmatch("[^\n]*") do
+        local header, section = line:match("^(#+)%s(.+)")
+        if header ~= nil then
+            table.insert(sections, {
+                line_cursor=line_cursor,
+                text=string.rep(" ", #header - 1) .. section,
+            })
+        end
+
+        line_cursor = line_cursor + #line + 1
+    end
+
+    self.subviews.table_of_contents:setChoices(sections)
+end

--- a/internal/journal/text_editor.lua
+++ b/internal/journal/text_editor.lua
@@ -59,6 +59,10 @@ function TextEditor:init()
     self:setFocus(true)
 end
 
+function TextEditor:setCursor(cursor_offset)
+    return self.subviews.text_area:setCursor(cursor_offset)
+end
+
 function TextEditor:getPreferredFocusState()
     return true
 end

--- a/internal/journal/text_editor.lua
+++ b/internal/journal/text_editor.lua
@@ -237,7 +237,6 @@ function TextEditor:onInput(keys)
     return TextEditor.super.onInput(self, keys)
 end
 
-
 TextEditorView = defclass(TextEditorView, widgets.Widget)
 
 TextEditorView.ATTRS{

--- a/internal/journal/text_editor.lua
+++ b/internal/journal/text_editor.lua
@@ -60,10 +60,12 @@ function TextEditor:init()
 end
 
 function TextEditor:scrollToCursor(cursor_offset)
-    local _, cursor_liny_y = self.subviews.text_area.wrapped_text:indexToCoords(
-        cursor_offset
-    )
-    self:setRenderStartLineY(cursor_liny_y)
+    if self.scrollbar.visible then
+        local _, cursor_liny_y = self.subviews.text_area.wrapped_text:indexToCoords(
+            cursor_offset
+        )
+        self:setRenderStartLineY(cursor_liny_y)
+    end
 end
 
 function TextEditor:setCursor(cursor_offset)

--- a/internal/journal/text_editor.lua
+++ b/internal/journal/text_editor.lua
@@ -7,7 +7,7 @@ local wrapped_text = reqscript('internal/journal/wrapped_text')
 
 local CLIPBOARD_MODE = {LOCAL = 1, LINE = 2}
 
-TextEditor = defclass(TextEditor, widgets.Widget)
+TextEditor = defclass(TextEditor, widgets.Panel)
 
 TextEditor.ATTRS{
     text = '',
@@ -57,6 +57,13 @@ function TextEditor:init()
         widgets.HelpButton{command="gui/journal", frame={r=0,t=0}}
     }
     self:setFocus(true)
+end
+
+function TextEditor:scrollToCursor(cursor_offset)
+    local _, cursor_liny_y = self.subviews.text_area.wrapped_text:indexToCoords(
+        cursor_offset
+    )
+    self:setRenderStartLineY(cursor_liny_y)
 end
 
 function TextEditor:setCursor(cursor_offset)

--- a/internal/journal/text_editor.lua
+++ b/internal/journal/text_editor.lua
@@ -20,7 +20,6 @@ TextEditor.ATTRS{
 
 function TextEditor:init()
     self.render_start_line_y = 1
-
     self:addviews{
         TextEditorView{
             view_id='text_area',
@@ -49,7 +48,7 @@ function TextEditor:init()
     self:setFocus(true)
 end
 
-function TextEditor:text()
+function TextEditor:getText()
     return self.subviews.text_area.text
 end
 

--- a/internal/journal/text_editor.lua
+++ b/internal/journal/text_editor.lua
@@ -513,9 +513,9 @@ function TextEditorView:onInput(keys)
 
     if self:onMouseInput(keys) then
         return true
-    elseif self:onCursorInput(keys) then
-        return true
     elseif self:onTextManipulationInput(keys) then
+        return true
+    elseif self:onCursorInput(keys) then
         return true
     elseif keys.CUSTOM_CTRL_C then
         self:copy()

--- a/internal/journal/text_editor.lua
+++ b/internal/journal/text_editor.lua
@@ -750,12 +750,12 @@ function TextEditorView:onCursorInput(keys)
         -- go to text end
         self:setCursor(#self.text + 1)
         return true
-    elseif keys.CUSTOM_CTRL_B or keys.KEYBOARD_CURSOR_LEFT_FAST then
+    elseif keys.CUSTOM_CTRL_B or keys.A_MOVE_W_DOWN then
         -- back one word
         local word_start = self:wordStartOffset()
         self:setCursor(word_start)
         return true
-    elseif keys.CUSTOM_CTRL_F or keys.KEYBOARD_CURSOR_RIGHT_FAST then
+    elseif keys.CUSTOM_CTRL_F or keys.A_MOVE_E_DOWN then
         -- forward one word
         local word_end = self:wordEndOffset()
         self:setCursor(word_end)

--- a/internal/journal/text_editor.lua
+++ b/internal/journal/text_editor.lua
@@ -103,7 +103,7 @@ function TextEditor:init()
     self:addviews{
         TextEditorView{
             view_id='text_area',
-            frame={l=0,r=2,t=0},
+            frame={l=0,r=3,t=0},
             text = self.init_text,
 
             text_pen = self.text_pen,

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -6,6 +6,8 @@ config = {
     mode = 'fortress'
 }
 
+local df_major_version = tonumber(dfhack.getCompiledDFVersion():match('%d+'))
+
 local function simulate_input_keys(...)
     local keys = {...}
     for _,key in ipairs(keys) do
@@ -687,172 +689,6 @@ function test.keyboard_arrow_right_navigation()
     journal:dismiss()
 end
 
-function test.fast_rewind_words_right()
-    local journal, text_area = arrange_empty_journal({w=55})
-
-    local text = table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh porttitor mi, vitae rutrum eros metus nec libero.',
-    }, '\n')
-
-    simulate_input_text(text)
-    text_area:setCursor(1)
-    journal:onRender()
-
-    simulate_input_keys('A_MOVE_E_DOWN')
-
-    expect.eq(read_rendered_text(text_area), table.concat({
-        '60:_Lorem ipsum dolor sit amet, consectetur adipiscing ',
-        'elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ',
-        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
-        'libero.',
-    }, '\n'));
-
-    simulate_input_keys('A_MOVE_E_DOWN')
-
-    expect.eq(read_rendered_text(text_area), table.concat({
-        '60: Lorem_ipsum dolor sit amet, consectetur adipiscing ',
-        'elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ',
-        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
-        'libero.',
-    }, '\n'));
-
-    for i=1,6 do
-        simulate_input_keys('A_MOVE_E_DOWN')
-    end
-
-    expect.eq(read_rendered_text(text_area), table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing_',
-        'elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ',
-        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
-        'libero.',
-    }, '\n'));
-
-    simulate_input_keys('A_MOVE_E_DOWN')
-
-    expect.eq(read_rendered_text(text_area), table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
-        'elit._',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ',
-        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
-        'libero.',
-    }, '\n'));
-
-    simulate_input_keys('A_MOVE_E_DOWN')
-
-    expect.eq(read_rendered_text(text_area), table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
-        'elit.',
-        '112:_Sed consectetur, urna sit amet aliquet egestas, ',
-        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
-        'libero.',
-    }, '\n'));
-
-    for i=1,17 do
-        simulate_input_keys('A_MOVE_E_DOWN')
-    end
-
-    expect.eq(read_rendered_text(text_area), table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
-        'elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ',
-        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
-        'libero._',
-    }, '\n'));
-
-    simulate_input_keys('A_MOVE_E_DOWN')
-
-    expect.eq(read_rendered_text(text_area), table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
-        'elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ',
-        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
-        'libero._',
-    }, '\n'));
-
-    journal:dismiss()
-end
-
-function test.fast_rewind_words_left()
-    local journal, text_area = arrange_empty_journal({w=55})
-
-    local text = table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh porttitor mi, vitae rutrum eros metus nec libero.',
-    }, '\n')
-
-    simulate_input_text(text)
-
-    simulate_input_keys('A_MOVE_W_DOWN')
-
-    expect.eq(read_rendered_text(text_area), table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
-        'elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ',
-        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
-        '_ibero.',
-    }, '\n'));
-
-    simulate_input_keys('A_MOVE_W_DOWN')
-
-    expect.eq(read_rendered_text(text_area), table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
-        'elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ',
-        'ante nibh porttitor mi, vitae rutrum eros metus _ec ',
-        'libero.',
-    }, '\n'));
-
-    for i=1,8 do
-        simulate_input_keys('A_MOVE_W_DOWN')
-    end
-
-    expect.eq(read_rendered_text(text_area), table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
-        'elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ',
-        '_nte nibh porttitor mi, vitae rutrum eros metus nec ',
-        'libero.',
-    }, '\n'));
-
-    simulate_input_keys('A_MOVE_W_DOWN')
-
-    expect.eq(read_rendered_text(text_area), table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
-        'elit.',
-        '112: Sed consectetur, urna sit amet aliquet _gestas, ',
-        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
-        'libero.',
-    }, '\n'));
-
-    for i=1,16 do
-        simulate_input_keys('A_MOVE_W_DOWN')
-    end
-
-    expect.eq(read_rendered_text(text_area), table.concat({
-        '_0: Lorem ipsum dolor sit amet, consectetur adipiscing ',
-        'elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ',
-        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
-        'libero.',
-    }, '\n'));
-
-    simulate_input_keys('A_MOVE_W_DOWN')
-
-    expect.eq(read_rendered_text(text_area), table.concat({
-        '_0: Lorem ipsum dolor sit amet, consectetur adipiscing ',
-        'elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ',
-        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
-        'libero.',
-    }, '\n'));
-
-    journal:dismiss()
-end
-
 function test.handle_backspace()
     local journal, text_area = arrange_empty_journal({w=55})
 
@@ -1453,41 +1289,6 @@ function test.arrows_reset_selection()
     simulate_input_keys('CUSTOM_CTRL_A')
 
     simulate_input_keys('KEYBOARD_CURSOR_DOWN')
-    expect.eq(read_selected_text(text_area), '')
-
-    journal:dismiss()
-end
-
-function test.fast_rewind_reset_selection()
-    local journal, text_area = arrange_empty_journal({w=65})
-
-    local text = table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh porttitor mi, vitae rutrum eros metus nec libero.',
-    }, '\n')
-
-    simulate_input_text(text)
-
-    simulate_input_keys('CUSTOM_CTRL_A')
-
-    expect.eq(read_rendered_text(text_area), table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh ',
-        'porttitor mi, vitae rutrum eros metus nec libero.',
-    }, '\n'));
-
-    expect.eq(read_selected_text(text_area), table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh ',
-        'porttitor mi, vitae rutrum eros metus nec libero.',
-    }, '\n'));
-
-    simulate_input_keys('A_MOVE_W_DOWN')
-    expect.eq(read_selected_text(text_area), '')
-
-    simulate_input_keys('CUSTOM_CTRL_A')
-
-    simulate_input_keys('A_MOVE_E_DOWN')
     expect.eq(read_selected_text(text_area), '')
 
     journal:dismiss()
@@ -2873,7 +2674,7 @@ end
 function test.resize_table_of_contents_together()
     local journal, text_area = arrange_empty_journal({
         w=100,
-        h=10,
+        h=20,
         allow_layout_restore=false
     })
 
@@ -2893,7 +2694,13 @@ function test.resize_table_of_contents_together()
 
     local toc_panel = journal.subviews.table_of_contents_panel
     -- simulate mouse drag resize of toc panel
-    simulate_mouse_drag(toc_panel, toc_panel.frame_body.width, 1, toc_panel.frame_body.width + 10, 1)
+    simulate_mouse_drag(
+        toc_panel,
+        toc_panel.frame_body.width + 1,
+        1,
+        toc_panel.frame_body.width + 1 + 10,
+        1
+    )
 
     expect.eq(text_area.frame_body.width, 101 - 24 - 10)
 
@@ -2965,6 +2772,11 @@ function test.table_of_contents_selection_follows_cursor()
     journal:dismiss()
 end
 
+if df_major_version < 51 then
+    -- temporary ignore test features that base on newest API of the DF game
+    return
+end
+
 function test.table_of_contents_keyboard_navigation()
     local journal, text_area = arrange_empty_journal({
         w=100,
@@ -3031,6 +2843,207 @@ function test.table_of_contents_keyboard_navigation()
     simulate_input_keys('A_MOVE_N_DOWN')
 
     expect.eq(toc:getSelected(), 3)
+
+    journal:dismiss()
+end
+
+function test.fast_rewind_words_right()
+    local journal, text_area = arrange_empty_journal({w=55})
+
+    local text = table.concat({
+        '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh porttitor mi, vitae rutrum eros metus nec libero.',
+    }, '\n')
+
+    simulate_input_text(text)
+    text_area:setCursor(1)
+    journal:onRender()
+
+    simulate_input_keys('A_MOVE_E_DOWN')
+
+    expect.eq(read_rendered_text(text_area), table.concat({
+        '60:_Lorem ipsum dolor sit amet, consectetur adipiscing ',
+        'elit.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ',
+        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
+        'libero.',
+    }, '\n'));
+
+    simulate_input_keys('A_MOVE_E_DOWN')
+
+    expect.eq(read_rendered_text(text_area), table.concat({
+        '60: Lorem_ipsum dolor sit amet, consectetur adipiscing ',
+        'elit.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ',
+        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
+        'libero.',
+    }, '\n'));
+
+    for i=1,6 do
+        simulate_input_keys('A_MOVE_E_DOWN')
+    end
+
+    expect.eq(read_rendered_text(text_area), table.concat({
+        '60: Lorem ipsum dolor sit amet, consectetur adipiscing_',
+        'elit.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ',
+        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
+        'libero.',
+    }, '\n'));
+
+    simulate_input_keys('A_MOVE_E_DOWN')
+
+    expect.eq(read_rendered_text(text_area), table.concat({
+        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
+        'elit._',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ',
+        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
+        'libero.',
+    }, '\n'));
+
+    simulate_input_keys('A_MOVE_E_DOWN')
+
+    expect.eq(read_rendered_text(text_area), table.concat({
+        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
+        'elit.',
+        '112:_Sed consectetur, urna sit amet aliquet egestas, ',
+        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
+        'libero.',
+    }, '\n'));
+
+    for i=1,17 do
+        simulate_input_keys('A_MOVE_E_DOWN')
+    end
+
+    expect.eq(read_rendered_text(text_area), table.concat({
+        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
+        'elit.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ',
+        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
+        'libero._',
+    }, '\n'));
+
+    simulate_input_keys('A_MOVE_E_DOWN')
+
+    expect.eq(read_rendered_text(text_area), table.concat({
+        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
+        'elit.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ',
+        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
+        'libero._',
+    }, '\n'));
+
+    journal:dismiss()
+end
+
+function test.fast_rewind_words_left()
+    local journal, text_area = arrange_empty_journal({w=55})
+
+    local text = table.concat({
+        '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh porttitor mi, vitae rutrum eros metus nec libero.',
+    }, '\n')
+
+    simulate_input_text(text)
+
+    simulate_input_keys('A_MOVE_W_DOWN')
+
+    expect.eq(read_rendered_text(text_area), table.concat({
+        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
+        'elit.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ',
+        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
+        '_ibero.',
+    }, '\n'));
+
+    simulate_input_keys('A_MOVE_W_DOWN')
+
+    expect.eq(read_rendered_text(text_area), table.concat({
+        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
+        'elit.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ',
+        'ante nibh porttitor mi, vitae rutrum eros metus _ec ',
+        'libero.',
+    }, '\n'));
+
+    for i=1,8 do
+        simulate_input_keys('A_MOVE_W_DOWN')
+    end
+
+    expect.eq(read_rendered_text(text_area), table.concat({
+        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
+        'elit.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ',
+        '_nte nibh porttitor mi, vitae rutrum eros metus nec ',
+        'libero.',
+    }, '\n'));
+
+    simulate_input_keys('A_MOVE_W_DOWN')
+
+    expect.eq(read_rendered_text(text_area), table.concat({
+        '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
+        'elit.',
+        '112: Sed consectetur, urna sit amet aliquet _gestas, ',
+        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
+        'libero.',
+    }, '\n'));
+
+    for i=1,16 do
+        simulate_input_keys('A_MOVE_W_DOWN')
+    end
+
+    expect.eq(read_rendered_text(text_area), table.concat({
+        '_0: Lorem ipsum dolor sit amet, consectetur adipiscing ',
+        'elit.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ',
+        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
+        'libero.',
+    }, '\n'));
+
+    simulate_input_keys('A_MOVE_W_DOWN')
+
+    expect.eq(read_rendered_text(text_area), table.concat({
+        '_0: Lorem ipsum dolor sit amet, consectetur adipiscing ',
+        'elit.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ',
+        'ante nibh porttitor mi, vitae rutrum eros metus nec ',
+        'libero.',
+    }, '\n'));
+
+    journal:dismiss()
+end
+
+function test.fast_rewind_reset_selection()
+    local journal, text_area = arrange_empty_journal({w=65})
+
+    local text = table.concat({
+        '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh porttitor mi, vitae rutrum eros metus nec libero.',
+    }, '\n')
+
+    simulate_input_text(text)
+
+    simulate_input_keys('CUSTOM_CTRL_A')
+
+    expect.eq(read_rendered_text(text_area), table.concat({
+        '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh ',
+        'porttitor mi, vitae rutrum eros metus nec libero.',
+    }, '\n'));
+
+    expect.eq(read_selected_text(text_area), table.concat({
+        '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh ',
+        'porttitor mi, vitae rutrum eros metus nec libero.',
+    }, '\n'));
+
+    simulate_input_keys('A_MOVE_W_DOWN')
+    expect.eq(read_selected_text(text_area), '')
+
+    simulate_input_keys('CUSTOM_CTRL_A')
+
+    simulate_input_keys('A_MOVE_E_DOWN')
+    expect.eq(read_selected_text(text_area), '')
 
     journal:dismiss()
 end

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -90,7 +90,7 @@ local function arrange_empty_journal(options)
     end
 
     if options.h then
-        journal_window.frame.h = options.h + 3
+        journal_window.frame.h = options.h + 6
     end
 
 

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -183,6 +183,51 @@ function test.load_input_multiline_text()
     journal:dismiss()
 end
 
+function test.handle_numpad_numbers_as_text()
+    local journal, text_area, journal_window = arrange_empty_journal({w=80})
+
+    local text = table.concat({
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    }, '\n')
+    simulate_input_text(text)
+
+    simulate_input_keys({
+        STANDARDSCROLL_LEFT      = true,
+        KEYBOARD_CURSOR_LEFT     = true,
+        _STRING                  = 52,
+        STRING_A052              = true,
+    })
+
+    expect.eq(read_rendered_text(text_area), text .. '4_')
+
+    simulate_input_keys({
+        STRING_A054              = true,
+        STANDARDSCROLL_RIGHT     = true,
+        KEYBOARD_CURSOR_RIGHT    = true,
+        _STRING                  = 54,
+    })
+    expect.eq(read_rendered_text(text_area), text .. '46_')
+
+    simulate_input_keys({
+        KEYBOARD_CURSOR_DOWN     = true,
+        STRING_A050              = true,
+        _STRING                  = 50,
+        STANDARDSCROLL_DOWN      = true,
+    })
+
+    expect.eq(read_rendered_text(text_area), text .. '462_')
+
+    simulate_input_keys({
+        KEYBOARD_CURSOR_UP       = true,
+        STRING_A056              = true,
+        STANDARDSCROLL_UP        = true,
+        _STRING                  = 56,
+    })
+
+    expect.eq(read_rendered_text(text_area), text .. '4628_')
+    journal:dismiss()
+end
+
 function test.wrap_text_to_available_width()
     local journal, text_area = arrange_empty_journal({w=55})
 

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -86,7 +86,7 @@ local function arrange_empty_journal(options)
     end
 
     if options.w then
-        journal_window.frame.w = options.w + 7
+        journal_window.frame.w = options.w + 8
     end
 
     if options.h then

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -2899,3 +2899,72 @@ function test.resize_table_of_contents_together()
 
     journal:dismiss()
 end
+
+function test.table_of_contents_selection_follows_cursor()
+    local journal, text_area = arrange_empty_journal({
+        w=100,
+        h=50,
+        allow_layout_restore=false
+    })
+
+    local text = table.concat({
+        '# Header 1',
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        'Nulla ut lacus ut tortor semper consectetur.',
+        '# Header 2',
+        'Ut eu orci non nibh hendrerit posuere.',
+        'Sed euismod odio eu fringilla bibendum.',
+        '## Subheader 1',
+        'Etiam dignissim diam nec aliquet facilisis.',
+        'Integer tristique purus at tellus luctus, vel aliquet sapien sollicitudin.',
+        '## Subheader 2',
+        'Fusce ornare est vitae urna feugiat, vel interdum quam vestibulum.',
+        '10: Vivamus id felis scelerisque, lobortis diam ut, mollis nisi.',
+        '### Subsubheader 1',
+        '# Header 3',
+        'Donec quis lectus ac erat placerat eleifend.',
+        'Aenean non orci id erat malesuada pharetra.',
+        'Nunc in lectus et metus finibus venenatis.',
+    }, '\n')
+
+    simulate_input_text(text)
+
+    simulate_input_keys('CUSTOM_CTRL_O')
+
+    local toc = journal.subviews.table_of_contents
+
+    text_area:setCursor(1)
+    gui_journal.view:onRender()
+
+    expect.eq(toc:getSelected(), 1)
+
+
+    text_area:setCursor(8)
+    gui_journal.view:onRender()
+
+    expect.eq(toc:getSelected(), 1)
+
+
+    text_area:setCursor(140)
+    gui_journal.view:onRender()
+
+    expect.eq(toc:getSelected(), 2)
+
+
+    text_area:setCursor(300)
+    gui_journal.view:onRender()
+
+    print(read_rendered_text(text_area))
+
+    expect.eq(toc:getSelected(), 3)
+
+
+    text_area:setCursor(646)
+    gui_journal.view:onRender()
+
+    print(read_rendered_text(text_area))
+
+    expect.eq(toc:getSelected(), 6)
+
+    journal:dismiss()
+end

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -80,16 +80,15 @@ local function arrange_empty_journal(options)
     local journal_window = journal.subviews.journal_window
 
     if not options.allow_size_restore then
-        journal_window.frame.w = 50
-        journal_window.frame.h = 50
+        journal_window.frame= {w = 50, h = 50}
     end
 
     if options.w then
-        journal_window.frame.w = options.w + 6
+        journal_window.frame.w = options.w + 7
     end
 
     if options.h then
-        journal_window.frame.h = options.h + 4
+        journal_window.frame.h = options.h + 5
     end
 
     journal:updateLayout()
@@ -101,7 +100,7 @@ local function arrange_empty_journal(options)
 
     journal:onRender()
 
-    return journal, text_area
+    return journal, text_area, journal_window
 end
 
 local function read_rendered_text(text_area)
@@ -165,7 +164,7 @@ function test.load()
 end
 
 function test.load_input_multiline_text()
-    local journal, text_area = arrange_empty_journal({w=80})
+    local journal, text_area, journal_window = arrange_empty_journal({w=80})
 
     local text = table.concat({
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -699,7 +699,7 @@ function test.fast_rewind_words_right()
     text_area:setCursor(1)
     journal:onRender()
 
-    simulate_input_keys('KEYBOARD_CURSOR_RIGHT_FAST')
+    simulate_input_keys('A_MOVE_E_DOWN')
 
     expect.eq(read_rendered_text(text_area), table.concat({
         '60:_Lorem ipsum dolor sit amet, consectetur adipiscing ',
@@ -709,7 +709,7 @@ function test.fast_rewind_words_right()
         'libero.',
     }, '\n'));
 
-    simulate_input_keys('KEYBOARD_CURSOR_RIGHT_FAST')
+    simulate_input_keys('A_MOVE_E_DOWN')
 
     expect.eq(read_rendered_text(text_area), table.concat({
         '60: Lorem_ipsum dolor sit amet, consectetur adipiscing ',
@@ -720,7 +720,7 @@ function test.fast_rewind_words_right()
     }, '\n'));
 
     for i=1,6 do
-        simulate_input_keys('KEYBOARD_CURSOR_RIGHT_FAST')
+        simulate_input_keys('A_MOVE_E_DOWN')
     end
 
     expect.eq(read_rendered_text(text_area), table.concat({
@@ -731,7 +731,7 @@ function test.fast_rewind_words_right()
         'libero.',
     }, '\n'));
 
-    simulate_input_keys('KEYBOARD_CURSOR_RIGHT_FAST')
+    simulate_input_keys('A_MOVE_E_DOWN')
 
     expect.eq(read_rendered_text(text_area), table.concat({
         '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
@@ -741,7 +741,7 @@ function test.fast_rewind_words_right()
         'libero.',
     }, '\n'));
 
-    simulate_input_keys('KEYBOARD_CURSOR_RIGHT_FAST')
+    simulate_input_keys('A_MOVE_E_DOWN')
 
     expect.eq(read_rendered_text(text_area), table.concat({
         '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
@@ -752,7 +752,7 @@ function test.fast_rewind_words_right()
     }, '\n'));
 
     for i=1,17 do
-        simulate_input_keys('KEYBOARD_CURSOR_RIGHT_FAST')
+        simulate_input_keys('A_MOVE_E_DOWN')
     end
 
     expect.eq(read_rendered_text(text_area), table.concat({
@@ -763,7 +763,7 @@ function test.fast_rewind_words_right()
         'libero._',
     }, '\n'));
 
-    simulate_input_keys('KEYBOARD_CURSOR_RIGHT_FAST')
+    simulate_input_keys('A_MOVE_E_DOWN')
 
     expect.eq(read_rendered_text(text_area), table.concat({
         '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
@@ -786,7 +786,7 @@ function test.fast_rewind_words_left()
 
     simulate_input_text(text)
 
-    simulate_input_keys('KEYBOARD_CURSOR_LEFT_FAST')
+    simulate_input_keys('A_MOVE_W_DOWN')
 
     expect.eq(read_rendered_text(text_area), table.concat({
         '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
@@ -796,7 +796,7 @@ function test.fast_rewind_words_left()
         '_ibero.',
     }, '\n'));
 
-    simulate_input_keys('KEYBOARD_CURSOR_LEFT_FAST')
+    simulate_input_keys('A_MOVE_W_DOWN')
 
     expect.eq(read_rendered_text(text_area), table.concat({
         '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
@@ -807,7 +807,7 @@ function test.fast_rewind_words_left()
     }, '\n'));
 
     for i=1,8 do
-        simulate_input_keys('KEYBOARD_CURSOR_LEFT_FAST')
+        simulate_input_keys('A_MOVE_W_DOWN')
     end
 
     expect.eq(read_rendered_text(text_area), table.concat({
@@ -818,7 +818,7 @@ function test.fast_rewind_words_left()
         'libero.',
     }, '\n'));
 
-    simulate_input_keys('KEYBOARD_CURSOR_LEFT_FAST')
+    simulate_input_keys('A_MOVE_W_DOWN')
 
     expect.eq(read_rendered_text(text_area), table.concat({
         '60: Lorem ipsum dolor sit amet, consectetur adipiscing ',
@@ -829,7 +829,7 @@ function test.fast_rewind_words_left()
     }, '\n'));
 
     for i=1,16 do
-        simulate_input_keys('KEYBOARD_CURSOR_LEFT_FAST')
+        simulate_input_keys('A_MOVE_W_DOWN')
     end
 
     expect.eq(read_rendered_text(text_area), table.concat({
@@ -840,7 +840,7 @@ function test.fast_rewind_words_left()
         'libero.',
     }, '\n'));
 
-    simulate_input_keys('KEYBOARD_CURSOR_LEFT_FAST')
+    simulate_input_keys('A_MOVE_W_DOWN')
 
     expect.eq(read_rendered_text(text_area), table.concat({
         '_0: Lorem ipsum dolor sit amet, consectetur adipiscing ',
@@ -1482,12 +1482,12 @@ function test.fast_rewind_reset_selection()
         'porttitor mi, vitae rutrum eros metus nec libero.',
     }, '\n'));
 
-    simulate_input_keys('KEYBOARD_CURSOR_LEFT_FAST')
+    simulate_input_keys('A_MOVE_W_DOWN')
     expect.eq(read_selected_text(text_area), '')
 
     simulate_input_keys('CUSTOM_CTRL_A')
 
-    simulate_input_keys('KEYBOARD_CURSOR_RIGHT_FAST')
+    simulate_input_keys('A_MOVE_E_DOWN')
     expect.eq(read_selected_text(text_area), '')
 
     journal:dismiss()

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -78,7 +78,7 @@ local function arrange_empty_journal(options)
 
     local journal_window = journal.subviews.journal_window
 
-    if not options.allow_size_restore then
+    if not options.allow_layout_restore then
         journal_window.frame= {w = 50, h = 50}
     end
 
@@ -90,13 +90,19 @@ local function arrange_empty_journal(options)
         journal_window.frame.h = options.h + 5
     end
 
-    journal:updateLayout()
 
     local text_area = journal_window.subviews.text_area
 
     text_area.enable_cursor_blink = false
     text_area:setText('')
 
+    if not options.allow_layout_restore then
+        local toc_panel = journal_window.subviews.table_of_contents_panel
+        toc_panel.visible = false
+        toc_panel.frame.w = 20
+    end
+
+    journal:updateLayout()
     journal:onRender()
 
     return journal, text_area, journal_window
@@ -2348,23 +2354,28 @@ function test.cut_and_paste_selected_text()
     journal:dismiss()
 end
 
-function test.restore_size_and_position()
+function test.restore_layout()
     local journal, _ = arrange_empty_journal()
+
     journal.subviews.journal_window.frame = {
         l = 13,
         t = 13,
         w = 80,
         h = 23
     }
+    journal.subviews.table_of_contents_panel.frame.w = 37
+
     journal:updateLayout()
     journal:dismiss()
 
-    journal, _ = arrange_empty_journal({allow_size_restore=true})
+    journal, _ = arrange_empty_journal({allow_layout_restore=true})
 
     expect.eq(journal.subviews.journal_window.frame.l, 13)
     expect.eq(journal.subviews.journal_window.frame.t, 13)
     expect.eq(journal.subviews.journal_window.frame.w, 80)
     expect.eq(journal.subviews.journal_window.frame.h, 23)
+
+    expect.eq(journal.subviews.table_of_contents_panel.frame.w, 37)
 
     journal:dismiss()
 end
@@ -2633,7 +2644,11 @@ function test.generate_table_of_contents()
 end
 
 function test.jump_to_table_of_contents_sections()
-    local journal, text_area = arrange_empty_journal({w=100, h=10})
+    local journal, text_area = arrange_empty_journal({
+        w=100,
+        h=10,
+        allow_layout_restore=false
+    })
 
     local text = table.concat({
         '# Header 1',
@@ -2772,9 +2787,12 @@ function test.jump_to_table_of_contents_sections()
     journal:dismiss()
 end
 
-
 function test.resize_table_of_contents_together()
-    local journal, text_area = arrange_empty_journal({w=100, h=10})
+    local journal, text_area = arrange_empty_journal({
+        w=100,
+        h=10,
+        allow_layout_restore=false
+    })
 
     local text = table.concat({
         '# Header 1',

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -84,7 +84,7 @@ local function arrange_empty_journal(options)
     end
 
     if options.w then
-        journal_window.frame.w = options.w + 7
+        journal_window.frame.w = options.w + 6
     end
 
     if options.h then

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -49,13 +49,12 @@ local function simulate_mouse_click(element, x, y)
     gui_journal.view:onRender()
 end
 
-local function simulate_mouse_drag(text_area, x_from, y_from, x_to, y_to)
-    local g_x_from, g_y_from = text_area.frame_body:globalXY(x_from, y_from)
-    local g_x_to, g_y_to = text_area.frame_body:globalXY(x_to, y_to)
+local function simulate_mouse_drag(element, x_from, y_from, x_to, y_to)
+    local g_x_from, g_y_from = element.frame_body:globalXY(x_from, y_from)
+    local g_x_to, g_y_to = element.frame_body:globalXY(x_to, y_to)
 
     df.global.gps.mouse_x = g_x_from
     df.global.gps.mouse_y = g_y_from
-
 
     gui.simulateInput(dfhack.gui.getCurViewscreen(true), {
         _MOUSE_L=true,
@@ -2635,7 +2634,6 @@ end
 
 function test.jump_to_table_of_contents_sections()
     local journal, text_area = arrange_empty_journal({w=100, h=10})
-    local scrollbar = journal.subviews.text_area_scrollbar
 
     local text = table.concat({
         '# Header 1',
@@ -2770,6 +2768,33 @@ function test.jump_to_table_of_contents_sections()
         'Aenean non orci id erat malesuada pharetra.',
         'Nunc in lectus et metus finibus venenatis.',
     }, '\n'))
+
+    journal:dismiss()
+end
+
+
+function test.resize_table_of_contents_together()
+    local journal, text_area = arrange_empty_journal({w=100, h=10})
+
+    local text = table.concat({
+        '# Header 1',
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        'Nulla ut lacus ut tortor semper consectetur.',
+    }, '\n')
+
+    simulate_input_text(text)
+
+    expect.eq(text_area.frame_body.width, 101)
+
+    simulate_input_keys('CUSTOM_CTRL_T')
+
+    expect.eq(text_area.frame_body.width, 81)
+
+    local toc_panel = journal.subviews.table_of_contents_panel
+    -- simulate mouse drag resize of toc panel
+    simulate_mouse_drag(toc_panel, toc_panel.frame_body.width, 1, toc_panel.frame_body.width + 10, 1)
+
+    expect.eq(text_area.frame_body.width, 71)
 
     journal:dismiss()
 end

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -2954,17 +2954,83 @@ function test.table_of_contents_selection_follows_cursor()
     text_area:setCursor(300)
     gui_journal.view:onRender()
 
-    print(read_rendered_text(text_area))
-
     expect.eq(toc:getSelected(), 3)
 
 
     text_area:setCursor(646)
     gui_journal.view:onRender()
 
-    print(read_rendered_text(text_area))
+    expect.eq(toc:getSelected(), 6)
+
+    journal:dismiss()
+end
+
+function test.table_of_contents_keyboard_navigation()
+    local journal, text_area = arrange_empty_journal({
+        w=100,
+        h=50,
+        allow_layout_restore=false
+    })
+
+    local text = table.concat({
+        '# Header 1',
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        'Nulla ut lacus ut tortor semper consectetur.',
+        '# Header 2',
+        'Ut eu orci non nibh hendrerit posuere.',
+        'Sed euismod odio eu fringilla bibendum.',
+        '## Subheader 1',
+        'Etiam dignissim diam nec aliquet facilisis.',
+        'Integer tristique purus at tellus luctus, vel aliquet sapien sollicitudin.',
+        '## Subheader 2',
+        'Fusce ornare est vitae urna feugiat, vel interdum quam vestibulum.',
+        '10: Vivamus id felis scelerisque, lobortis diam ut, mollis nisi.',
+        '### Subsubheader 1',
+        '# Header 3',
+        'Donec quis lectus ac erat placerat eleifend.',
+        'Aenean non orci id erat malesuada pharetra.',
+        'Nunc in lectus et metus finibus venenatis.',
+    }, '\n')
+
+    simulate_input_text(text)
+
+    simulate_input_keys('CUSTOM_CTRL_O')
+
+    local toc = journal.subviews.table_of_contents
+
+    text_area:setCursor(5)
+    gui_journal.view:onRender()
+
+    simulate_input_keys('A_MOVE_N_DOWN')
+
+    expect.eq(toc:getSelected(), 1)
+
+    simulate_input_keys('A_MOVE_N_DOWN')
 
     expect.eq(toc:getSelected(), 6)
+
+    simulate_input_keys('A_MOVE_N_DOWN')
+    simulate_input_keys('A_MOVE_N_DOWN')
+
+    expect.eq(toc:getSelected(), 4)
+
+    simulate_input_keys('A_MOVE_S_DOWN')
+
+    expect.eq(toc:getSelected(), 5)
+
+    simulate_input_keys('A_MOVE_S_DOWN')
+    simulate_input_keys('A_MOVE_S_DOWN')
+    simulate_input_keys('A_MOVE_S_DOWN')
+
+    expect.eq(toc:getSelected(), 2)
+
+
+    text_area:setCursor(250)
+    gui_journal.view:onRender()
+
+    simulate_input_keys('A_MOVE_N_DOWN')
+
+    expect.eq(toc:getSelected(), 3)
 
     journal:dismiss()
 end

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -72,11 +72,13 @@ end
 local function arrange_empty_journal(options)
     options = options or {}
 
-    gui_journal.main({save_prefix='test:'})
+    gui_journal.main({
+        save_prefix='test:',
+        save_on_change=options.save_on_change or false,
+        save_layout=options.allow_layout_restore or false
+    })
 
     local journal = gui_journal.view
-    journal.save_on_change = options.save_on_change or false
-
     local journal_window = journal.subviews.journal_window
 
     if not options.allow_layout_restore then
@@ -84,11 +86,11 @@ local function arrange_empty_journal(options)
     end
 
     if options.w then
-        journal_window.frame.w = options.w + 6
+        journal_window.frame.w = options.w + 7
     end
 
     if options.h then
-        journal_window.frame.h = options.h + 5
+        journal_window.frame.h = options.h + 3
     end
 
 
@@ -102,7 +104,7 @@ local function arrange_empty_journal(options)
     if not options.allow_layout_restore then
         local toc_panel = journal_window.subviews.table_of_contents_panel
         toc_panel.visible = false
-        toc_panel.frame.w = 20
+        toc_panel.frame.w = 25
     end
 
     journal:updateLayout()
@@ -2403,7 +2405,7 @@ function test.cut_and_paste_selected_text()
 end
 
 function test.restore_layout()
-    local journal, _ = arrange_empty_journal()
+    local journal, _ = arrange_empty_journal({allow_layout_restore=true})
 
     journal.subviews.journal_window.frame = {
         l = 13,
@@ -2701,7 +2703,7 @@ function test.generate_table_of_contents()
 
     expect.eq(journal.subviews.table_of_contents_panel.visible, false)
 
-    simulate_input_keys('CUSTOM_CTRL_T')
+    simulate_input_keys('CUSTOM_CTRL_O')
 
     expect.eq(journal.subviews.table_of_contents_panel.visible, true)
 
@@ -2753,7 +2755,7 @@ function test.jump_to_table_of_contents_sections()
 
     simulate_input_text(text)
 
-    simulate_input_keys('CUSTOM_CTRL_T')
+    simulate_input_keys('CUSTOM_CTRL_O')
 
     local toc = journal.subviews.table_of_contents
 
@@ -2885,15 +2887,15 @@ function test.resize_table_of_contents_together()
 
     expect.eq(text_area.frame_body.width, 101)
 
-    simulate_input_keys('CUSTOM_CTRL_T')
+    simulate_input_keys('CUSTOM_CTRL_O')
 
-    expect.eq(text_area.frame_body.width, 81)
+    expect.eq(text_area.frame_body.width, 101 - 24)
 
     local toc_panel = journal.subviews.table_of_contents_panel
     -- simulate mouse drag resize of toc panel
     simulate_mouse_drag(toc_panel, toc_panel.frame_body.width, 1, toc_panel.frame_body.width + 10, 1)
 
-    expect.eq(text_area.frame_body.width, 71)
+    expect.eq(text_area.frame_body.width, 101 - 24 - 10)
 
     journal:dismiss()
 end


### PR DESCRIPTION
# Description
![screen](https://github.com/user-attachments/assets/2692af14-fc38-44e3-99bc-4685077b6c7f)

Add table of contents and undo/redo features to the `gui/journal` script.
Notable features:
 - adding line starting from `#` give 1-th level ToC header. `##` and more give more indented ToC links
 - `Ctrl+O` toggle ToC
 - visible "Shifter" button to show/hide ToC
 - ToC panel can be resized by mouse
 - click in ToC entry scroll to given header in the text
 - `CTRL+Z` undo, `CTRL+Y` redo

Bugfixes:
 - 2846 numbers are not longer interpreted as cursor moves

# TODO later
- add buttons to insert new header of 1/2/3 indentation (to ToC panel?)
- stop render text on resize, it is slow
- consider hiding ToC panel (now panel without STYLE_FRAME can not be resized)