### PR TITLE
Fix df.talk_choice_type def not being up to date for internal/convo.lua

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,12 +27,12 @@ Template for new versions:
 # Future
 
 ## New Tools
-
 - `autocheese`: automatically make cheese using barrels that have accumulated sufficient milk
 
 ## New Features
 
 ## Fixes
+- `advtools`: fix dfhack-added conversation options not appearing in the ask whereabouts conversation tree
 
 ## Misc Improvements
 - `assign-preferences`: new ``--show`` option to display the preferences of the selected unit

--- a/internal/advtools/convo.lua
+++ b/internal/advtools/convo.lua
@@ -81,7 +81,7 @@ local function addWhereaboutsChoice(race, name, target_id, heard_of)
     if heard_of then
         title = title .. " (Heard of)"
     end
-    local choice = new_choice(df.talk_choice_type.AskWhereabouts, title, dfhack.translation.translateName(name):split())
+    local choice = new_choice(df.talk_choice_type.AskForDirectionsToHF, title, dfhack.translation.translateName(name):split())
     -- insert before the last choice, which is usually "back"
     adventure.conversation.conv_choice_info:insert(#adventure.conversation.conv_choice_info-1, choice)
     choice.choice.invocation_target_hfid = target_id


### PR DESCRIPTION
This also fixes the extra options not appearing in the conversation menu in the "Ask directions" screen