### PR TITLE
Feat: Add "show" to pref-adjust

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -62,6 +62,7 @@ Template for new versions:
 - `caravan`: add filter for written works in display furniture assignment dialog
 - `fix/wildlife`: don't vaporize stuck wildlife that is onscreen -- kill them instead (as if they died from old age)
 - `gui/sitemap`: show primary group affiliation for visitors and invaders (e.g. civilization name or performance troupe)
+- `pref-assign`: updated to allow users to run `pref-assign show` to get a list of units current preferences
 
 # 50.15-r1
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -34,6 +34,7 @@ Template for new versions:
 - `deathcause`: fix error when retrieving the name of a historical figure
 
 ## Misc Improvements
+- `pref-assign`: updated to allow users to run `pref-assign show` to get a list of units current preferences
 
 ## Removed
 
@@ -62,7 +63,6 @@ Template for new versions:
 - `caravan`: add filter for written works in display furniture assignment dialog
 - `fix/wildlife`: don't vaporize stuck wildlife that is onscreen -- kill them instead (as if they died from old age)
 - `gui/sitemap`: show primary group affiliation for visitors and invaders (e.g. civilization name or performance troupe)
-- `pref-assign`: updated to allow users to run `pref-assign show` to get a list of units current preferences
 
 # 50.15-r1
 

--- a/docs/pref-adjust.rst
+++ b/docs/pref-adjust.rst
@@ -19,7 +19,7 @@ Usage
 ``pref-adjust list``
     List all types of preferences. No changes will be made to any units.
 ``pref-adjust show``
-    Show the preferences of a unit.
+    Show the preferences of the selected unit.
 ``pref-adjust all|goth_all|clear_all``
     Changes/clears preferences for all units.
 ``pref-adjust one|goth|clear``

--- a/docs/pref-adjust.rst
+++ b/docs/pref-adjust.rst
@@ -3,7 +3,7 @@ pref-adjust
 
 .. dfhack-tool::
     :summary: See the preferences of a dwarf or set them to a designated profile.
-    :tags: fort armok units preferences
+    :tags: fort armok units
 
 This tool replaces a dwarf's preferences with an "ideal" set which is easy to
 satisfy::

--- a/docs/pref-adjust.rst
+++ b/docs/pref-adjust.rst
@@ -21,7 +21,7 @@ Usage
 ``pref-adjust show``
     Show the preferences of the selected unit.
 ``pref-adjust all|goth_all|clear_all``
-    Changes/clears preferences for all units.
+    Changes/clears preferences for all citizens.
 ``pref-adjust one|goth|clear``
     Changes/clears preferences for the currently selected dwarf.
 

--- a/docs/pref-adjust.rst
+++ b/docs/pref-adjust.rst
@@ -2,7 +2,7 @@ pref-adjust
 ===========
 
 .. dfhack-tool::
-    :summary: Get/Set the preferences of a dwarf.
+    :summary: Get the preferences of a dwarf, Set the preferences of a dwarf to a designated profile.
     :tags: fort armok units preferences
 
 This tool replaces a dwarf's preferences with an "ideal" set which is easy to

--- a/docs/pref-adjust.rst
+++ b/docs/pref-adjust.rst
@@ -2,8 +2,8 @@ pref-adjust
 ===========
 
 .. dfhack-tool::
-    :summary: Set the preferences of a dwarf to an ideal.
-    :tags: fort armok units
+    :summary: Get/Set the preferences of a dwarf.
+    :tags: fort armok units preferences
 
 This tool replaces a dwarf's preferences with an "ideal" set which is easy to
 satisfy::
@@ -16,19 +16,21 @@ satisfy::
 Usage
 -----
 
+``pref-adjust list``
+    List all types of preferences. No changes will be made to any units.
+``pref-adjust show``
+    Show the preferences of a unit.
 ``pref-adjust all|goth_all|clear_all``
-    Changes/clears preferences for all dwarves.
+    Changes/clears preferences for all units.
 ``pref-adjust one|goth|clear``
     Changes/clears preferences for the currently selected dwarf.
-``pref-adjust list``
-    List all types of preferences. No changes will be made to any dwarves.
 
 
 Examples
 --------
 
 ``pref-adjust all``
-    Change preferences for all dwarves to an ideal.
+    Change preferences for all units to an ideal.
 
 Goth mode
 ---------
@@ -41,3 +43,5 @@ instead of the easy-to-satisfy ideal defaults::
     their horrifying features.  When possible, she prefers to consume sewer
     brew, gutter cruor and bloated tubers.  She absolutely detests elves,
     humans and dwarves.
+
+

--- a/docs/pref-adjust.rst
+++ b/docs/pref-adjust.rst
@@ -2,7 +2,7 @@ pref-adjust
 ===========
 
 .. dfhack-tool::
-    :summary: Get the preferences of a dwarf, Set the preferences of a dwarf to a designated profile.
+    :summary: See the preferences of a dwarf or set them to a designated profile.
     :tags: fort armok units preferences
 
 This tool replaces a dwarf's preferences with an "ideal" set which is easy to

--- a/docs/pref-adjust.rst
+++ b/docs/pref-adjust.rst
@@ -43,5 +43,3 @@ instead of the easy-to-satisfy ideal defaults::
     their horrifying features.  When possible, she prefers to consume sewer
     brew, gutter cruor and bloated tubers.  She absolutely detests elves,
     humans and dwarves.
-
-

--- a/docs/pref-adjust.rst
+++ b/docs/pref-adjust.rst
@@ -30,7 +30,7 @@ Examples
 --------
 
 ``pref-adjust all``
-    Change preferences for all units to an ideal.
+    Change preferences for all citizens to an ideal.
 
 Goth mode
 ---------

--- a/pref-adjust.lua
+++ b/pref-adjust.lua
@@ -269,7 +269,8 @@ function build_all_lists(printflag)
 end -- end func build_all_lists
 -- ---------------------------------------------------------------------------
 function get_preferences(unit)
-    if unit == nil then
+    if not unit then  
+
         print("No unit selected!")
         return
     end
@@ -294,17 +295,17 @@ function get_preferences(unit)
         elseif pref_type == "LikePlant" then
             description = "Likes plant: " .. dfhack.matinfo.getToken(pref.mattype, pref.matindex)
         elseif pref_type == "HateCreature" then
-            description = "Hates creature: " .. df.global.world.raws.creatures.all[pref.poetic_form_id].creature_id
+            description = "Hates creature: " .. df.global.world.raws.creatures.all[pref.creature_id].creature_id
         elseif pref_type == "LikeColor" then
-            description = "Likes color: " .. df.global.world.raws.descriptors.colors[pref.poetic_form_id].id
+            description = "Likes color: " .. df.global.world.raws.descriptors.colors[pref.color_id].id
         elseif pref_type == "LikeShape" then
-            description = "Likes shape: " .. df.global.world.raws.descriptors.shapes[pref.poetic_form_id].id
+            description = "Likes shape: " .. df.global.world.raws.descriptors.shapes[pref.shape_id].id
         elseif pref_type == "LikePoeticForm" then
             description = "Likes poetic form: " .. dfhack.translation.translateName(df.global.world.poetic_forms.all[pref.poetic_form_id].name, true)
         elseif pref_type == "LikeMusicalForm" then
-            description = "Likes musical form: " .. dfhack.translation.translateName(df.global.world.musical_forms.all[pref.poetic_form_id].name, true)
+            description = "Likes musical form: " .. dfhack.translation.translateName(df.global.world.musical_forms.all[pref.musical_form_id].name, true)
         elseif pref_type == "LikeDanceForm" then
-            description = "Likes dance form: " .. dfhack.translation.translateName(df.global.world.dance_forms.all[pref.poetic_form_id].name, true)
+            description = "Likes dance form: " .. dfhack.translation.translateName(df.global.world.dance_forms.all[pref.dance_form_id].name, true)
         else
             description = "Unknown preference type: " .. tostring(pref.type)
         end

--- a/pref-adjust.lua
+++ b/pref-adjust.lua
@@ -270,7 +270,6 @@ end -- end func build_all_lists
 -- ---------------------------------------------------------------------------
 function get_preferences(unit)
     if not unit then  
-
         print("No unit selected!")
         return
     end
@@ -362,20 +361,11 @@ elseif opt == "all" then
     handle_all("IDEAL")
 elseif opt == "goth_all" then
     handle_all("GOTH")
-if opt == "show" then
+elseif opt == "show" then
     local unit = dfhack.gui.getSelectedUnit(true)
     get_preferences(unit)
 else
-    print ("Sets preferences of one dwarf, or of all dwarves, using profiles.")
-    print ("Valid options:")
-    print ("list       -- show available preference type lists")
-    print ("show       -- show current preferences")
-    print ("clear      -- clear preferences of selected unit")
-    print ("clear_all  -- clear preferences of all units")
-    print ("goth       -- alter current dwarf preferences to Goth")
-    print ("goth_all   -- alter all dwarf preferences to Goth")
-    print ("one        -- alter current dwarf preferences to Ideal")
-    print ("all        -- alter all dwarf preferences to Ideal")
+    print(dfhack.script_help())
     if opt and opt ~= "help" then
         qerror("Unrecognized option: " .. opt)
     end

--- a/pref-adjust.lua
+++ b/pref-adjust.lua
@@ -269,7 +269,7 @@ function build_all_lists(printflag)
 end -- end func build_all_lists
 -- ---------------------------------------------------------------------------
 function get_preferences(unit)
-    if not unit then  
+    if not unit then
         print("No unit selected!")
         return
     end

--- a/pref-adjust.lua
+++ b/pref-adjust.lua
@@ -362,7 +362,7 @@ elseif opt == "all" then
 elseif opt == "goth_all" then
     handle_all("GOTH")
 if opt == "show" then
-    local unit = dfhack.gui.getSelectedUnit()
+    local unit = dfhack.gui.getSelectedUnit(true)
     get_preferences(unit)
 else
     print ("Sets preferences of one dwarf, or of all dwarves, using profiles.")

--- a/pref-adjust.lua
+++ b/pref-adjust.lua
@@ -326,7 +326,7 @@ build_all_lists(false)
 local opt = ({...})[1]
 
 function handle_one(profile)
-    local unit = dfhack.gui.getSelectedUnit()
+    local unit = dfhack.gui.getSelectedUnit(true)
     if unit == nil then
         print ("No unit available!  Aborting with extreme prejudice.")
         return
@@ -343,7 +343,7 @@ end
 if opt == "list" then
     build_all_lists(true)
 elseif opt == "clear" then
-    local unit = dfhack.gui.getSelectedUnit()
+    local unit = dfhack.gui.getSelectedUnit(true)
     if unit==nil then
         print ("No unit available!  Aborting with extreme prejudice.")
         return

--- a/pref-adjust.lua
+++ b/pref-adjust.lua
@@ -6,7 +6,6 @@ pss_counter = pss_counter or 31415926
 
 -- ---------------------------------------------------------------------------
 function insert_preference(unit, preftype, val1)
-
     if preftype == df.unit_preference.T_type.LikeMaterial then
         utils.insert_or_update(unit.status.current_soul.preferences, {
             new = true,
@@ -269,6 +268,51 @@ function build_all_lists(printflag)
     end
 end -- end func build_all_lists
 -- ---------------------------------------------------------------------------
+function get_preferences(unit)
+    if unit == nil then
+        print("No unit selected!")
+        return
+    end
+
+    local preferences = unit.status.current_soul.preferences
+    if #preferences == 0 then
+        print("Unit " .. unit_name_to_console(unit) .. " has no preferences.")
+        return
+    end
+
+    print("Preferences for " .. unit_name_to_console(unit) .. ":")
+    for _, pref in ipairs(preferences) do
+        local pref_type = df.unit_preference.T_type[pref.type]
+        local description = ""
+
+        if pref_type == "LikeMaterial" then
+            description = "Likes material: " .. dfhack.matinfo.getToken(pref.mattype, pref.matindex)
+        elseif pref_type == "LikeFood" then
+            description = "Likes food: " .. dfhack.matinfo.getToken(pref.mattype, pref.matindex)
+        elseif pref_type == "LikeItem" then
+            description = "Likes item type: " .. tostring(pref.item_type)
+        elseif pref_type == "LikePlant" then
+            description = "Likes plant: " .. dfhack.matinfo.getToken(pref.mattype, pref.matindex)
+        elseif pref_type == "HateCreature" then
+            description = "Hates creature: " .. df.global.world.raws.creatures.all[pref.poetic_form_id].creature_id
+        elseif pref_type == "LikeColor" then
+            description = "Likes color: " .. df.global.world.raws.descriptors.colors[pref.poetic_form_id].id
+        elseif pref_type == "LikeShape" then
+            description = "Likes shape: " .. df.global.world.raws.descriptors.shapes[pref.poetic_form_id].id
+        elseif pref_type == "LikePoeticForm" then
+            description = "Likes poetic form: " .. dfhack.translation.translateName(df.global.world.poetic_forms.all[pref.poetic_form_id].name, true)
+        elseif pref_type == "LikeMusicalForm" then
+            description = "Likes musical form: " .. dfhack.translation.translateName(df.global.world.musical_forms.all[pref.poetic_form_id].name, true)
+        elseif pref_type == "LikeDanceForm" then
+            description = "Likes dance form: " .. dfhack.translation.translateName(df.global.world.dance_forms.all[pref.poetic_form_id].name, true)
+        else
+            description = "Unknown preference type: " .. tostring(pref.type)
+        end
+
+        print(description)
+    end
+end -- end function: get_preferences
+-- ---------------------------------------------------------------------------
 function unit_name_to_console(unit)
     return dfhack.df2console(dfhack.units.getReadableName(unit))
 end
@@ -317,10 +361,14 @@ elseif opt == "all" then
     handle_all("IDEAL")
 elseif opt == "goth_all" then
     handle_all("GOTH")
+if opt == "show" then
+    local unit = dfhack.gui.getSelectedUnit()
+    get_preferences(unit)
 else
     print ("Sets preferences of one dwarf, or of all dwarves, using profiles.")
     print ("Valid options:")
     print ("list       -- show available preference type lists")
+    print ("show       -- show current preferences")
     print ("clear      -- clear preferences of selected unit")
     print ("clear_all  -- clear preferences of all units")
     print ("goth       -- alter current dwarf preferences to Goth")


### PR DESCRIPTION
This feature returns the list of Likes for a selected dwarf.

This script may be useful if:
* a user wants to view a quick list of likes for a dwarf
* a user wants to view the list of likes after updating a dwarfs likes
* Other scripts may find this helpful, as this functionality is not otherwise exposed via dfhack