### PR TITLE
RightClickOverlay: check focus before clearing selection_pos

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -39,6 +39,7 @@ Template for new versions:
 - `fix/dry-buckets`: don't empty buckets for wells that are actively in use
 - `gui/unit-info-viewer`: skill progress bars now show correct XP thresholds for skills past Legendary+5
 - `caravan`: no longer incorrectly identify wood-based plant items and plant-based soaps as being ethically unsuitable for trading with the elves
+- `gui/design`: don't require an extra cancel input to exit or cancel designations
 
 ## Misc Improvements
 - `immortal-cravings`: goblins and other naturally non-eating/non-drinking races will now also satisfy their needs for eating and drinking

--- a/gui/design.lua
+++ b/gui/design.lua
@@ -143,9 +143,13 @@ RightClickOverlay.ATTRS{
 function RightClickOverlay:onInput(keys)
     if keys._MOUSE_R or keys.LEAVESCREEN then
         -- building mode
-        if uibs.selection_pos.x >= 0 then
-            uibs.selection_pos:clear()
-            return true
+        if dfhack.gui.matchFocusString('dwarfmode/Building/Placement',
+            dfhack.gui.getDFViewscreen(true))
+        then
+            if uibs.selection_pos.x >= 0 then
+                uibs.selection_pos:clear()
+                return true
+            end
         -- all other modes
         elseif selection_rect.start_x >= 0 then
             selection_rect.start_x = -30000


### PR DESCRIPTION
I found myself sometimes needing to "exit twice" to exit out of a dig designation that didn't have a selection started.

# Problem Reproduction

- optionally, boot DF from scratch
- monitor .selection_pos with gm-editor
  - `gui/gm-editor buildreq.selection_pos`, Alt-a to enable live updates
- if needed, set .selection_pos to (0,0,0) to simulate a fresh DF start
  - the values can be edited in gm-editor, or
    - `:lua ~buildreq.selection_pos:assign(xyz2pos(0,0,0))`
- start one of the other (non-building placement) modes covered by RightClickOverlay (e.g. dig designation), but don't start a selection
- trigger LEAVESCREEN or right-click
  - **Expect**: selection mode is exited
  - **Result**: selection mode remains active
    - the gm-editor window will show that .selection_pos was changed to (-30k,-30k,-30k)
- a second trigger of LEAVESCREEN or right-click
  - the overlay will let the input pass and DF will exit the mode

# Alternate Fix

Just swapping the if and elseif mostly works okay and avoids having to do focus matching.

This works because all the components of selection_rect start at -30k in a fresh boot and this overlay makes sure the "start" components are -30k before exiting the modes that change them.

There would still be some edge cases though:

- cancelling *some kinds* of selection_rect selections while this overlay is (temporarily) disabled
  - DF leaves the selection_rect "start" parts set when cancelling stockpile, zone, burrow selections
- new selection_rect uses in DF that this overlay hasn't been updated to also handle

Either could create a "cancel input suppressed" situations for building placement mode.
