### PR TITLE
Fix notes tool to use new TextArea instead of deprecated TextEditor

### DIFF
--- a/notes.lua
+++ b/notes.lua
@@ -5,7 +5,6 @@ local widgets = require('gui.widgets')
 local textures = require('gui.textures')
 local overlay = require('plugins.overlay')
 local guidm = require('gui.dwarfmode')
-local text_editor = reqscript('internal/journal/text_editor')
 
 local green_pin = dfhack.textures.loadTileset(
     'hack/data/art/note_green_pin_map.png',
@@ -172,7 +171,7 @@ function NoteManager:init()
                     auto_width=true,
                     on_activate=function() self.subviews.name:setFocus(true) end,
                 },
-                text_editor.TextEditor{
+                widgets.TextArea{
                     view_id='name',
                     frame={t=1,h=3},
                     frame_style=gui.FRAME_INTERIOR,
@@ -187,7 +186,7 @@ function NoteManager:init()
                     auto_width=true,
                     on_activate=function() self.subviews.comment:setFocus(true) end,
                 },
-                text_editor.TextEditor{
+                widgets.TextArea{
                     view_id='comment',
                     frame={t=6,b=3},
                     frame_style=gui.FRAME_INTERIOR,


### PR DESCRIPTION
The `notes` are broken now, as it still used old `TextEditor` widget instead of `TextArea` widget.
This PR fix the tool.