### PR TITLE
modtools/create-item

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,10 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `gui/create-item`: fix items of type "VERMIN", "PET", "REMANS", "FISH", "RAW FISH", and "EGG" no longer spawn creature item "nothing."
+Items will now spawn correctly, and will be of the creature type and creature caste that selected by the user. Items of these  types will also stack correctly when needed.
+- `modtools/create-item`:  fix items of type "VERMIN", "PET", "REMANS", "FISH", "RAW FISH", and "EGG" no longer spawn creature item "nothing"s.
+Items will now spawn correctly, and will be of the creature type and creature caste that selected by the user. Items of these  types will also stack correctly when needed.
 
 ## Misc Improvements
 

--- a/modtools/create-item.lua
+++ b/modtools/create-item.lua
@@ -1,5 +1,6 @@
 -- creates an item of a given type and material
 --author expwnent
+--In the year 2024 dikbutdagrate assumed the identity of tjudge1 and edited this file. Now it spawns vermin, pets, eggs, fish, raw fish, and remains correctly.  
 --@module=true
 
 local argparse = require('argparse')
@@ -35,6 +36,15 @@ local no_quality_item_types = utils.invert{
     'ROCK',
     'EGG',
     'BRANCH',
+}
+
+local typesThatUseCreaturesExceptCorpses = utils.invert {
+    'REMAINS',
+    'FISH',
+    'FISH_RAW',
+    'VERMIN',
+    'PET',
+    'EGG',
 }
 
 local CORPSE_PIECES = utils.invert{'BONE', 'SKIN', 'CARTILAGE', 'TOOTH', 'NERVE', 'NAIL', 'HORN', 'HOOF', 'CHITIN',
@@ -326,16 +336,27 @@ function hackWish(accessors, opts)
         until count
     end
     if not mattype or not itemtype then return end
-    if df.item_type.attrs[itemtype].is_stackable then
+    if not typesThatUseCreaturesExceptCorpses[df.item_type[itemtype]] and df.item_type.attrs[itemtype].is_stackable then 
         return createItem({mattype, matindex}, {itemtype, itemsubtype}, quality, unit, description, count)
+    end
+    if typesThatUseCreaturesExceptCorpses[df.item_type[itemtype]] and df.item_type.attrs[itemtype].is_stackable then 
+        return createItem({matindex, casteId}, {itemtype, itemsubtype}, quality, unit, description, count)
     end
     local items = {}
     for _ = 1,count do
         if itemtype == df.item_type.CORPSEPIECE or itemtype == df.item_type.CORPSE then
             table.insert(items, createCorpsePiece(unit, bodypart, partlayerID, matindex, casteId, corpsepieceGeneric))
         else
-            for _,item in ipairs(createItem({mattype, matindex}, {itemtype, itemsubtype}, quality, unit, description, 1)) do
-                table.insert(items, item)
+            if typesThatUseCreaturesExceptCorpses[df.item_type[itemtype]] then
+                for 
+                    _,item in ipairs(createItem({matindex, casteId}, {itemtype, itemsubtype}, quality, unit, description, 1)) do
+                        table.insert(items, item)
+                end
+            else
+                for
+                    _,item in ipairs(createItem({mattype, matindex}, {itemtype, itemsubtype}, quality, unit, description, 1)) do
+                    table.insert(items, item)
+                end
             end
         end
     end

--- a/modtools/create-item.lua
+++ b/modtools/create-item.lua
@@ -345,8 +345,8 @@ function hackWish(accessors, opts)
             table.insert(items, createCorpsePiece(unit, bodypart, partlayerID, matindex, casteId, corpsepieceGeneric))
         else
             local mat = typesThatUseCreaturesExceptCorpses[df.item_type[itemtype]] and {matindex, casteId} or {mattype, matindex}
-            for _,item in ipairs(createItem(mat, {itemtype, itemsubtype}, quality, unit, description, 1)) do 
-                table.insert(items, item) 
+            for _,item in ipairs(createItem(mat, {itemtype, itemsubtype}, quality, unit, description, 1)) do
+                table.insert(items, item)
             end
         end
     end

--- a/modtools/create-item.lua
+++ b/modtools/create-item.lua
@@ -1,6 +1,5 @@
 -- creates an item of a given type and material
 --author expwnent
---In the year 2024 dikbutdagrate assumed the identity of tjudge1 and edited this file. Now it spawns vermin, pets, eggs, fish, raw fish, and remains correctly.
 --@module=true
 
 local argparse = require('argparse')

--- a/modtools/create-item.lua
+++ b/modtools/create-item.lua
@@ -1,6 +1,6 @@
 -- creates an item of a given type and material
 --author expwnent
---In the year 2024 dikbutdagrate assumed the identity of tjudge1 and edited this file. Now it spawns vermin, pets, eggs, fish, raw fish, and remains correctly.  
+--In the year 2024 dikbutdagrate assumed the identity of tjudge1 and edited this file. Now it spawns vermin, pets, eggs, fish, raw fish, and remains correctly.
 --@module=true
 
 local argparse = require('argparse')
@@ -336,10 +336,10 @@ function hackWish(accessors, opts)
         until count
     end
     if not mattype or not itemtype then return end
-    if not typesThatUseCreaturesExceptCorpses[df.item_type[itemtype]] and df.item_type.attrs[itemtype].is_stackable then 
+    if not typesThatUseCreaturesExceptCorpses[df.item_type[itemtype]] and df.item_type.attrs[itemtype].is_stackable then
         return createItem({mattype, matindex}, {itemtype, itemsubtype}, quality, unit, description, count)
     end
-    if typesThatUseCreaturesExceptCorpses[df.item_type[itemtype]] and df.item_type.attrs[itemtype].is_stackable then 
+    if typesThatUseCreaturesExceptCorpses[df.item_type[itemtype]] and df.item_type.attrs[itemtype].is_stackable then
         return createItem({matindex, casteId}, {itemtype, itemsubtype}, quality, unit, description, count)
     end
     local items = {}
@@ -348,7 +348,7 @@ function hackWish(accessors, opts)
             table.insert(items, createCorpsePiece(unit, bodypart, partlayerID, matindex, casteId, corpsepieceGeneric))
         else
             if typesThatUseCreaturesExceptCorpses[df.item_type[itemtype]] then
-                for 
+                for
                     _,item in ipairs(createItem({matindex, casteId}, {itemtype, itemsubtype}, quality, unit, description, 1)) do
                         table.insert(items, item)
                 end

--- a/modtools/create-item.lua
+++ b/modtools/create-item.lua
@@ -335,27 +335,18 @@ function hackWish(accessors, opts)
         until count
     end
     if not mattype or not itemtype then return end
-    if not typesThatUseCreaturesExceptCorpses[df.item_type[itemtype]] and df.item_type.attrs[itemtype].is_stackable then
-        return createItem({mattype, matindex}, {itemtype, itemsubtype}, quality, unit, description, count)
-    end
-    if typesThatUseCreaturesExceptCorpses[df.item_type[itemtype]] and df.item_type.attrs[itemtype].is_stackable then
-        return createItem({matindex, casteId}, {itemtype, itemsubtype}, quality, unit, description, count)
+    if df.item_type.attrs[itemtype].is_stackable then
+        local mat = typesThatUseCreaturesExceptCorpses[df.item_type[itemtype]] and {matindex, casteId} or {mattype, matindex}
+        return createItem(mat, {itemtype, itemsubtype}, quality, unit, description, count)
     end
     local items = {}
     for _ = 1,count do
         if itemtype == df.item_type.CORPSEPIECE or itemtype == df.item_type.CORPSE then
             table.insert(items, createCorpsePiece(unit, bodypart, partlayerID, matindex, casteId, corpsepieceGeneric))
         else
-            if typesThatUseCreaturesExceptCorpses[df.item_type[itemtype]] then
-                for
-                    _,item in ipairs(createItem({matindex, casteId}, {itemtype, itemsubtype}, quality, unit, description, 1)) do
-                        table.insert(items, item)
-                end
-            else
-                for
-                    _,item in ipairs(createItem({mattype, matindex}, {itemtype, itemsubtype}, quality, unit, description, 1)) do
-                    table.insert(items, item)
-                end
+            local mat = typesThatUseCreaturesExceptCorpses[df.item_type[itemtype]] and {matindex, casteId} or {mattype, matindex}
+            for _,item in ipairs(createItem(mat, {itemtype, itemsubtype}, quality, unit, description, 1)) do 
+                table.insert(items, item) 
             end
         end
     end


### PR DESCRIPTION
Fixed issues with spawning creature based items. Vermin, pets, eggs, fish, raw fish, and remains now spawn and stack correctly.

Fixes: [DFHack/dfhack#4689](https://github.com/DFHack/dfhack/issues/4689)
Fixes: [DFHack/dfhack#4507](https://github.com/DFHack/dfhack/issues/4507)
Fixes: [DFHack/dfhack#3674](https://github.com/DFHack/dfhack/issues/3674)