### PR TITLE
Position.lua: site/adv world coords

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -51,7 +51,7 @@ Template for new versions:
 - `gui/sitemap`: show whether a unit is friendly, hostile, or wild
 - `gui/sitemap`: show whether a unit is caged
 - `gui/control-panel`: include option for turning off dumping of old clothes for `tailor`, for players who have magma pit dumps and want to save old clothes from being dumped into the magma
-- `position`: report current historical era (e.g., "Age of Myth") and site/adventurer world coords
+- `position`: report current historical era (e.g., "Age of Myth"), site/adventurer world coords, and mouse map tile coords
 
 ## Documentation
 - `gui/embark-anywhere`: add information about how the game determines world tile pathability and instructions for bridging two landmasses

--- a/changelog.txt
+++ b/changelog.txt
@@ -44,10 +44,8 @@ Template for new versions:
 - `gui/design`: don't overcount "affected tiles" for Line & Freeform drawing tools
 - `deep-embark`: fix error when embarking where there is no land to stand on (e.g. when embarking in the ocean with `gui/embark-anywhere`
 - `deep-embark`: fix failure to transport units and items when embarking where there is no room to spawn the starting wagon
-- `gui/create-item`: fix items of type "VERMIN", "PET", "REMANS", "FISH", "RAW FISH", and "EGG" no longer spawn creature item "nothing."
-Items will now spawn correctly, and will be of the creature type and creature caste that selected by the user. Items of these  types will also stack correctly when needed.
-- `modtools/create-item`:  fix items of type "VERMIN", "PET", "REMANS", "FISH", "RAW FISH", and "EGG" no longer spawn creature item "nothing"s.
-Items will now spawn correctly, and will be of the creature type and creature caste that selected by the user. Items of these  types will also stack correctly when needed.
+- `gui/create-item`: fix items of type "VERMIN", "PET", "REMANS", "FISH", "RAW FISH", and "EGG" no longer spawn creature item "nothing." Items will now spawn correctly, and will be of the creature type and creature caste that selected by the user. Items of these  types will also stack correctly when needed.
+- `modtools/create-item`:  fix items of type "VERMIN", "PET", "REMANS", "FISH", "RAW FISH", and "EGG" no longer spawn creature item "nothing"s. Items will now spawn correctly, and will be of the creature type and creature caste that selected by the user. Items of these  types will also stack correctly when needed.
 
 ## Misc Improvements
 - `gui/sitemap`: show whether a unit is friendly, hostile, or wild

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,10 +17,6 @@ Template for new versions:
 ## New Features
 
 ## Fixes
-- `gui/create-item`: fix items of type "VERMIN", "PET", "REMANS", "FISH", "RAW FISH", and "EGG" no longer spawn creature item "nothing."
-Items will now spawn correctly, and will be of the creature type and creature caste that selected by the user. Items of these  types will also stack correctly when needed.
-- `modtools/create-item`:  fix items of type "VERMIN", "PET", "REMANS", "FISH", "RAW FISH", and "EGG" no longer spawn creature item "nothing"s.
-Items will now spawn correctly, and will be of the creature type and creature caste that selected by the user. Items of these  types will also stack correctly when needed.
 
 ## Misc Improvements
 
@@ -48,12 +44,16 @@ Items will now spawn correctly, and will be of the creature type and creature ca
 - `gui/design`: don't overcount "affected tiles" for Line & Freeform drawing tools
 - `deep-embark`: fix error when embarking where there is no land to stand on (e.g. when embarking in the ocean with `gui/embark-anywhere`
 - `deep-embark`: fix failure to transport units and items when embarking where there is no room to spawn the starting wagon
+- `gui/create-item`: fix items of type "VERMIN", "PET", "REMANS", "FISH", "RAW FISH", and "EGG" no longer spawn creature item "nothing."
+Items will now spawn correctly, and will be of the creature type and creature caste that selected by the user. Items of these  types will also stack correctly when needed.
+- `modtools/create-item`:  fix items of type "VERMIN", "PET", "REMANS", "FISH", "RAW FISH", and "EGG" no longer spawn creature item "nothing"s.
+Items will now spawn correctly, and will be of the creature type and creature caste that selected by the user. Items of these  types will also stack correctly when needed.
 
 ## Misc Improvements
 - `gui/sitemap`: show whether a unit is friendly, hostile, or wild
 - `gui/sitemap`: show whether a unit is caged
 - `gui/control-panel`: include option for turning off dumping of old clothes for `tailor`, for players who have magma pit dumps and want to save old clothes from being dumped into the magma
-- `position`: report current historical era (e.g., "Age of Myth")
+- `position`: report current historical era (e.g., "Age of Myth") and site/adventurer world coords
 
 ## Documentation
 - `gui/embark-anywhere`: add information about how the game determines world tile pathability and instructions for bridging two landmasses

--- a/docs/position.rst
+++ b/docs/position.rst
@@ -8,8 +8,8 @@ position
 This tool reports the current date, clock time, month, season, and historical
 era. It also reports the keyboard cursor position (or just the z-level if no
 active cursor), window size, and mouse location on the screen. If a site is
-loaded, it prints the world coordinates of the site, else the world
-coordinates of the adventurer.
+loaded, it prints the world coordinates of the site. If not, it prints the world
+coordinates of the adventurer (if applicable).
 
 Can also be used to copy the current keyboard cursor position for later use.
 

--- a/docs/position.rst
+++ b/docs/position.rst
@@ -3,11 +3,13 @@ position
 
 .. dfhack-tool::
     :summary: Report cursor and mouse position, along with other info.
-    :tags: fort inspection map
+    :tags: adventure fort inspection map
 
 This tool reports the current date, clock time, month, season, and historical
 era. It also reports the keyboard cursor position (or just the z-level if no
-active cursor), window size, and mouse location on the screen.
+active cursor), window size, and mouse location on the screen. If a site is
+loaded, it prints the world coordinates of the site, else the world
+coordinates of the adventurer.
 
 Can also be used to copy the current keyboard cursor position for later use.
 

--- a/position.lua
+++ b/position.lua
@@ -54,31 +54,43 @@ end
 
 print('Place:')
 print('    The z-level is z='..df.global.window_z)
-print('    The cursor is at x='..cursor.x..', y='..cursor.y)
-print('    The window is '..df.global.gps.dimx..' tiles wide and '..df.global.gps.dimy..' tiles high.')
 
-if df.global.gps.mouse_x < 0 then
-    print('    The mouse is not in the DF window.')
+if cursor.x < 0 then
+    print('    The keyboard cursor is inactive.')
 else
-    print('    The mouse is at x='..df.global.gps.mouse_x..', y='..df.global.gps.mouse_y..' within the window.')
+    print('    The keyboard cursor is at x='..cursor.x..', y='..cursor.y)
+end
+
+local x, y = dfhack.screen.getWindowSize()
+print('    The window is '..x..' tiles wide and '..y..' tiles high.')
+
+x, y = dfhack.screen.getMousePos()
+if x then
+    print('    The mouse is at x='..x..', y='..y..' within the window.')
+    local pos = dfhack.gui.getMousePos()
+    if pos then
+        print('    The mouse is over map tile x='..pos.x..', y='..pos.y)
+    end
+else
+    print('    The mouse is not in the DF window.')
 end
 
 local wd = df.global.world.world_data
 local site = dfhack.world.getCurrentSite()
 if site then
-    print(('    The current site is at x=%d, y=%d on the world map (%dx%d).'):
+    print(('    The current site is at x=%d, y=%d on the %dx%d world map.'):
         format(site.pos.x, site.pos.y, wd.world_width, wd.world_height))
 elseif dfhack.world.isAdventureMode() then
-    local ax, ay = -1, -1
+    x, y = -1, -1
     for _,army in ipairs(df.global.world.armies.all) do
         if army.flags.player then
-            ax, ay = army.pos.x // 48, army.pos.y // 48
+            x, y = army.pos.x // 48, army.pos.y // 48
             break
         end
     end
-    if ax < 0 then
-        ax, ay = wd.midmap_data.adv_region_x, wd.midmap_data.adv_region_y
+    if x < 0 then
+        x, y = wd.midmap_data.adv_region_x, wd.midmap_data.adv_region_y
     end
-    print(('    The adventurer is at x=%d, y=%d on the world map (%dx%d).'):
-        format(ax, ay, wd.world_width, wd.world_height))
+    print(('    The adventurer is at x=%d, y=%d on the %dx%d world map.'):
+        format(x, y, wd.world_width, wd.world_height))
 end

--- a/position.lua
+++ b/position.lua
@@ -33,18 +33,18 @@ local months = {
 --Adventurer mode counts 86400 ticks to a day and 29030400 ticks per year
 --Twelve months per year, 28 days to every month, 336 days per year
 
-local julian_day = math.floor(df.global.cur_year_tick / 1200) + 1
-local month = math.floor(julian_day / 28) + 1 --days and months are 1-indexed
+local julian_day = df.global.cur_year_tick // 1200 + 1
+local month = julian_day // 28 + 1 --days and months are 1-indexed
 local day = julian_day % 28
 
-local time_of_day = math.floor(df.global.cur_year_tick_advmode / 336)
+local time_of_day = df.global.cur_year_tick_advmode // 336
 local second = time_of_day % 60
-local minute = math.floor(time_of_day / 60) % 60
-local hour = math.floor(time_of_day / 3600) % 24
+local minute = time_of_day // 60 % 60
+local hour = time_of_day // 3600 % 24
 
 print('Time:')
-print('    The time is '..string.format('%02d:%02d:%02d', hour, minute, second))
-print('    The date is '..string.format('%05d-%02d-%02d', df.global.cur_year, month, day))
+print(('    The time is %02d:%02d:%02d'):format(hour, minute, second))
+print(('    The date is %03d-%02d-%02d'):format(df.global.cur_year, month, day))
 print('    It is the month of '..months[month])
 
 local eras = df.global.world.history.eras
@@ -55,7 +55,30 @@ end
 print('Place:')
 print('    The z-level is z='..df.global.window_z)
 print('    The cursor is at x='..cursor.x..', y='..cursor.y)
-print('    The window is '..df.global.gps.dimx..' tiles wide and '..df.global.gps.dimy..' tiles high')
-if df.global.gps.mouse_x == -1 then print('    The mouse is not in the DF window') else
-print('    The mouse is at x='..df.global.gps.mouse_x..', y='..df.global.gps.mouse_y..' within the window') end
---TODO:  print('    The fortress is at '..x, y..' on the world map ('..worldsize..' square)')
+print('    The window is '..df.global.gps.dimx..' tiles wide and '..df.global.gps.dimy..' tiles high.')
+
+if df.global.gps.mouse_x < 0 then
+    print('    The mouse is not in the DF window.')
+else
+    print('    The mouse is at x='..df.global.gps.mouse_x..', y='..df.global.gps.mouse_y..' within the window.')
+end
+
+local wd = df.global.world.world_data
+local site = dfhack.world.getCurrentSite()
+if site then
+    print(('    The current site is at x=%d, y=%d on the world map (%dx%d).'):
+        format(site.pos.x, site.pos.y, wd.world_width, wd.world_height))
+elseif dfhack.world.isAdventureMode() then
+    local ax, ay = -1, -1
+    for _,army in ipairs(df.global.world.armies.all) do
+        if army.flags.player then
+            ax, ay = army.pos.x // 48, army.pos.y // 48
+            break
+        end
+    end
+    if ax < 0 then
+        ax, ay = wd.midmap_data.adv_region_x, wd.midmap_data.adv_region_y
+    end
+    print(('    The adventurer is at x=%d, y=%d on the world map (%dx%d).'):
+        format(ax, ay, wd.world_width, wd.world_height))
+end


### PR DESCRIPTION
Print current site world coords, or adventurer (if applicable). Also swapped out uses of `math.floor` for `//`. Decreased padding zeros for current year from 5 to 3 digits (which is still sufficient to distinguish it from a month or day).

Script is now tagged `adventure`. It needs testing by someone on the adventurer beta. (Needs to be run inside site, outside site, travel mode, and dead.)

Moved some changelog entries in the template section to the proper spot (if nobody fixes that before this PR merges).