### PR TITLE
[rejuvenate]: ensure histfig data stays consistent and respect age-related caste data per race

### DIFF
--- a/armoks-blessing.lua
+++ b/armoks-blessing.lua
@@ -1,24 +1,9 @@
 -- Adjust all attributes of all dwarves to an ideal
 -- by vjek
 
+local rejuvenate = reqscript('rejuvenate')
 local utils = require('utils')
 
-function rejuvenate(unit)
-    if unit==nil then
-        print ("No unit available!  Aborting with extreme prejudice.")
-        return
-    end
-
-    local current_year=df.global.cur_year
-    local newbirthyear=current_year - 20
-    if unit.birth_year < newbirthyear then
-        unit.birth_year=newbirthyear
-    end
-    if unit.old_year < current_year+100 then
-        unit.old_year=current_year+100
-    end
-
-end
 -- ---------------------------------------------------------------------------
 function brainwash_unit(unit)
     if unit==nil then
@@ -251,7 +236,7 @@ function adjust_all_dwarves(skillname)
         print("Adjusting "..dfhack.df2console(dfhack.TranslateName(dfhack.units.getVisibleName(v))))
         brainwash_unit(v)
         elevate_attributes(v)
-        rejuvenate(v)
+        rejuvenate.rejuvenate(v, true)
         if skillname then
             if df.job_skill_class[skillname] then
                 LegendaryByClass(skillname,v)

--- a/changelog.txt
+++ b/changelog.txt
@@ -45,6 +45,8 @@ Template for new versions:
 - `deep-embark`: fix error when embarking where there is no land to stand on (e.g. when embarking in the ocean with `gui/embark-anywhere`)
 - `deep-embark`: fix failure to transport units and items when embarking where there is no room to spawn the starting wagon
 - `gui/create-item`, `modtools/create-item`: items of type "VERMIN", "PET", "REMANS", "FISH", "RAW FISH", and "EGG" no longer spawn creature item "nothing" and will now stack correctly
+- `rejuvenate`: don't set a lifespan limit for creatures that are immortal (e.g. elves, goblins)
+- `rejuvenate`: properly disconnect babies from mothers when aging babies up to adults
 
 ## Misc Improvements
 - `gui/sitemap`: show whether a unit is friendly, hostile, or wild

--- a/docs/rejuvenate.rst
+++ b/docs/rejuvenate.rst
@@ -7,7 +7,8 @@ rejuvenate
 
 If your most valuable citizens are getting old, this tool can save them. It
 decreases the age of the selected dwarf to 20 years, or to the age specified.
-Age is only increased using the --force option.
+Age can only be increased (e.g. when this tool is run on babies or children)
+if the ``--force`` option is specified.
 
 Usage
 -----
@@ -24,7 +25,7 @@ Examples
 ``rejuvenate --all``
     Set the age of all dwarves over 20 to 20.
 ``rejuvenate --all --force``
-    Set the age of all dwarves (including babies) to 20.
+    Set the age of all dwarves (including children and babies) to 20.
 ``rejuvenate --age 149 --force``
     Set the age of the selected dwarf to 149, even if they are younger.
 
@@ -34,9 +35,9 @@ Options
 ``--all``
     Rejuvenate all citizens, not just the selected one.
 ``--age <num>``
-    Sets the target to the age specified. If this is not set, the target age is 20.
+    Sets the target to the age specified. If this is not set, the target age defaults to ``20``.
 ``--force``
-    Set age for units under the specified age to the specified age. Useful if there are too
-    many babies around...
+    Set age for units under the specified age to the specified age. Useful if
+    there are too many babies around...
 ``--dry-run``
     Only list units that would be changed; don't actually change ages.

--- a/docs/rejuvenate.rst
+++ b/docs/rejuvenate.rst
@@ -6,9 +6,9 @@ rejuvenate
     :tags: fort armok units
 
 If your most valuable citizens are getting old, this tool can save them. It
-decreases the age of the selected dwarf to 20 years, or to the age specified.
-Age can only be increased (e.g. when this tool is run on babies or children)
-if the ``--force`` option is specified.
+decreases the age of the selected dwarf to the minimum adult age, or to the age
+specified. Age can only be increased (e.g. when this tool is run on babies or
+children) if the ``--force`` option is specified.
 
 Usage
 -----
@@ -21,11 +21,15 @@ Examples
 --------
 
 ``rejuvenate``
-    Set the age of the selected dwarf to 20 (if they're older).
+    Set the age of the selected dwarf to 18 (if they're older than 18). The
+    target age may be different if you have modded dwarves to become an adult
+    at a different age, or if you have selected a unit that is not a dwarf.
 ``rejuvenate --all``
-    Set the age of all dwarves over 20 to 20.
+    Set the ages of all adult citizens and residents to their minimum adult
+    ages.
 ``rejuvenate --all --force``
-    Set the age of all dwarves (including children and babies) to 20.
+    Set the ages of all citizens and residents (including children and babies)
+    to their minimum adult ages.
 ``rejuvenate --age 149 --force``
     Set the age of the selected dwarf to 149, even if they are younger.
 
@@ -33,9 +37,9 @@ Options
 -------
 
 ``--all``
-    Rejuvenate all citizens, not just the selected one.
+    Rejuvenate all citizens and residents instead of a selected unit.
 ``--age <num>``
-    Sets the target to the age specified. If this is not set, the target age defaults to ``20``.
+    Sets the target to the age specified. If this is not set, the target age defaults to the minimum adult age for the unit.
 ``--force``
     Set age for units under the specified age to the specified age. Useful if
     there are too many babies around...

--- a/rejuvenate.lua
+++ b/rejuvenate.lua
@@ -1,65 +1,60 @@
--- set age of selected unit
--- by vjek
 --@ module = true
 
 local utils = require('utils')
 
-function rejuvenate(unit, force, dry_run, age)
+local ANY_BABY = df.global.world.units.other.ANY_BABY
+
+-- called by armoks-blessing
+function rejuvenate(unit, quiet, force, dry_run, age)
+    age = age or 20
     local current_year = df.global.cur_year
-    if not age then
-        age = 20
-    end
     local new_birth_year = current_year - age
-    local name = dfhack.df2console(dfhack.TranslateName(dfhack.units.getVisibleName(unit)))
+    local new_old_year = unit.old_year < 0 and -1 or math.max(unit.old_year, new_birth_year + 160)
+    local name = dfhack.df2console(dfhack.units.getReadableName(unit))
     if unit.birth_year > new_birth_year and not force then
-        print(name .. ' is under ' .. age .. ' years old. Use --force to force.')
+        if not quiet then
+            dfhack.printerr(name .. ' is under ' .. age .. ' years old. Use --force to force.')
+        end
         return
     end
     if dry_run then
         print('would change: ' .. name)
         return
     end
+
+    local hf = df.historical_figure.find(unit.hist_figure_id)
     unit.birth_year = new_birth_year
-    if unit.old_year < new_birth_year + 160 then
-        unit.old_year = new_birth_year + 160
-    end
+    if hf then hf.born_year = new_birth_year end
+    unit.old_year = new_old_year
+    if hf then hf.old_year = new_old_year end
+
     if unit.profession == df.profession.BABY or unit.profession == df.profession.CHILD then
         if unit.profession == df.profession.BABY then
-            local leftoverUnits = {}
-            local shiftedLeftoverUnits = {}
-            -- create a copy
-            local babyUnits = df.global.world.units.other.ANY_BABY
-            -- create a new table with the units that aren't being removed in this iteration
-            for _, v in ipairs(babyUnits) do
-                if not v.id == unit.id then
-                    table.insert(leftoverUnits, v)
-                end
+            local idx = utils.linear_index(ANY_BABY, unit.id, 'id')
+            if idx then
+                ANY_BABY:erase(idx)
             end
-            -- create a shifted table of the leftover units to make up for lua tables starting with index 1 and the game starting with index 0
-            for i = 0, #leftoverUnits - 1, 1 do
-                local x = i+1
-                shiftedLeftoverUnits[i] = leftoverUnits[x]
-            end
-            -- copy the leftover units back to the game table
-            df.global.world.units.other.ANY_BABY = shiftedLeftoverUnits
-            -- set extra flags to defaults
             unit.flags1.rider = false
             unit.relationship_ids.RiderMount = -1
-            unit.mount_type = 0
+            unit.mount_type = df.rider_positions_type.STANDARD
             unit.profession2 = df.profession.STANDARD
-            unit.idle_area_type = 26
+            unit.idle_area_type = df.unit_station_type.MillBuilding
             unit.mood = -1
 
             -- let the mom know she isn't carrying anyone anymore
-            local motherUnitId = unit.relationship_ids.Mother
-            df.unit.find(motherUnitId).flags1.ridden = false
+            local mother = df.unit.find(unit.relationship_ids.Mother)
+            if mother then mother.flags1.ridden = false end
         end
         unit.profession = df.profession.STANDARD
+        unit.profession2 = df.profession.STANDARD
+        if hf then hf.profession = df.profession.STANDARD end
     end
-    print(name .. ' is now ' .. age .. ' years old and will live to at least 160')
+    if not quiet then
+        print(name .. ' is now ' .. age .. ' years old and will live to at least 160')
+    end
 end
 
-function main(args)
+local function main(args)
     local units = {} --as:df.unit[]
     if args.all then
         units = dfhack.units.getCitizens()
@@ -67,7 +62,7 @@ function main(args)
         table.insert(units, dfhack.gui.getSelectedUnit(true) or qerror("Please select a unit in the UI."))
     end
     for _, u in ipairs(units) do
-        rejuvenate(u, args.force, args['dry-run'], args.age)
+        rejuvenate(u, false, args.force, args['dry-run'], args.age)
     end
 end
 


### PR DESCRIPTION
- set related histfig data when we set unit data
- don't allow player to set age into childhood/babyhood
- set max age as per the age ranges in the unit's caste
- reuse the rejuvenate logic in `armoks-blessing`, which had a copied, inferior implementation

Includes #1284
Fixes: https://github.com/DFHack/dfhack/issues/4894