### PR TITLE
[gui/journal] don't include trailing newlines when copying a line

### DIFF
--- a/internal/journal/text_editor.lua
+++ b/internal/journal/text_editor.lua
@@ -369,10 +369,7 @@ function TextEditorView:copy()
         local curr_line = self.text:sub(
             self:lineStartOffset(),
             self:lineEndOffset()
-        )
-        if curr_line:sub(-1,-1) ~= NEWLINE then
-            curr_line = curr_line .. NEWLINE
-        end
+        ):match('^(.-)\n*$')
 
         self:setClipboard(curr_line)
 


### PR DESCRIPTION
it causes artifacts when pasting that line in `gui/launcher` or other edit boxes