### PR TITLE
docs spelling fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -137,7 +137,7 @@ Template for new versions:
 - `caravan`: remember filter settings for pedestal item assignment dialog
 - `quickfort`: new ``delete`` command for deleting player-owned blueprints (library and mod-added blueprints cannot be deleted)
 - `quickfort`: support enabling `logistics` features for autoforbid and autoclaim on stockpiles
-- `gui/quickfort`: allow farm plots, dirt roads, and paved roads to be designated around partial obstructions without callling it an error, matching vanilla behavior
+- `gui/quickfort`: allow farm plots, dirt roads, and paved roads to be designated around partial obstructions without calling it an error, matching vanilla behavior
 - `gui/launcher`: refresh default tag filter when mortal mode is toggled in `gui/control-panel` so changes to which tools autocomplete take effect immediately
 - `gui/civ-alert`: you can now register multiple burrows as civilian alert safe spaces
 - `exterminate`: add ``all`` target for convenient scorched earth tactics
@@ -209,7 +209,7 @@ Template for new versions:
 ## Fixes
 - `open-legends`: don't interfere with the dragging of vanilla list scrollbars
 - `gui/create-item`: properly restrict bags to bag materials by default
-- `gui/create-item`: allow gloves and shoees to be made out of textiles by default
+- `gui/create-item`: allow gloves and shoes to be made out of textiles by default
 - `exterminate`: don't classify dangerous non-invader units as friendly (e.g. snatchers)
 
 ## Misc Improvements
@@ -257,7 +257,7 @@ Template for new versions:
 # 50.12-r2
 
 ## New Tools
-- `agitation-rebalance`: alter mechanics of irriation-related attacks so they are less constant and are more responsive to recent player bahavior
+- `agitation-rebalance`: alter mechanics of irritation-related attacks so they are less constant and are more responsive to recent player behavior
 - `fix/ownership`: fix instances of multiple citizens claiming the same items, resulting in "Store owned item" job loops
 - `fix/stuck-worship`: fix prayer so units don't get stuck in uninterruptible "Worship!" states
 - `instruments`: provides information on how to craft the instruments used by the player civilization
@@ -306,7 +306,7 @@ Template for new versions:
 - `gui/notify`: display important notifications that vanilla doesn't support yet and provide quick zoom links to notification targets.
 - `list-waves`: (reinstated) show migration wave information
 - `make-legendary`: (reinstated) make a dwarf legendary in specified skills
-- `combat-harden`: (reinstated) set a dwarf's resistence to being affected by visible corpses
+- `combat-harden`: (reinstated) set a dwarf's resistance to being affected by visible corpses
 - `add-thought`: (reinstated) add custom thoughts to a dwarf
 - `devel/input-monitor`: interactive UI for debugging input issues
 
@@ -565,7 +565,7 @@ Template for new versions:
 - `workorder`: reduce existing orders for automatic shearing and milking jobs when animals are no longer available
 - `gui/quickfort`: adapt "cursor lock" to mouse controls so it's easier to see the full preview for multi-level blueprints before you apply them
 - `gui/quickfort`: only display post-blueprint messages once when repeating the blueprint up or down z-levels
-- `combine`: reduce max different stacks in containers to 30 to prevent contaners from getting overfull
+- `combine`: reduce max different stacks in containers to 30 to prevent containers from getting overfull
 
 ## Removed
 - `gui/automelt`: replaced by an overlay panel that appears when you click on a stockpile
@@ -597,7 +597,7 @@ Template for new versions:
 ## Misc Improvements
 - `gui/quickfort`: blueprints that designate items for dumping/forbidding/etc. no longer show an error highlight for tiles that have no items on them
 - `gui/quickfort`: place (stockpile layout) mode is now supported. note that detailed stockpile configurations were part of query mode and are not yet supported
-- `gui/quickfort`: you can now generate manager orders for items required to complete bluerpints
+- `gui/quickfort`: you can now generate manager orders for items required to complete blueprints
 - `gui/create-item`: ask for number of items to spawn by default
 - `light-aquifers-only`: now available as a fort Autostart option in `gui/control-panel`. note that it will only appear if "armok" tools are configured to be shown on the Preferences tab.
 - `gui/gm-editor`: when passing the ``--freeze`` option, further ensure that the game is frozen by halting all rendering (other than for DFHack tool windows)
@@ -713,7 +713,7 @@ Template for new versions:
 - `troubleshoot-item`: reports on the contents of containers with counts for each contained item type
 - `devel/visualize-structure`: now automatically inspects the contents of most pointer fields, rather than inspecting the pointers themselves
 - `devel/query`: will now search for jobs at the map coordinate highlighted, if no explicit job is highlighted and there is a map tile highlighted
-- `caravan`: add trade screen overlay that assists with seleting groups of items and collapsing groups in the UI
+- `caravan`: add trade screen overlay that assists with selecting groups of items and collapsing groups in the UI
 - `gui/gm-editor`: will now inspect a selected building itself if the building has no current jobs
 
 ## Removed
@@ -779,7 +779,7 @@ Template for new versions:
 - `gui/quickfort`: don't close the window when applying a blueprint so players can apply the same blueprint multiple times more easily
 - `locate-ore`: now only searches revealed tiles by default
 - `modtools/spawn-liquid`: sets tile temperature to stable levels when spawning water or magma
--@ `prioritize`: pushing minecarts is now included in the default priortization list
+-@ `prioritize`: pushing minecarts is now included in the default prioritization list
 - `prioritize`: now automatically starts boosting the default list of job types when enabled
 - `unforbid`: avoids unforbidding unreachable and underwater items by default
 - `gui/create-item`: added whole corpse spawning alongside corpsepieces. (under "corpse")

--- a/docs/agitation-rebalance.rst
+++ b/docs/agitation-rebalance.rst
@@ -130,7 +130,7 @@ Irritation counters are saved with the cavern layer in the world region, which
 extends beyond the boundaries of your current fort. If you retire a fort and
 start another one nearby, the caverns will retain any irritation added by the
 first fort. This means that new forts may start with already-irritated caverns
-and meet with immediate resistence.
+and meet with immediate resistance.
 
 The settings
 ~~~~~~~~~~~~
@@ -182,7 +182,7 @@ When enabled, this mod makes the following changes:
 
 When agitated wildlife enters the map on the surface, the surface irritation
 counter is set to the value of ``Wilderness irritation minimum``, ensuring
-that the *next* group of widlife that enters the map will *not* be agitated.
+that the *next* group of wildlife that enters the map will *not* be agitated.
 This means that the incursions act more like a warning shot than an open
 floodgate. You will not be attacked again unless you continue your activities
 on the surface that raise the chance of a subsequent attack.
@@ -211,7 +211,7 @@ attacks can still be controlled independently of this mod.
 
 Finally, if you have walled yourself off from the danger in the caverns, yet you
 continue to irritate nature down there, this mod will ensure that the number of
-active cavern invaders, cumulative across all cavern levels, never exeeds the
+active cavern invaders, cumulative across all cavern levels, never exceeds the
 value set for ``Cavern dweller maximum attackers``. This prevents excessive FPS
 loss during gameplay and keeps the number of creatures milling around outside
 your gates (or hidden in the shadows) to a reasonable number.

--- a/docs/caravan.rst
+++ b/docs/caravan.rst
@@ -74,7 +74,7 @@ selected, then the range of items will be selected.
 
 If any current merchants have ethical concerns, the list of goods that you can
 bring to the depot is automatically filtered (by default) to only show
-ethically acceptible items. Be aware that, again, by default, if you have items
+ethically acceptable items. Be aware that, again, by default, if you have items
 in bins, and there are unethical items mixed into the bins, then the bins will
 still be brought to the depot so you can trade the ethical items within those
 bins. Please use the DFHack enhanced trade screen for the actual barter to
@@ -96,7 +96,7 @@ Trade screen
 
 **caravan.trade**
 
-This overlay enables some convenent gestures and keyboard shortcuts for working
+This overlay enables some convenient gestures and keyboard shortcuts for working
 with bins:
 
 - ``Shift-Click checkbox``: Select all items inside a bin without selecting the

--- a/docs/confirm.rst
+++ b/docs/confirm.rst
@@ -5,7 +5,7 @@ confirm
     :summary: Adds confirmation dialogs for destructive actions.
     :tags: fort interface
 
-In the base game, it is frightenly easy to destroy hours of work with a single
+In the base game, it is frighteningly easy to destroy hours of work with a single
 misclick. Now you can avoid the consequences of accidentally disbanding a squad
 (for example), or deleting a hauling route.
 

--- a/docs/devel/dump-tooltip-ids.rst
+++ b/docs/devel/dump-tooltip-ids.rst
@@ -19,7 +19,7 @@ as item 500, but we detect that caption at position 501 in ``main_interface.hove
 produced by the script will include the above element at position 501 instead of 500.
 
 Before running this script, the size of ``main_interface.hover_instruction`` must be aligned properly with the
-loaded verison of DF so the array of strings can be read.
+loaded version of DF so the array of strings can be read.
 
 Usage
 -----

--- a/docs/devel/input-monitor.rst
+++ b/docs/devel/input-monitor.rst
@@ -11,7 +11,7 @@ and mouse device.
 The labels for Shift, Ctrl, and Alt light up when those modifier keys are being
 held down.
 
-Similar lables for left, middle, and right mouse buttons light up when any of
+Similar labels for left, middle, and right mouse buttons light up when any of
 those buttons are being held down.
 
 The input stream panel shows the keybindings that are being triggered. You can

--- a/docs/devel/spawn-unit-helper.rst
+++ b/docs/devel/spawn-unit-helper.rst
@@ -13,8 +13,8 @@ Usage
 
 1. Enter the :kbd:`k` menu and change mode using
     ``rb_eval df.gametype = :DWARF_ARENA``
-2. Spawn creatures with the normal arena mode UI (:kbd:`c` ingame)
-3. Revert to forgress mode using
+2. Spawn creatures with the normal arena mode UI (:kbd:`c` in-game)
+3. Revert to fortress mode using
     ``rb_eval df.gametype = #{df.gametype.inspect}``
 4. To convert spawned creatures to livestock, select each one with the :kbd:`v`
     menu, and enter ``rb_eval df.unit_find.civ_id = df.ui.civ_id``

--- a/docs/fix/dead-units.rst
+++ b/docs/fix/dead-units.rst
@@ -32,4 +32,4 @@ Options
 ``--burrow``
     Scrub dead units from burrow membership lists.
 ``-q``, ``--quiet``
-    Surpress console output (final status update is still printed if at least one item was affected).
+    Suppress console output (final status update is still printed if at least one item was affected).

--- a/docs/fix/empty-wheelbarrows.rst
+++ b/docs/fix/empty-wheelbarrows.rst
@@ -26,12 +26,12 @@ Examples
 ``fix/empty-wheelbarrows --dry-run``
     Lists all wheelbarrows that would be emptied and their contents without performing the action.
 ``fix/empty-wheelbarrows --quiet``
-    Does the action while surpressing output to console.
+    Does the action while suppressing output to console.
 
 Options
 -------
 
 ``-q``, ``--quiet``
-    Surpress console output (final status update is still printed if at least one item was affected).
+    Suppress console output (final status update is still printed if at least one item was affected).
 ``-d``, ``--dry-run``
     Dry run, don't commit changes.

--- a/docs/fix/sleepers.rst
+++ b/docs/fix/sleepers.rst
@@ -7,7 +7,7 @@ fix/sleepers
 
 Fixes :bug:`6798`. This bug is characterized by sleeping units who refuse to
 awaken in adventure mode regardless of talking to them, hitting them, or waiting
-so long you die of thirst. If you come accross one or more bugged sleepers in
+so long you die of thirst. If you come across one or more bugged sleepers in
 adventure mode, simply run the script and all nearby sleepers will be cured.
 
 Usage

--- a/docs/gui/journal.rst
+++ b/docs/gui/journal.rst
@@ -14,7 +14,7 @@ and both short-term and long-term plans.
 
 This is particularly useful when you need to take a longer break from the game.
 Having detailed notes makes it much easier to resume your game after
-a few weekds or months, without losing track of your progress and objectives.
+a few weeks or months, without losing track of your progress and objectives.
 
 Supported Features
 ------------------

--- a/docs/gui/launcher.rst
+++ b/docs/gui/launcher.rst
@@ -118,7 +118,7 @@ Default tag filters
 By default, commands intended for developers and modders are filtered out of the
 autocomplete list. This includes any tools tagged with ``unavailable``. If you
 have "mortal mode" enabled in the `gui/control-panel` preferences, any tools
-with the ``armok`` tag are filterd out as well.
+with the ``armok`` tag are filtered out as well.
 
 You can toggle this default filtering by hitting :kbd:`Ctrl`:kbd:`D` to switch
 into "Dev mode" at any time. You can also adjust your command filters in the

--- a/docs/gui/settings-manager.rst
+++ b/docs/gui/settings-manager.rst
@@ -45,7 +45,7 @@ automatically restored when you embark on a new fort. This will toggle the
 relevant command in `gui/control-panel` on the Automation -> Autostart page.
 
 There is a similar panel on the Labor -> Work Details page that allows for
-saving and restoring of work detail definitons. Be aware that work detail
+saving and restoring of work detail definitions. Be aware that work detail
 assignments to units cannot be saved, so you have to assign the work details to
 individual units after you restore the definitions. Another caveat is that DF
 doesn't evaluate work detail definitions until a change (any change) is made on

--- a/docs/gui/teleport.rst
+++ b/docs/gui/teleport.rst
@@ -14,7 +14,7 @@ pre-selected for teleport.
 Note that you *can* select enemies that are lying in ambush and are not visible
 on the map yet, so you if you select an area and see a marker that indicates
 that a unit is selected, but you don't see the unit itself, this is likely what
-it is. You can stil teleport these units while they are hidden.
+it is. You can still teleport these units while they are hidden.
 
 Usage
 -----

--- a/docs/gui/tiletypes.rst
+++ b/docs/gui/tiletypes.rst
@@ -79,7 +79,7 @@ smooth. Note that when creating walls, they will inherit the smoothness
 property of whatever was there before unless you specifically set the Special
 selector to ``NORMAL`` (for rough walls) or ``SMOOTH`` (for smooth walls).
 
-Extended special properties are avaialable via the gear button.
+Extended special properties are available via the gear button.
 
 Variant
 ~~~~~~~

--- a/docs/list-waves.rst
+++ b/docs/list-waves.rst
@@ -20,7 +20,7 @@ Usage
 
     list-waves [<wave num> ...] [<options>]
 
-You can show only information about specific waves by specifing the wave
+You can show only information about specific waves by specifying the wave
 numbers on the commandline. Otherwise, all waves are shown. The first migration
 wave that normally arrives in a fort's second season is wave number 1. The
 founding dwarves arrive in wave 0.

--- a/docs/modtools/set-need.rst
+++ b/docs/modtools/set-need.rst
@@ -28,9 +28,9 @@ Valid need targets:
 
 :need <ID>:
     ID of the need to target. For example 0 or DrinkAlcohol.
-    If the need is PrayOrMedidate, a -deity argument is also required.
+    If the need is PrayOrMeditate, a -deity argument is also required.
 :deity <HISTFIG ID>:
-    Required when using PrayOrMedidate needs. This value should be the historical figure ID of the deity in question.
+    Required when using PrayOrMeditate needs. This value should be the historical figure ID of the deity in question.
 :all:
     All of the target's needs will be affected.
 

--- a/docs/modtools/syndrome-trigger.rst
+++ b/docs/modtools/syndrome-trigger.rst
@@ -13,9 +13,9 @@ Usage
 
 ::
 
-    modutils/syndrome-trigger --clear
-    modutils/syndrome-trigger --syndrome <name> --command [ <command> ]
-    modutils/syndrome-trigger --synclass <class> --command [ <command> ]
+    modtools/syndrome-trigger --clear
+    modtools/syndrome-trigger --syndrome <name> --command [ <command> ]
+    modtools/syndrome-trigger --synclass <class> --command [ <command> ]
 
 Options
 -------
@@ -41,4 +41,4 @@ Examples
 
 ::
 
-    modutils/syndrome-trigger --synclass VAMPCURSE --command [ modtools/spawn-flow -flowType Dragonfire -location [ \\LOCATION ] ]
+    modtools/syndrome-trigger --synclass VAMPCURSE --command [ modtools/spawn-flow -flowType Dragonfire -location [ \\LOCATION ] ]


### PR DESCRIPTION
Here are some spelling fixes for `scripts`.

I made separate commits for a couple of "code" references (an enum member, and a DFHack path). The new spellings for these seem to be correct:
- `df.need_type[2]` gives `PrayOrMeditate`
- `syndrome-trigger` is under `modtools` in code and docs