### PR TITLE
position.lua: additional info, option to copy cursor pos

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -36,6 +36,7 @@ Template for new versions:
 - `caravan`: If you have managed to select an item that is ethically unacceptable to the merchant, an "Ethics warning" badge will now appear next to the "Trade" button. Clicking on the badge will show you which items that you have selected are problematic. The dialog has a button that you can click to deselect the problematic items in the trade list.
 - `confirm`: If you have ethically unacceptable items selected for trade, the "Are you sure you want to trade" confirmation will warn you about them
 - `quickfort`: ``#zone`` blueprints now integrated with `preserve-rooms` so you can create a zone and automatically assign it to a noble or administrative role
+- `position`: option to copy cursor position to clipboard
 
 ## Fixes
 - `timestream`: ensure child growth events (e.g. becoming an adult) are not skipped
@@ -46,6 +47,7 @@ Template for new versions:
 - `gui/sitemap`: show whether a unit is friendly, hostile, or wild
 - `gui/sitemap`: show whether a unit is caged
 - `gui/control-panel`: include option for turning off dumping of old clothes for `tailor`, for players who have magma pit dumps and want to save old clothes from being dumped into the magma
+- `position`: report current historical era (e.g., "Age of Myth")
 
 ## Removed
 

--- a/docs/position.rst
+++ b/docs/position.rst
@@ -5,13 +5,30 @@ position
     :summary: Report cursor and mouse position, along with other info.
     :tags: fort inspection map
 
-This tool reports the current date, clock time, month, and season. It also
-reports the cursor position (or just the z-level if no cursor), window size, and
-mouse location on the screen.
+This tool reports the current date, clock time, month, season, and historical
+era. It also reports the keyboard cursor position (or just the z-level if no
+active cursor), window size, and mouse location on the screen.
+
+Can also be used to copy the current cursor position for later use.
 
 Usage
 -----
 
 ::
 
-    position
+    position [--copy]
+
+Examples
+--------
+
+``position``
+    Print various information.
+``position -c``
+    Copy cursor position to system clipboard.
+
+Options
+-------
+
+``-c``, ``--copy``
+    Copy current keyboard cursor position to the clipboard in format ``0,0,0``
+    instead of reporting info. For convenience with other tools.

--- a/docs/position.rst
+++ b/docs/position.rst
@@ -9,7 +9,7 @@ This tool reports the current date, clock time, month, season, and historical
 era. It also reports the keyboard cursor position (or just the z-level if no
 active cursor), window size, and mouse location on the screen.
 
-Can also be used to copy the current cursor position for later use.
+Can also be used to copy the current keyboard cursor position for later use.
 
 Usage
 -----

--- a/position.lua
+++ b/position.lua
@@ -1,3 +1,19 @@
+
+local cursor = df.global.cursor
+local args = {...}
+if #args > 0 then --Copy keyboard cursor to clipboard
+    if #args > 1 then
+        qerror('Too many arguments!')
+    elseif args[1] ~= '-c' and args[1] ~= '--copy' then
+        qerror('Invalid argument "'..args[1]..'"!')
+    elseif cursor.x < 0 then
+        qerror('No keyboard cursor!')
+    end
+
+    dfhack.internal.setClipboardTextCp437(('%d,%d,%d'):format(cursor.x, cursor.y, cursor.z))
+    return
+end
+
 local months = {
     'Granite, in early Spring.',
     'Slate, in mid Spring.',
@@ -30,11 +46,15 @@ print('Time:')
 print('    The time is '..string.format('%02d:%02d:%02d', hour, minute, second))
 print('    The date is '..string.format('%05d-%02d-%02d', df.global.cur_year, month, day))
 print('    It is the month of '..months[month])
---TODO:  print('    It is the Age of '..age_name)
+
+local eras = df.global.world.history.eras
+if #eras > 0 then
+    print('    It is the '..eras[#eras-1].title.name..'.')
+end
 
 print('Place:')
 print('    The z-level is z='..df.global.window_z)
-print('    The cursor is at x='..df.global.cursor.x..', y='..df.global.cursor.y)
+print('    The cursor is at x='..cursor.x..', y='..cursor.y)
 print('    The window is '..df.global.gps.dimx..' tiles wide and '..df.global.gps.dimy..' tiles high')
 if df.global.gps.mouse_x == -1 then print('    The mouse is not in the DF window') else
 print('    The mouse is at x='..df.global.gps.mouse_x..', y='..df.global.gps.mouse_y..' within the window') end


### PR DESCRIPTION
Adds an option (`-c`, `--copy`) to copy the current cursor position to the system clipboard.

Also implements display of the current historical era.

Fort site position isn't implemented yet. We might want to handle adventurer world position along with that (refer to #1194 for how that's done w/r/t travel map).