### PR TITLE
[gui/settings-manager] add overlay for editing reserved_barrels setting

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,8 @@ Template for new versions:
 - `fix/stuck-squad`: allow squads and messengers returning from missions to rescue squads that have gotten stuck on the world map
 
 ## New Features
+- `gui/settings-manager`: new overlay on the Labor -> Standing Orders tab for configuring the number of barrels to reserve for job use (so you can brew alcohol and not have all your barrels claimed by stockpiles for container storage)
+- `gui/settings-manager`: standing orders save/load now includes the reserved barrels setting
 
 ## Fixes
 

--- a/docs/gui/settings-manager.rst
+++ b/docs/gui/settings-manager.rst
@@ -39,10 +39,13 @@ back. You can also toggle an option to automatically load the saved settings
 for new embarks.
 
 When a fort is loaded, you can also go to the Labor -> Standing Orders page.
-You will see a new panel that allows you to save and restore your settings for
-standing orders. You can also toggle whether the saved standing orders are
-automatically restored when you embark on a new fort. This will toggle the
-relevant command in `gui/control-panel` on the Automation -> Autostart page.
+You will see tow new panels. The first allows you to configure how many barrels
+to reserve for use by workshop jobs (instead of being claimed by stockpiles for
+container storage). The second panel allows you to save and restore your
+settings for standing orders. You can also toggle whether the saved standing
+orders are automatically restored when you embark on a new fort. This will
+toggle the relevant command in `gui/control-panel` on the Automation ->
+Autostart page.
 
 There is a similar panel on the Labor -> Work Details page that allows for
 saving and restoring of work detail definitions. Be aware that work detail


### PR DESCRIPTION
also include the reserved_barrels setting when importing/exporting standing orders

Fixes: https://github.com/DFHack/dfhack/issues/5004