### PR TITLE
[gui/rename] fix typo causing error on language change

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@ Template for new versions:
 
 ## Fixes
 - `advtools`: fix dfhack-added conversation options not appearing in the ask whereabouts conversation tree
+- `gui/rename`: fix error when changing the language of a unit's name
 
 ## Misc Improvements
 - `assign-preferences`: new ``--show`` option to display the preferences of the selected unit

--- a/gui/rename.lua
+++ b/gui/rename.lua
@@ -704,7 +704,7 @@ function Rename:set_language(val, prev_val)
             sync_name()
         else
             sync_name.language = val
-            sync_name.first_name = self.target.first_name
+            sync_name.first_name = self.target.name.first_name
         end
     end
 end


### PR DESCRIPTION
Changing the language of a unit's name caused an error here, preventing the name from being fully set on the unit.