### PR TITLE
`notes` script

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ Template for new versions:
 - `embark-anyone`: allows you to embark as any civilization, including dead and non-dwarven ones
 - `idle-crafting`: allow dwarves to independently satisfy their need to craft objects
 - `gui/family-affairs`: (reinstated) inspect or meddle with pregnancies, marriages, or lover relationships
+- `notes`: Manage map-specific notes
 
 ## New Features
 - `caravan`: DFHack dialogs for trade screens (both ``Bring goods to depot`` and the ``Trade`` barter screen) can now filter by item origins (foreign vs. fort-made) and can filter bins by whether they have a mix of ethically acceptable and unacceptable items in them

--- a/docs/notes.rst
+++ b/docs/notes.rst
@@ -2,7 +2,7 @@ notes
 =====
 
 .. dfhack-tool::
-    :summary: Manage map-specific notes
+    :summary: Manage map-specific notes.
     :tags: fort interface map
 
 The `notes` tool enables players to annotate specific tiles
@@ -25,18 +25,18 @@ Usage
 Add new note in the current position of the keyboard cursor.
 
 Creating a Note
-~~~~~~~~~~~~~~~
+---------------
 1. Use the keyboard cursor to select the desired map tile where you want to place a note.
 2. Execute ``notes add`` via the DFHack console.
 3. In the pop-up dialog, fill in the note's title and detailed comment.
 4. Press :kbd:`Alt` + :kbd:`S` to create the note.
 
 Editing or Deleting a Note
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------
 - Click on the green pin representing the note directly on the map.
 - A dialog will appear, offering options to edit the title or comment, or to delete the note entirely.
 
 Managing Notes Visibility
-~~~~~~~~~~~~~~~~~~~~~~~~~
-- Access the ``DFHack Control Panel`` / ``UI Overlays`` tab.
+-------------------------
+- Access the `gui/control-panel` / ``UI Overlays`` tab.
 - Toggle the ``notes.map-notes`` overlay to show or hide the notes on the map.

--- a/docs/notes.rst
+++ b/docs/notes.rst
@@ -1,0 +1,42 @@
+notes
+=====
+
+.. dfhack-tool::
+    :summary: Manage map-specific notes
+    :tags: fort interface map
+
+The `notes` tool enables players to annotate specific tiles
+on the Dwarf Fortress game map with customizable notes.
+
+Each note is displayed as a green pin on the map and includes a one-line title and a detailed comment.
+
+It can be used to e.g.:
+ - marking plans for future constructions
+ - explaining mechanisms or traps
+ - noting historical events
+
+Usage
+-----
+
+::
+
+    notes add
+
+Add new note in the current position of the keyboard cursor.
+
+Creating a Note
+~~~~~~~~~~~~~~~
+1. Use the keyboard cursor to select the desired map tile where you want to place a note.
+2. Execute ``notes add`` via the DFHack console.
+3. In the pop-up dialog, fill in the note's title and detailed comment.
+4. Press :kbd:`Alt` + :kbd:`S` to create the note.
+
+Editing or Deleting a Note
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+- Click on the green pin representing the note directly on the map.
+- A dialog will appear, offering options to edit the title or comment, or to delete the note entirely.
+
+Managing Notes Visibility
+~~~~~~~~~~~~~~~~~~~~~~~~~
+- Access the ``DFHack Control Panel`` / ``UI Overlays`` tab.
+- Toggle the ``notes.map-notes`` overlay to show or hide the notes on the map.

--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -123,6 +123,7 @@ function JournalWindow:init()
             on_text_change=self:callback('onTextChange'),
             on_cursor_change=self:callback('onCursorChange'),
         },
+        widgets.HelpButton{command="gui/journal", frame={r=0,t=1}},
         widgets.Panel{
             frame={l=0,r=0,b=1,h=1},
             frame_inset={l=1,r=1,t=0, w=100},

--- a/internal/journal/table_of_contents.lua
+++ b/internal/journal/table_of_contents.lua
@@ -37,12 +37,12 @@ function TableOfContents:init()
 
     local function can_prev()
         local toc = self.subviews.table_of_contents
-        return #toc:getChoices() > 0 and toc:getSelected() > 1
+        return #toc:getChoices() > 0
     end
     local function can_next()
         local toc = self.subviews.table_of_contents
         local num_choices = #toc:getChoices()
-        return num_choices > 0 and toc:getSelected() < num_choices
+        return num_choices > 0
     end
 
     self:addviews{

--- a/internal/journal/text_editor.lua
+++ b/internal/journal/text_editor.lua
@@ -234,7 +234,7 @@ function TextEditor:onInput(keys)
         return self.subviews.scrollbar:onInput(keys)
     end
 
-    if keys._MOUSE_L then
+    if keys._MOUSE_L and self:getMousePos() then
         self:setFocus(true)
     end
 

--- a/internal/journal/text_editor.lua
+++ b/internal/journal/text_editor.lua
@@ -123,8 +123,7 @@ function TextEditor:init()
             view_id='scrollbar',
             frame={r=0,t=1},
             on_scroll=self:callback('onScrollbar')
-        },
-        widgets.HelpButton{command="gui/journal", frame={r=0,t=0}}
+        }
     }
     self:setFocus(true)
 end

--- a/internal/journal/text_editor.lua
+++ b/internal/journal/text_editor.lua
@@ -169,14 +169,14 @@ function TextEditor:setCursor(cursor_offset)
 end
 
 function TextEditor:getPreferredFocusState()
-    return true
+    return self.parent_view.focus
 end
 
 function TextEditor:postUpdateLayout()
     self:updateScrollbar(self.render_start_line_y)
 
     if self.subviews.text_area.cursor == nil then
-        local cursor = self.init_cursor or #self.text + 1
+        local cursor = self.init_cursor or #self.init_text + 1
         self.subviews.text_area:setCursor(cursor)
         self:scrollToCursor(cursor)
     end
@@ -232,6 +232,10 @@ end
 function TextEditor:onInput(keys)
     if (self.subviews.scrollbar.is_dragging) then
         return self.subviews.scrollbar:onInput(keys)
+    end
+
+    if keys._MOUSE_L then
+        self:setFocus(true)
     end
 
     return TextEditor.super.onInput(self, keys)
@@ -629,6 +633,8 @@ function TextEditorView:onInput(keys)
         self:paste()
         self.history:store(HISTORY_ENTRY.OTHER, self.text, self.cursor)
         return true
+    else
+        return TextEditor.super.onInput(self, keys)
     end
 end
 

--- a/notes.lua
+++ b/notes.lua
@@ -7,7 +7,12 @@ local overlay = require('plugins.overlay')
 local guidm = require('gui.dwarfmode')
 local text_editor = reqscript('internal/journal/text_editor')
 
-local green_pin = dfhack.textures.loadTileset('hack/data/art/note-green-pin.png', 32, 32, true)
+local green_pin = dfhack.textures.loadTileset(
+    'hack/data/art/note_green_pin_map.png',
+    32,
+    32,
+    true
+)
 
 NotesOverlay = defclass(NotesOverlay, overlay.OverlayWidget)
 NotesOverlay.ATTRS{
@@ -171,7 +176,8 @@ function NoteManager:init()
                     frame={t=1,h=3},
                     frame_style=gui.FRAME_INTERIOR,
                     init_text=self.note and self.note.point.name or '',
-                    init_cursor=1
+                    init_cursor=1,
+                    one_line_mode=true
                 },
                 widgets.HotkeyLabel {
                     key='CUSTOM_ALT_C',

--- a/notes.lua
+++ b/notes.lua
@@ -15,8 +15,10 @@ NotesOverlay.ATTRS{
     viewscreens='dwarfmode',
     default_enabled=true,
     overlay_onupdate_max_freq_seconds=30,
-    fullscreen=true,
 }
+
+local waypoints = df.global.plotinfo.waypoints
+local map_notes = df.global.plotinfo.waypoints.points
 
 function NotesOverlay:init()
     self.notes = {}
@@ -35,11 +37,14 @@ end
 
 function NotesOverlay:onInput(keys)
     if keys._MOUSE_L then
-        local pos = dfhack.gui.getMousePos()
+        local top_most_screen = dfhack.gui.getDFViewscreen(true)
+        if dfhack.gui.matchFocusString('dwarfmode/Default', top_most_screen) then
+            local pos = dfhack.gui.getMousePos()
 
-        local note = self:clickedNote(pos)
-        if note ~= nil then
-            self:showNoteManager(note)
+            local note = self:clickedNote(pos)
+            if note ~= nil then
+                self:showNoteManager(note)
+            end
         end
     end
 end
@@ -52,11 +57,9 @@ function NotesOverlay:clickedNote(click_pos)
 
     self.last_click_pos = click_pos
 
-    local notes = df.global.plotinfo.waypoints.points
-
     local last_note_on_pos = nil
     local first_note_on_pos = nil
-    for _, note in pairs(notes) do
+    for _, note in ipairs(map_notes) do
         if same_xyz(note.pos, click_pos) then
             if last_note_on_pos == pos_curr_note then
                 return note
@@ -122,7 +125,7 @@ function NotesOverlay:reloadVisibleNotes()
         z=df.global.window_z
     }
 
-    for _, point in ipairs(df.global.plotinfo.waypoints.points) do
+    for _, point in ipairs(map_notes) do
         if viewport:isVisible(point.pos) then
             local pos = viewport:tileToScreen(point.pos)
             table.insert(self.notes, {
@@ -135,8 +138,7 @@ end
 
 NoteManager = defclass(NoteManager, gui.ZScreen)
 NoteManager.ATTRS{
-    focus_path='hotspot/menu',
-    hotspot_frame=DEFAULT_NIL,
+    focus_path='notes/note-manager',
     note=DEFAULT_NIL,
     on_update=DEFAULT_NIL,
 }
@@ -148,7 +150,6 @@ function NoteManager:init()
         widgets.Window{
             frame={w=35,h=20},
             frame_inset={t=1},
-            autoarrange_subviews=false,
             subviews={
                 widgets.HotkeyLabel {
                     key='CUSTOM_ALT_N',
@@ -158,50 +159,51 @@ function NoteManager:init()
                 },
                 text_editor.TextEditor{
                     view_id='name',
-                    focus_path='notes/name',
                     frame={t=1,h=3},
                     frame_style=gui.FRAME_INTERIOR,
-                    frame_style_b=nil,
                     init_text=self.note and self.note.name or ''
                 },
                 widgets.HotkeyLabel {
                     key='CUSTOM_ALT_C',
                     label='Comment',
-                    frame={t=4},
+                    frame={t=5},
                     on_activate=function() self.subviews.comment:setFocus(true) end,
                 },
                 text_editor.TextEditor{
                     view_id='comment',
-                    frame={t=5,b=3},
-                    focus_path='notes/comment',
+                    frame={t=6,b=3},
                     frame_style=gui.FRAME_INTERIOR,
                     init_text=self.note and self.note.comment or ''
                 },
                 widgets.Panel{
                     view_id='buttons',
-                    frame={b=0,h=3},
+                    frame={b=0,h=2},
                     autoarrange_subviews=true,
                     subviews={
-                        edit_mode and widgets.TextButton{
+                        widgets.HotkeyLabel{
                             view_id='Save',
                             frame={h=1},
                             label='Save',
                             key='CUSTOM_ALT_S',
+                            visible=edit_mode,
                             on_activate=function() self:saveNote() end,
                             enabled=function() return #self.subviews.name:getText() > 0 end,
-                        } or widgets.TextButton{
+                        },
+                        widgets.HotkeyLabel{
                             view_id='Create',
                             frame={h=1},
                             label='Create',
                             key='CUSTOM_ALT_S',
+                            visible=not edit_mode,
                             on_activate=function() self:createNote() end,
                             enabled=function() return #self.subviews.name:getText() > 0 end,
                         },
-                        edit_mode and widgets.TextButton{
+                        widgets.HotkeyLabel{
                             view_id='delete',
                             frame={h=1},
                             label='Delete',
                             key='CUSTOM_ALT_D',
+                            visible=edit_mode,
                             on_activate=function() self:deleteNote() end,
                         } or nil,
                     }
@@ -212,8 +214,8 @@ function NoteManager:init()
 end
 
 function NoteManager:createNote()
-    local x, y, z = pos2xyz(df.global.cursor)
-    if x == nil then
+    local cursor_pos = guidm.getCursorPos()
+    if cursor_pos == nil then
         print('Enable keyboard cursor to add a note.')
         return
     end
@@ -222,14 +224,12 @@ function NoteManager:createNote()
     local comment = self.subviews.comment:getText()
 
     if #name == 0 then
-        print('Note need at least a name')
+        dfhack.printerr('Note need at least a name')
         return
     end
 
-    local waypoints = df.global.plotinfo.waypoints
-    local notes = df.global.plotinfo.waypoints.points
 
-    notes:insert("#", {
+    map_notes:insert("#", {
         new=true,
 
         id = waypoints.next_point_id,
@@ -238,7 +238,7 @@ function NoteManager:createNote()
         bg_color=0,
         name=name,
         comment=comment,
-        pos=xyz2pos(x, y, z)
+        pos=cursor_pos
     })
     waypoints.next_point_id = waypoints.next_point_id + 1
 
@@ -258,11 +258,10 @@ function NoteManager:saveNote()
     local comment = self.subviews.comment:getText()
 
     if #name == 0 then
-        print('Note need at least a name')
+        dfhack.printerr('Note need at least a name')
         return
     end
 
-    local notes = df.global.plotinfo.waypoints.points
     self.note.name = name
     self.note.comment = comment
 
@@ -278,9 +277,9 @@ function NoteManager:deleteNote()
         return
     end
 
-    for ind, note in pairs(df.global.plotinfo.waypoints.points) do
-        if note == self.note then
-            df.global.plotinfo.waypoints.points:erase(ind)
+    for ind, note in pairs(map_notes) do
+        if note.id == self.note.id then
+            map_notes:erase(ind)
             break
         end
     end
@@ -307,9 +306,9 @@ local function main(args)
     end
 
     if args[1] == 'add' then
-        local x = pos2xyz(df.global.cursor)
-        if x == nil then
-            print('Enable keyboard cursor to add a note.')
+        local cursor_pos = guidm.getCursorPos()
+        if cursor_pos == nil then
+            dfhack.printerr('Enable keyboard cursor to add a note.')
             return
         end
 

--- a/notes.lua
+++ b/notes.lua
@@ -163,7 +163,8 @@ function NoteManager:init()
                     view_id='name',
                     frame={t=1,h=3},
                     frame_style=gui.FRAME_INTERIOR,
-                    init_text=self.note and self.note.point.name or ''
+                    init_text=self.note and self.note.point.name or '',
+                    init_cursor=1
                 },
                 widgets.HotkeyLabel {
                     key='CUSTOM_ALT_C',
@@ -175,7 +176,8 @@ function NoteManager:init()
                     view_id='comment',
                     frame={t=6,b=3},
                     frame_style=gui.FRAME_INTERIOR,
-                    init_text=self.note and self.note.point.comment or ''
+                    init_text=self.note and self.note.point.comment or '',
+                    init_cursor=1
                 },
                 widgets.Panel{
                     view_id='buttons',

--- a/notes.lua
+++ b/notes.lua
@@ -131,7 +131,9 @@ function NotesOverlay:reloadVisibleNotes()
     }
 
     for _, map_point in ipairs(map_points) do
-        if viewport:isVisible(map_point.pos) then
+        if (viewport:isVisible(map_point.pos)
+            and map_point.name ~= nil and #map_point.name > 0)
+        then
             local screen_pos = viewport:tileToScreen(map_point.pos)
             table.insert(self.visible_notes, {
                 point=map_point,

--- a/notes.lua
+++ b/notes.lua
@@ -1,0 +1,181 @@
+--@ module = true
+
+local gui = require('gui')
+local widgets = require('gui.widgets')
+local textures = require('gui.textures')
+local overlay = require('plugins.overlay')
+local guidm = require('gui.dwarfmode')
+local text_editor = reqscript('internal/journal/text_editor')
+
+-- local green_pin = dfhack.textures.loadTileset('hack/data/art/green-pin.png', 8, 12, true),
+
+-- NotesView = defclass(NotesView, gui.View)
+-- NotesView.ATTRS{}
+
+NotesOverlay = defclass(NotesOverlay, overlay.OverlayWidget)
+NotesOverlay.ATTRS{
+    desc='Render map notes.',
+    viewscreens='dwarfmode',
+    default_enabled=true,
+    -- TODO increase to 30 seconds
+    overlay_onupdate_max_freq_seconds=1,
+    hotspot=true,
+    fullscreen=true,
+}
+
+function NotesOverlay:init()
+end
+
+function NotesOverlay:onRenderFrame(dc)
+    if not df.global.pause_state and not dfhack.screen.inGraphicsMode() then
+        return
+    end
+
+    dc:map(true)
+    -- local texpos = dfhack.textures.getTexposByHandle(green_pin[1])
+    local texpos = textures.tp_green_pin(1)
+    local color, ch = COLOR_RED, 'X'
+    dc:pen({ch='X', fg=COLOR_GREEN, bg=COLOR_BLACK, tile=texpos})
+
+    local viewport = guidm.Viewport.get()
+
+    for _, point in ipairs(df.global.plotinfo.waypoints.points) do
+        if viewport:isVisible(point.pos) then
+            local pos = viewport:tileToScreen(point.pos)
+            dc
+                :seek(pos.x, pos.y)
+                :tile()
+        end
+    end
+
+    dc:map(false)
+
+end
+
+NoteManager = defclass(NoteManager, gui.ZScreen)
+NoteManager.ATTRS{
+    focus_path='hotspot/menu',
+    hotspot_frame=DEFAULT_NIL,
+}
+
+function NoteManager:init()
+    self:addviews{
+        widgets.Window{
+            frame={w=35,h=20},
+            frame_inset={t=1},
+            autoarrange_subviews=false,
+            subviews={
+                widgets.HotkeyLabel {
+                    key='CUSTOM_ALT_N',
+                    label='Name',
+                    frame={t=0},
+                    on_activate=function() self.subviews.name:setFocus(true) end,
+                },
+                text_editor.TextEditor{
+                    view_id='name',
+                    focus_path='notes/name',
+                    frame={t=1,h=3},
+                    frame_style=gui.FRAME_INTERIOR,
+                    frame_style_b=nil,NoteManager
+                },
+                widgets.HotkeyLabel {
+                    key='CUSTOM_ALT_C',
+                    label='Comment',
+                    frame={t=4},
+                    on_activate=function() self.subviews.comment:setFocus(true) end,
+                },
+                text_editor.TextEditor{
+                    view_id='comment',
+                    frame={t=5,b=3},
+                    focus_path='notes/comment',
+                    frame_style=gui.FRAME_INTERIOR,
+                },
+                widgets.Panel{
+                    view_id='buttons',
+                    frame={b=0,h=3},
+                    autoarrange_subviews=true,
+                    subviews={
+                        widgets.TextButton{
+                            view_id='Create',
+                            frame={h=1},
+                            label='Create',
+                            key='CUSTOM_ALT_S',
+                            on_activate=function() self:createNote() end,
+                            enabled=function() return #self.subviews.name:getText() > 0 end,
+                        },
+                        widgets.TextButton{
+                            view_id='cancel',
+                            frame={h=1},
+                            label='Cancel',
+                            key='LEAVESCREEN'
+                        },
+                        widgets.TextButton{
+                            view_id='delete',
+                            frame={h=1},
+                            label='Delete',
+                            key='CUSTOM_ALT_D',
+                        },
+                    }
+                }
+            },
+        },
+    }
+end
+
+function NoteManager:createNote()
+    local name = self.subviews.name:getText()
+    local comment = self.subviews.comment:getText()
+
+    if #name == 0 then
+        print('Note need at least a name')
+        return
+    end
+
+    local waypoints = df.global.plotinfo.waypoints
+    local notes = df.global.plotinfo.waypoints.points
+
+    local x, y, z = pos2xyz(df.global.cursor)
+    if x == nil then
+        print('Enable keyboard cursor to add a note.')
+        return
+    end
+
+    notes:insert("#", {
+        new=true,
+
+        id = waypoints.next_point_id,
+        tile=88,
+        fg_color=7,
+        bg_color=0,
+        name=name,
+        comment=comment,
+        pos=xyz2pos(x, y, z)
+    })
+    waypoints.next_point_id = waypoints.next_point_id + 1
+    self:dismiss()
+end
+
+-- register widgets
+OVERLAY_WIDGETS = {
+    map_notes=NotesOverlay
+}
+
+local function main(args)
+    if #args == 0 then
+        return
+    end
+
+    if args[1] == 'add' then
+        local x = pos2xyz(df.global.cursor)
+        if x == nil then
+            print('Enable keyboard cursor to add a note.')
+            return
+        end
+
+        return NoteManager{}:show()
+    end
+end
+
+if not dfhack_flags.module then
+    main({...})
+end

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -77,7 +77,7 @@ local function arrange_empty_journal(options)
     gui_journal.main({
         save_prefix='test:',
         save_on_change=options.save_on_change or false,
-        save_layout=options.allow_layout_restore or false
+        save_layout=options.allow_layout_restore or false,
     })
 
     local journal = gui_journal.view
@@ -3068,3 +3068,6 @@ function test.show_tutorials_on_first_use()
     expect.str_find('Section 1\n', read_rendered_text(toc_panel));
     journal:dismiss()
 end
+
+-- TODO: separate journal tests from TextEditor tests
+-- add "one_line_mode" tests


### PR DESCRIPTION
# Notes
This PR introduce notes feature that allows to add simple notes to the game map.

![screen](https://github.com/user-attachments/assets/f051a84e-960e-46a8-9e6e-8c6b8541d8cd)

Features:
 - `notes add` to add new note to the map (in place of keyboard cursor)
 - enable `notes.map_notes` overlay to render notes on the map as green pins
 - click on map notes to open note details and edit screen
 - click few times to toggle between notes if they are all in the same tile
 - the overlay has been written with performance in mind (and profiled)

TODO:
- [x] documentation
- [x] way to trigger note modal in ASCII mode
- [x] one-line-mode for text editor, for the note name
- [x] move `?` button from the text area component to the journal itself