### PR TITLE
[gui/settings-manager] fix position of settings restored message

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -36,6 +36,7 @@ Template for new versions:
 - `gui/unit-info-viewer`: correctly display skill levels when rust is involved
 - `timestream`: fix dwarves spending too long eating and drinking
 - `locate-ore`: fix sometimes selecting an incorrect tile when there are multiple mineral veins in a single map block
+- `gui/settings-manager`: fix position of "settings restored" message on embark when the player has no saved embark profiles
 - `build-now`: fix error when building buildings that (in previous DF versions) required the architecture labor
 - `prioritize`: fix incorrect loading of persisted data on some OS types
 - `list-waves`: no longer gets confused by units that leave the map and then return (e.g. squads who go out on raids)

--- a/gui/settings-manager.lua
+++ b/gui/settings-manager.lua
@@ -173,13 +173,13 @@ DifficultyEmbarkNotificationOverlay.ATTRS {
     default_pos={x=75, y=18},
     viewscreens='setupdwarfgame/Default',
     default_enabled=true,
-    frame={w=23, h=3},
+    frame={w=25, h=3},
 }
 
 function DifficultyEmbarkNotificationOverlay:init()
     self:addviews{
         widgets.Panel{
-            frame={t=0, w=25},
+            frame={h=3, b=0, w=25},
             frame_style=gui.FRAME_MEDIUM,
             frame_background=gui.CLEAR_PEN,
             subviews={
@@ -195,6 +195,12 @@ end
 
 function DifficultyEmbarkNotificationOverlay:preUpdateLayout(parent_rect)
     self.frame.w = parent_rect.width - (self.frame.l or (self.default_pos.x - 1))
+end
+
+function DifficultyEmbarkNotificationOverlay:render(dc)
+    local scr = dfhack.gui.getDFViewscreen(true)
+    self.frame.h = #scr.embark_profile == 0 and 11 or 3
+    DifficultyEmbarkNotificationOverlay.super.render(self, dc)
 end
 
 local last_scr_type


### PR DESCRIPTION
when the player has no saved embark profiles

Fixes: https://github.com/DFHack/dfhack/issues/4811