### PR TITLE
[makeown] set histfig name as well as unit name

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -38,6 +38,7 @@ Template for new versions:
 - `prioritize`: fix incorrect loading of persisted data on some OS types
 - `list-waves`: no longer gets confused by units that leave the map and then return (e.g. squads who go out on raids)
 - `fix/dead-units`: fix error when removing dead units from burrows and the unit with the greatest ID was dead
+- `makeown`: ensure names given to adopted units (or units created with `gui/sandbox`) are respected later in legends mode
 
 ## Misc Improvements
 - `build-now`: if `suspendmanager` is running, run an unsuspend cycle immediately before scanning for buildings to build

--- a/makeown.lua
+++ b/makeown.lua
@@ -32,6 +32,10 @@ function name_unit(unit)
     unit.name.parts_of_speech.RearCompound = df.part_of_speech.Verb3rdPerson
     unit.name.type = df.language_name_type.Figure
     unit.name.has_name = true
+
+    local hf = df.historical_figure.find(unit.hist_figure_id)
+    if not hf then return end
+    hf.name:assign(unit.name)
 end
 
 local function fix_clothing_ownership(unit)


### PR DESCRIPTION
we were neglecting to copy the generated name to the histfig, causing the unit to lose their name in legends mode