### PR TITLE
Fix some EditField hotkey conflicts

### DIFF
--- a/gui/autochop.lua
+++ b/gui/autochop.lua
@@ -239,6 +239,7 @@ function Autochop:init()
                 self:update_choices()
             end,
             visible=is_not_minimal,
+            disabled=function() return self.subviews.target.focus end,
         },
         widgets.Label{
             view_id='summary',

--- a/gui/quantum.lua
+++ b/gui/quantum.lua
@@ -133,6 +133,7 @@ function Quantum:init()
             view_id='create_sp',
             key='CUSTOM_CTRL_Z',
             label='Create output pile:',
+            disabled=function() return self.subviews.name.focus end,
         },
         widgets.CycleHotkeyLabel{
             view_id='feeder_mode',

--- a/gui/quickfort.lua
+++ b/gui/quickfort.lua
@@ -380,6 +380,7 @@ function Quickfort:init()
                         label='Warm dig:',
                         initial_option=markers.warm,
                         on_change=function(val) markers.warm = val end,
+                        disabled=function() return self.subviews.repeat_times.focus end,
                     },
                 },
             },

--- a/gui/quickfort.lua
+++ b/gui/quickfort.lua
@@ -38,7 +38,7 @@ transformations = transformations or {}
 
 -- blueprint selection dialog, shown when the script starts or when a user wants
 -- to load a new blueprint into the ui
-BlueprintDialog = defclass(SelectDialog, gui.ZScreenModal)
+BlueprintDialog = defclass(BlueprintDialog, gui.ZScreenModal)
 BlueprintDialog.ATTRS{
     focus_path='quickfort/dialog',
     on_select=DEFAULT_NIL,

--- a/internal/gm-unit/editor_civilization.lua
+++ b/internal/gm-unit/editor_civilization.lua
@@ -107,7 +107,7 @@ function CivBox:choose_race()
 end
 function CivBox:init(info)
     self.subviews.list.frame={t=3,r=0,l=0}
-    self.subviews.list.edit.ignore_keys={"STRING_A047"},
+    self.subviews.list.edit.text_area.text_area.ignore_keys={"STRING_A047"}
     self:addviews{
         widgets.Label{frame={t=1,l=0},text={
         {text="Filter race ",key="STRING_A047",key_sep="()",on_activate=self:callback("choose_race")},


### PR DESCRIPTION
Other EditField conflicts will be posted in an issue, but these seemed small- and effective-enough to put into commits.

The encapsulation violation for the CivBox fix isn't exactly pleasant, but it would probably be much more invasive to get EditField to support post-init reconfiguration.