### PR TITLE
Feat: Add `show` to `assign-preferences` script

### DIFF
--- a/assign-preferences.lua
+++ b/assign-preferences.lua
@@ -1,193 +1,12 @@
 -- Change the preferences of a unit.
 --@ module = true
 
-local help = [====[
-
-assign-preferences
-==================
-A script to change the preferences of a unit.
-
-Preferences are classified into 12 types. The first 9 are:
-
-* like material;
-* like creature;
-* like food;
-* hate creature;
-* like item;
-* like plant;
-* like tree;
-* like colour;
-* like shape.
-
-These can be changed using this script.
-
-The remaining three are not currently managed by this script,
-and are: like poetic form, like musical form, like dance form.
-
-To produce the correct description in the "thoughts and preferences"
-page, you must specify the particular type of preference. For
-each type, a description is provided in the section below.
-
-You will need to know the token of the object you want your dwarf to like.
-You can find them in the wiki, otherwise in the folder "/raw/objects/" under
-the main DF directory you will find all the raws defined in the game.
-
-For more information:
-https://dwarffortresswiki.org/index.php/DF2014:Preferences
-
-Usage:
-
-``-help``:
-                    print the help page.
-
-``-unit <UNIT_ID>``:
-                    set the target unit ID. If not present, the
-                    currently selected unit will be the target.
-
-``-likematerial [ <TOKEN> <TOKEN> <...> ]``:
-                    usually a type of stone, a type of metal and a type
-                    of gem, plus it can also be a type of wood, a type of
-                    glass, a type of leather, a type of horn, a type of
-                    pearl, a type of ivory, a decoration material - coral
-                    or amber, a type of bone, a type of shell, a type
-                    of silk, a type of yarn, or a type of plant cloth.
-                    Write the full tokens.
-                    There must be a space before and after each square
-                    bracket.
-
-``-likecreature [ <TOKEN> <TOKEN> <...> ]``:
-                    one or more creatures liked by the unit. You can
-                    just list the species: the creature token will be
-                    something similar to ``CREATURE:SPARROW:SKIN``,
-                    so the name of the species will be ``SPARROW``. Nothing
-                    will stop you to write the full token, if you want: the
-                    script will just ignore the first and the last parts.
-                    There must be a space before and after each square
-                    bracket.
-
-``-likefood [ <TOKEN> <TOKEN> <...> ]``:
-                    usually a type of alcohol, plus it can be a type of
-                    meat, a type of fish, a type of cheese, a type of edible
-                    plant, a cookable plant/creature extract, a cookable
-                    mill powder, a cookable plant seed or a cookable plant
-                    leaf. Write the full tokens.
-                    There must be a space before and after each square
-                    bracket.
-
-``-hatecreature [ <TOKEN> <TOKEN> <...> ]``:
-                    works the same way as ``-likecreature``, but this time
-                    it's one or more creatures that the unit detests. They
-                    should be a type of ``HATEABLE`` vermin which isn't already
-                    explicitly liked, but no check is performed about this.
-                    Like before, you can just list the creature species.
-                    There must be a space before and after each square
-                    bracket.
-
-``-likeitem [ <TOKEN> <TOKEN> <...> ]``:
-                    a kind of weapon, a kind of ammo, a kind of piece of
-                    armor, a piece of clothing (including backpacks or
-                    quivers), a type of furniture (doors, floodgates, beds,
-                    chairs, windows, cages, barrels, tables, coffins,
-                    statues, boxes, armor stands, weapon racks, cabinets,
-                    bins, hatch covers, grates, querns, millstones, traction
-                    benches, or slabs), a kind of craft (figurines, amulets,
-                    scepters, crowns, rings, earrings, bracelets, or large
-                    gems), or a kind of miscellaneous item (catapult parts,
-                    ballista parts, a type of siege ammo, a trap component,
-                    coins, anvils, totems, chains, flasks, goblets,
-                    buckets, animal traps, an instrument, a toy, splints,
-                    crutches, or a tool). The item tokens can be found here:
-                    https://dwarffortresswiki.org/index.php/DF2014:Item_token
-                    If you want to specify an item subtype, look into the files
-                    listed under the column "Subtype" of the wiki page (they are
-                    in the "/raw/ojects/" folder), then specify the items using
-                    the full tokens found in those files (see examples below).
-                    There must be a space before and after each square
-                    bracket.
-
-``-likeplant [ <TOKEN> <TOKEN> <...> ]``:
-                    works in a similar way as ``-likecreature``, this time
-                    with plants. You can just List the plant species (the
-                    middle part of the token).
-                    There must be a space before and after each square
-                    bracket.
-
-``-liketree [ <TOKEN> <TOKEN> <...> ]``:
-                    works exactly as ``-likeplant``. I think this
-                    preference type is here for backward compatibility (?).
-                    You can still use it, however. As before,
-                    you can just list the tree (plant) species.
-                    There must be a space before and after each square
-                    bracket.
-
-``-likecolor [ <TOKEN> <TOKEN> <...> ]``:
-                    you can find the color tokens here:
-                    https://dwarffortresswiki.org/index.php/DF2014:Color#Color_tokens
-                    or inside the "descriptor_color_standard.txt" file
-                    (in the "/raw/ojects/" folder). You can use the full token or
-                    just the color name.
-                    There must be a space before and after each square
-                    bracket.
-
-``-likeshape [ <TOKEN> <TOKEN> <...> ]``:
-                    I couldn't find a list of shape tokens in the wiki, but you
-                    can find them inside the "descriptor_shape_standard.txt"
-                    file (in the "/raw/ojects/" folder). You can
-                    use the full token or just the shape name.
-                    There must be a space before and after each square
-                    bracket.
-
-``-reset``:
-                    clear all preferences. If the script is called
-                    with both this option and one or more preferences,
-                    first all the unit preferences will be cleared
-                    and then the listed preferences will be added.
-
-Examples:
-
-* "likes alabaster and willow wood"::
-
-    assign-preferences -reset -likematerial [ INORGANIC:ALABASTER PLANT:WILLOW:WOOD ]
-
-* "likes sparrows for their ..."::
-
-    assign-preferences -reset -likecreature SPARROW
-
-* "prefers to consume dwarven wine and olives"::
-
-    assign-preferences -reset -likefood [ PLANT:MUSHROOM_HELMET_PLUMP:DRINK PLANT:OLIVE:FRUIT ]
-
-* "absolutely detests jumping spiders::
-
-    assign-preferences -reset -hatecreature SPIDER_JUMPING
-
-* "likes logs and battle axes"::
-
-    assign-preferences -reset -likeitem [ WOOD ITEM_WEAPON:ITEM_WEAPON_AXE_BATTLE ]
-
-* "likes straberry plants for their ..."::
-
-    assign-preferences -reset -likeplant BERRIES_STRAW
-
-* "likes oaks for their ..."::
-
-    assign-preferences -reset -liketree OAK
-
-* "likes the color aqua"::
-
-    assign-preferences -reset -likecolor AQUA
-
-* "likes stars"::
-
-    assign-preferences -reset -likeshape STAR
-
-]====]
-
 local utils = require("utils")
 
 local valid_args = utils.invert({
                                     'help',
                                     'unit',
+                                    'show',
                                     'likematerial',
                                     'likecreature',
                                     'likefood',
@@ -205,6 +24,38 @@ local function print_yellow(text)
     dfhack.color(COLOR_YELLOW)
     print(text)
     dfhack.color(-1)
+end
+
+local function format_preference(pref, index)
+    print(string.format("Preference #%d:", index))
+
+    local pref_type = df.unit_preference.T_type[pref.type]
+    local description = ""
+    if pref_type == "LikeMaterial" then
+        description = "Likes material: " .. dfhack.matinfo.getToken(pref.mattype, pref.matindex)
+    elseif pref_type == "LikeFood" then
+        description = "Likes food: " .. dfhack.matinfo.getToken(pref.mattype, pref.matindex)
+    elseif pref_type == "LikeItem" then
+        description = "Likes item type: " .. tostring(pref.item_type)
+    elseif pref_type == "LikePlant" then
+        description = "Likes plant: " .. dfhack.matinfo.getToken(pref.mattype, pref.matindex)
+    elseif pref_type == "HateCreature" then
+        description = "Hates creature: " .. df.global.world.raws.creatures.all[pref.creature_id].creature_id
+    elseif pref_type == "LikeColor" then
+        description = "Likes color: " .. df.global.world.raws.descriptors.colors[pref.color_id].id
+    elseif pref_type == "LikeShape" then
+        description = "Likes shape: " .. df.global.world.raws.descriptors.shapes[pref.shape_id].id
+    elseif pref_type == "LikePoeticForm" then
+        description = "Likes poetic form: " .. dfhack.translation.translateName(df.global.world.poetic_forms.all[pref.poetic_form_id].name, true)
+    elseif pref_type == "LikeMusicalForm" then
+        description = "Likes musical form: " .. dfhack.translation.translateName(df.global.world.musical_forms.all[pref.musical_form_id].name, true)
+    elseif pref_type == "LikeDanceForm" then
+        description = "Likes dance form: " .. dfhack.translation.translateName(df.global.world.dance_forms.all[pref.dance_form_id].name, true)
+    else
+        description = "Unknown preference type: " .. tostring(pref.type)
+    end
+
+    print(description)
 end
 
 -- initialise random number generator
@@ -624,12 +475,25 @@ function assign(preferences, unit, reset)
     end
 end
 
+-- ----------------------------------------------- SHOW PREF UTILITY ------------------------------------------------ --
+local function showPreferences(unit)
+    assert(not unit or type(unit) == "number" or df.unit:is_instance(unit))
+    unit = unit or dfhack.gui.getSelectedUnit(true)
+    if not unit then
+        qerror("No unit found.")
+    end
+    
+    for i, pref in ipairs(unit.status.current_soul.preferences) do
+        format_preference(pref, i)
+    end
+end
+
 -- ------------------------------------------------------ MAIN ------------------------------------------------------ --
 local function main(...)
     local args = utils.processArgs({ ... }, valid_args)
 
     if args.help then
-        print(help)
+        print(dfhack.script_help())
         return
     end
 
@@ -646,9 +510,15 @@ local function main(...)
         reset = true
     end
 
+    if args.show then
+        showPreferences(unit)
+        return
+    end
+
     -- parse preferences
     args.unit = nil -- remove from args table
     args.reset = nil -- remove from args table
+    args.show = nil -- remove from args table
     local preferences = {}
     utils.assign(preferences, args)
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -61,6 +61,7 @@ Template for new versions:
 - `caravan`: add filter for written works in display furniture assignment dialog
 - `fix/wildlife`: don't vaporize stuck wildlife that is onscreen -- kill them instead (as if they died from old age)
 - `gui/sitemap`: show primary group affiliation for visitors and invaders (e.g. civilization name or performance troupe)
+- `assign-preferences`: updated to allow users to run `assign-preferences -show` to get a list of selected units preferences
 
 # 50.15-r1
 

--- a/docs/assign-preferences.rst
+++ b/docs/assign-preferences.rst
@@ -2,7 +2,7 @@ assign-preferences
 ==================
 
 .. dfhack-tool::
-    :summary: Adjust a unit's preferences.
+    :summary: View or Adjust a unit's preferences.
     :tags: fort armok units
 
 You will need to know the token of the object you want your dwarf to like.
@@ -71,6 +71,8 @@ brackets can be omitted.
 ``--unit <id>``
     The target unit ID. If not present, the currently selected unit will be the
     target.
+``--show``
+    Print the list of current likes/dislikes for the selected unit
 ``--likematerial [ <token> [<token> ...] ]``
     This is usually set to three tokens: a type of stone, a type of metal, and a
     type of gem. It can also be a type of wood, glass, leather, horn, pearl,


### PR DESCRIPTION
This feature returns the list of preferences for a selected dwarf.

This script may be useful if:

* a user wants to view a quick list of likes for a dwarf
* a user wants to view the list of likes after updating a dwarfs likes
* Other scripts may find this helpful, as this functionality is not otherwise exposed via dfhack