### PR TITLE
Fix blueprinted constructions over stairs

### DIFF
--- a/internal/quickfort/build.lua
+++ b/internal/quickfort/build.lua
@@ -139,7 +139,7 @@ local function is_valid_tile_bridge(pos, db_entry, b)
             (dir == T_direction.Right and pos.x == b.pos.x+b.width-1) then
         return is_valid_tile_has_space(pos)
     end
-    return is_valid_tile_has_space_or_is_ramp(pos)
+    return is_valid_tile_machine(pos)
 end
 
 -- although vanilla allows constructions to be built on top of constructed
@@ -213,7 +213,7 @@ local function is_tile_coverable(pos)
              shape ~= df.tiletype_shape.STAIR_DOWN) then
         return false
     end
-    return is_tile_floor_adjacent(pos)
+    return true
 end
 
 --


### PR DESCRIPTION
Fixes: https://github.com/DFHack/dfhack/issues/5012

Quickfort blueprints can't place bridges over stairs

The previous code is more restrictive than vanilla UI.

In-game, bridges may be placed in any supported position with a walkable, adjacent tile, including over any kind of stair.  In-game, floor hatches, grates, and bars do not require an adjacent floor for placement.

Initially I thought these changes may be too simple to be correct, but upon further study and testing, I can find no issues. 

These changes are in keeping with the 'mission statement' from the original dev found in the top comment of the build.ua file: "In general, we enforce the same rules as the in-game UI for allowed placement of buildings (e.g. beds have to be inside, doors have to be adjacent to a wall, etc.). A notable exception is that we allow constructions and machine components to be designated regardless of whether they are reachable or currently supported. This allows the user to designate an entire floor of an above-ground building or an entire power system without micromanagement."