### PR TITLE
Convert age argument to number in rejuvenate.lua

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -41,6 +41,7 @@ Template for new versions:
 - `control-panel`: fix setting numeric preferences from the commandline
 - `gui/quickfort`: fix build mode evluation rules to allow placement of various furniture and constructions on tiles with stair shapes or without orthagonal floor.
 - `emigration`: save-and-reload no longer resets the emigration cycle timeout, making gameplay more consistent
+- `rejuvenate`: ``--age`` no longer throws the error ``attempt to compare string with number``
 
 ## Misc Improvements
 - `control-panel`: Add realistic-melting tweak to control-panel registry

--- a/rejuvenate.lua
+++ b/rejuvenate.lua
@@ -84,7 +84,7 @@ local function main(args)
         table.insert(units, dfhack.gui.getSelectedUnit(true) or qerror("Please select a unit in the UI."))
     end
     for _, u in ipairs(units) do
-        rejuvenate(u, false, args.force, args['dry-run'], args.age)
+        rejuvenate(u, false, args.force, args['dry-run'], tonumber(args.age))
     end
 end
 


### PR DESCRIPTION
due to the less than comparison, age must be converted to a number or else any attempt to use that argument causes the script to fail with "attempt to compare string with number".