### PR TITLE
[makeown] remove converted units from current conflicts

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -34,7 +34,7 @@ Template for new versions:
 
 ## Fixes
 - `gui/quickfort`: only print a help blueprint's text once even if the repeat setting is enabled
-- `makeown`: quell any active enemy relationships with the converted creature
+- `makeown`: quell any active enemy or conflict relationships with converted creatures
 - `fix/loyaltycascade`: allow the fix to work on non-dwarven citizens
 - `control-panel`: fix setting numeric preferences from the commandline
 


### PR DESCRIPTION
should finally fix the "converted creature attacks fellow citizens" issues

also sanitizes the professions of both the unit and the histfig