### PR TITLE
[gui/gm-unit] refresh map sprite when profession is changed

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -40,6 +40,7 @@ Template for new versions:
 - `immortal-cravings`: goblins and other naturally non-eating/non-drinking races will now also satisfy their needs for eating and drinking
 - `caravan`: add filter for written works in display furniture assignment dialog
 - `fix/wildlife`: don't vaporize stuck wildlife that is onscreen -- kill them instead (as if they died from old age)
+- `gui/gm-unit`: refresh unit sprite when profession is changed
 
 ## Removed
 

--- a/internal/gm-unit/editor_profession.lua
+++ b/internal/gm-unit/editor_profession.lua
@@ -44,6 +44,7 @@ end
 function Editor_Prof:save_profession(_, choice)
     self.target_unit.profession = choice.profession
     self.target_unit.profession2 = choice.profession
+    self.target_unit.flags4.any_texture_must_be_refreshed = true
 end
 
 function Editor_Prof:onOpen()


### PR DESCRIPTION
Fixes: https://github.com/DFHack/dfhack/issues/5122