### PR TITLE
Fix usage of stale state in legends racefilter

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -45,6 +45,7 @@ Template for new versions:
 - `geld`, `ungeld`: save-and-reload no longer loses changes done by `geld` and `ungeld` for units who are historical figures
 - `rejuvenate`: fix error when specifying ``--age`` parameter
 - `gui/notify`: don't classify (peacefully) visiting night creatures as hostile
+- `exportlegends`: fix race filter not refreshing on world load, leading to incorrect results
 
 ## Misc Improvements
 - `idle-crafting`: also support making shell crafts for workshops with linked input stockpiles

--- a/exportlegends.lua
+++ b/exportlegends.lua
@@ -1040,7 +1040,7 @@ dfhack.onStateChange[GLOBAL_KEY] = function(sc)
     end
 
     -- Reset state when a world or map is loaded to ensure data remains current
-    if sc == SC_WORLD_LOADED or sc == SC_MAP_LOADED then
+    if sc == SC_WORLD_LOADED then
         racefilter.reset_state()
     end
 end

--- a/exportlegends.lua
+++ b/exportlegends.lua
@@ -1038,6 +1038,11 @@ dfhack.onStateChange[GLOBAL_KEY] = function(sc)
     if sc == SC_VIEWSCREEN_CHANGED and df.viewscreen_choose_game_typest:is_instance(dfhack.gui.getDFViewscreen(true)) then
         asyncexport.reset_state()
     end
+
+    -- Reset state when a world or map is loaded to ensure data remains current
+    if sc == SC_WORLD_LOADED or sc == SC_MAP_LOADED then
+        racefilter.reset_state()
+    end
 end
 
 if dfhack_flags.module then


### PR DESCRIPTION
Loading multiple worlds or timelines in legends mode originally did not reset the state, allowing stale data to be used in filtering. This resulted in incorrect results being presented.

This patch resets `racefilter` state on world or map load to ensure the state remains up to date.

Map loading is checked to prevent issues with `open-legends` which is able to access legends mode without reloading the world.