### PR TITLE
Show a simple tutorial for gui/journal on first use

### DIFF
--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -24,7 +24,14 @@ Happy digging!
 ]=]
 
 local TOC_WELCOME_COPY =  [=[
-Start a line with # symbols and a space to create header.
+Start a line with # symbols and a space to create a header. For example:
+
+# My section heading
+
+or
+
+## My section subheading
+
 Those headers will appear here, and you can click on them to jump to them in the text.
 ]=]
 
@@ -201,7 +208,7 @@ function JournalWindow:loadConfig()
 
     local table_of_contents = copyall(journal_config.data.toc or {})
     table_of_contents.width = table_of_contents.width or 20
-    table_of_contents.visible = table_of_contents.visible or true
+    table_of_contents.visible = table_of_contents.visible or false
 
     return window_frame, table_of_contents.visible, table_of_contents.width or 25
 end

--- a/internal/journal/table_of_contents.lua
+++ b/internal/journal/table_of_contents.lua
@@ -54,6 +54,10 @@ end
 function TableOfContents:previousSection()
     local section_cursor, section = self:currentSection()
 
+    if section == nil then
+        return
+    end
+
     if section.line_cursor == self.text_cursor then
         self.subviews.table_of_contents:setSelected(section_cursor - 1)
     end
@@ -62,10 +66,15 @@ function TableOfContents:previousSection()
 end
 
 function TableOfContents:nextSection()
+    local section_cursor, section = self:currentSection()
+
+    if section == nil then
+        return
+    end
+
     local curr_sel = self.subviews.table_of_contents:getSelected()
 
-    local target_sel = self.text_cursor and
-        self:currentSection() + 1 or curr_sel + 1
+    local target_sel = self.text_cursor and section_cursor + 1 or curr_sel + 1
 
     if curr_sel ~= target_sel then
         self.subviews.table_of_contents:setSelected(target_sel)

--- a/internal/journal/table_of_contents.lua
+++ b/internal/journal/table_of_contents.lua
@@ -98,6 +98,10 @@ function TableOfContents:setCursor(cursor)
     self.text_cursor = cursor
 end
 
+function TableOfContents:sections()
+    return self.subviews.table_of_contents.choices
+end
+
 function TableOfContents:reload(text, cursor)
     if not self.visible then
         return

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -168,6 +168,8 @@ end
 
 function test.load()
     local journal, text_area = arrange_empty_journal()
+    text_area:setText(' ')
+    journal:onRender()
 
     expect.eq('dfhack/lua/journal', dfhack.gui.getCurFocus(true)[1])
     expect.eq(read_rendered_text(text_area), '_')
@@ -3045,5 +3047,24 @@ function test.fast_rewind_reset_selection()
     simulate_input_keys('A_MOVE_E_DOWN')
     expect.eq(read_selected_text(text_area), '')
 
+    journal:dismiss()
+end
+
+function test.show_tutorials_on_first_use()
+    local journal, text_area, journal_window = arrange_empty_journal({w=65})
+    simulate_input_keys('CUSTOM_CTRL_O')
+
+    expect.str_find('Welcome to gui/journal', read_rendered_text(text_area));
+
+    simulate_input_text(' ')
+
+    expect.eq(read_rendered_text(text_area), ' _');
+
+    local toc_panel = journal_window.subviews.table_of_contents_panel
+    expect.str_find('Start a line with\n# symbols', read_rendered_text(toc_panel));
+
+    simulate_input_text('\n# Section 1')
+
+    expect.str_find('Section 1\n', read_rendered_text(toc_panel));
     journal:dismiss()
 end


### PR DESCRIPTION
Show a simple tutorial for gui/journal on first use.

There are 2 tutorials:

1. Main text are tutorial. Its render one line below the text input. Its render only on first usage of the journal in given fort. Dissapearing when user provide any text to the text area
2. Table of contents tutorial - visible always when there is no section in text


Also, from now the table of contents panel is visible by default.