### PR TITLE
[gui/design] Update Line & Freeform tools to not overcount tiles

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -39,6 +39,7 @@ Template for new versions:
 ## Fixes
 - `timestream`: ensure child growth events (e.g. becoming an adult) are not skipped over
 - `empty-bin`: ``--liquids`` option correctly emptying containers filled with LIQUID_MISC
+- `gui/design`: Update Line & Freeform tools to not overcount tiles
 
 ## Misc Improvements
 - `gui/sitemap`: show whether a unit is friendly, hostile, or wildlife

--- a/internal/design/shapes.lua
+++ b/internal/design/shapes.lua
@@ -445,8 +445,10 @@ function Line:plot_bresenham(x0, y0, x1, y1, thickness)
         while true do
             for j = -math.floor(thickness / 2), math.ceil(thickness / 2) - 1 do
                 if not self.arr[x + j] then self.arr[x + j] = {} end
-                self.arr[x + j][y] = true
-                self.num_tiles = self.num_tiles + 1
+                if not self.arr[x + j][y] then
+                    self.arr[x + j][y] = true
+                    self.num_tiles = self.num_tiles + 1
+                end
             end
 
             if x == x1 and y == y1 + i then
@@ -641,8 +643,10 @@ function FreeForm:update(points, extra_points)
         for x, y_row in pairs(line_class.arr) do
             for y, _ in pairs(y_row) do
                 if not self.arr[x] then self.arr[x] = {} end
-                self.arr[x][y] = true
-                self.num_tiles = self.num_tiles + 1
+                if not self.arr[x][y] then 
+                    self.arr[x][y] = true
+                    self.num_tiles = self.num_tiles + 1
+                end
             end
         end
     end

--- a/internal/design/shapes.lua
+++ b/internal/design/shapes.lua
@@ -643,7 +643,7 @@ function FreeForm:update(points, extra_points)
         for x, y_row in pairs(line_class.arr) do
             for y, _ in pairs(y_row) do
                 if not self.arr[x] then self.arr[x] = {} end
-                if not self.arr[x][y] then 
+                if not self.arr[x][y] then
                     self.arr[x][y] = true
                     self.num_tiles = self.num_tiles + 1
                 end


### PR DESCRIPTION
Fixes: https://github.com/DFHack/dfhack/issues/3927

### Validations:
Simple line now counts properly:
![image](https://github.com/user-attachments/assets/e8917c34-3183-482c-b0ee-83c7ffeeca11)

Symmetrical double-line now counts property:
![image](https://github.com/user-attachments/assets/a75aad2e-be0f-4316-89fa-fa52e7755be9)

Counts properly even w/incresed line thickness:
![image](https://github.com/user-attachments/assets/ef310dbf-55af-4587-b60e-0e0a56324aef)

Single point curved line still counts properly:
![image](https://github.com/user-attachments/assets/250c4992-91d9-43eb-a8bc-494daaa396e9)

Dual point curved line still counts properly:
![image](https://github.com/user-attachments/assets/ef7801fa-9678-4025-9817-ed9be9c91a6d)

Freeform line which is open now counts properly:
![image](https://github.com/user-attachments/assets/34820fbb-64b3-4f1b-a6e3-ee6467d8b8dd)

Freeform line which is closed now counts properly:
![image](https://github.com/user-attachments/assets/f3a3c7f4-d5b6-4727-96b9-877aeb30556d)

Even the xtra thikk, freeform lines now count properly:
![image](https://github.com/user-attachments/assets/c68c5bae-9b28-4aeb-8425-d2127e0a0f7c)



