### PR TITLE
Use guidm cursor fns

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -38,10 +38,9 @@ Template for new versions:
 
 ## Fixes
 - `position`: support for adv mode look cursor
-- `devel/query`, `devel/tree-info`, `hfs-pit`, `colonies`: now function in adventure mode
+- `devel/query`, `devel/tree-info`, `hfs-pit`, `colonies`, `toggle-kbd-cursor`: now function in adventure mode
 - `hfs-pit`: fix up tiletypes of pit walls, better placement of stairs (w/r/t eerie pits and ramp tops)
 - `modtools/create-item`: ``hackWish`` now respects ``opts.pos`` and will spawn items there if provided
-- `toggle-kbd-cursor`: exclude adventure mode because it isn't compatible
 
 ## Misc Improvements
 - `hide-tutorials`: handle tutorial popups for adventure mode

--- a/changelog.txt
+++ b/changelog.txt
@@ -30,12 +30,18 @@ Template for new versions:
 - `devel/export-map`: export map tile data to a JSON file
 - `autocheese`: automatically make cheese using barrels that have accumulated sufficient milk
 - `gui/spectate`: interactive UI for configuring `spectate`
+- `launch`: (reinstated) thrash your enemies with a flying suplex
+- `putontable`: (reinstated) make an item appear on a table like in adventure mode
 
 ## New Features
-- `advtools`: new ``advtools.fastcombat`` overlay (enabled by default)  allows you to skip combat animations and the announcement "More" button by mashing the movement keys
+- `advtools`: new ``advtools.fastcombat`` overlay (enabled by default) allows you to skip combat animations and the announcement "More" button by mashing the movement keys
 
 ## Fixes
 - `position`: support for adv mode look cursor
+- `devel/query`, `devel/tree-info`, `hfs-pit`, `colonies`: now function in adventure mode
+- `hfs-pit`: fix up tiletypes of pit walls, better placement of stairs (w/r/t eerie pits and ramp tops)
+- `modtools/create-item`: ``hackWish`` now respects ``opts.pos`` and will spawn items there if provided
+- `toggle-kbd-cursor`: exclude adventure mode because it isn't compatible
 
 ## Misc Improvements
 - `hide-tutorials`: handle tutorial popups for adventure mode
@@ -43,6 +49,7 @@ Template for new versions:
 - `gui/notify`: moody dwarf notification turns red when they can't reach workshop or items
 - `gui/confirm`: in the delete manager order confirmation dialog, show a description of which order you have selected to delete
 - `position`: display both adventurer and site pos simultaneously. Display map block pos+offset of selected tile.
+- `gui/create-item`: now accepts a ``pos`` argument of where to spawn items
 
 ## Removed
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -30,17 +30,20 @@ Template for new versions:
 - `devel/export-map`: export map tile data to a JSON file
 - `autocheese`: automatically make cheese using barrels that have accumulated sufficient milk
 - `gui/spectate`: interactive UI for configuring `spectate`
-- `launch`: (reinstated) thrash your enemies with a flying suplex
-- `putontable`: (reinstated) make an item appear on a table like in adventure mode
+- `launch`: (reinstated) new adventurer fighting move: thrash your enemies with a flying suplex
+- `putontable`: (reinstated) make an item appear on a table
+- `devel/query`: support adventure mode
+- `devel/tree-info`: support adventure mode
+- `hfs-pit`: support adventure mode
+- `colonies`: support adventure mode
+- `toggle-kbd-cursor`: support adventure mode
 
 ## New Features
 - `advtools`: new ``advtools.fastcombat`` overlay (enabled by default) allows you to skip combat animations and the announcement "More" button by mashing the movement keys
 
 ## Fixes
 - `position`: support for adv mode look cursor
-- `devel/query`, `devel/tree-info`, `hfs-pit`, `colonies`, `toggle-kbd-cursor`: now function in adventure mode
-- `hfs-pit`: fix up tiletypes of pit walls, better placement of stairs (w/r/t eerie pits and ramp tops)
-- `modtools/create-item`: ``hackWish`` now respects ``opts.pos`` and will spawn items there if provided
+- `hfs-pit`: use correct wall types when making pits with walls
 
 ## Misc Improvements
 - `hide-tutorials`: handle tutorial popups for adventure mode
@@ -49,6 +52,8 @@ Template for new versions:
 - `gui/confirm`: in the delete manager order confirmation dialog, show a description of which order you have selected to delete
 - `position`: display both adventurer and site pos simultaneously. Display map block pos+offset of selected tile.
 - `gui/create-item`: now accepts a ``pos`` argument of where to spawn items
+- `modtools/create-item`: exported ``hackWish`` function now supports ``opts.pos`` for determining spawn location
+- `hfs-pit`: improve placement of stairs w/r/t eerie pits and ramp tops
 
 ## Removed
 

--- a/colonies.lua
+++ b/colonies.lua
@@ -20,6 +20,8 @@ and ``colonies convert TERMITE`` ends your beekeeping industry.
 
 ]====]
 
+local guidm = require('gui.dwarfmode')
+
 function findVermin(target_verm)
     for k,v in ipairs(df.global.world.raws.creatures.all) do
         if v.creature_id == target_verm then
@@ -50,8 +52,8 @@ function convert_vermin_to(target_verm)
 end
 
 function place_vermin(target_verm)
-    local pos = copyall(df.global.cursor)
-    if pos.x == -30000 then
+    local pos = guidm.getCursorPos()
+    if not pos then
         qerror("Cursor must be pointing somewhere")
     end
     local verm = df.vermin:new()

--- a/devel/light.lua
+++ b/devel/light.lua
@@ -27,12 +27,6 @@ function setCell(x,y,cell)
     cell.bo=cell.bo or {r=0,g=0,b=0}
     render.setCell(x,y,cell)
 end
-function getCursorPos()
-    local g_cursor=df.global.cursor
-    if g_cursor.x ~= -30000 then
-        return copyall(g_cursor)
-    end
-end
 --luacheck: skip
 function falloff(color,sqDist,maxdist)
     local v1=1/(sqDist/maxdist+1)
@@ -273,7 +267,7 @@ function LightOverlay:calculateLightSun()
     end
 end
 function LightOverlay:calculateLightCursor()
-    local c=getCursorPos()
+    local c=guidm.getCursorPos()
 
     if c then
 

--- a/devel/query.lua
+++ b/devel/query.lua
@@ -2,7 +2,8 @@
 -- Written by Josh Cooper(cppcooper) on 2017-12-21, last modified: 2021-06-13
 -- Version: 3.2
 --luacheck:skip-entirely
-local utils=require('utils')
+local guidm = require('gui.dwarfmode')
+local utils = require('utils')
 local validArgs = utils.invert({
  'help',
 
@@ -221,14 +222,11 @@ function getSelectionData()
     elseif args.job then
         debugf(0,"job selection")
         selection = dfhack.gui.getSelectedJob(true)
-        if selection == nil and df.global.cursor.x >= 0 then
-            local pos = { x=df.global.cursor.x,
-                          y=df.global.cursor.y,
-                          z=df.global.cursor.z }
+        local pos = guidm.getCursorPos()
+        if selection == nil and pos then
             print("searching for a job at the cursor")
             for _link, job in utils.listpairs(df.global.world.jobs.list) do
-                local jp = job.pos
-                if jp.x == pos.x and jp.y == pos.y and jp.z == pos.z then
+                if same_xyz(job.pos, pos) then
                     if selection == nil then
                         selection = {}
                     end
@@ -240,7 +238,7 @@ function getSelectionData()
         path_info_pattern = path_info
     elseif args.tile then
         debugf(0,"tile selection")
-        local pos = copyall(df.global.cursor)
+        local pos = guidm.getCursorPos()
         selection = dfhack.maps.ensureTileBlock(pos.x,pos.y,pos.z)
         bpos = selection.map_pos
         path_info = string.format("tile[%d][%d][%d]",pos.x,pos.y,pos.z)
@@ -249,7 +247,7 @@ function getSelectionData()
         tiley = pos.y%16
     elseif args.block then
         debugf(0,"block selection")
-        local pos = copyall(df.global.cursor)
+        local pos = guidm.getCursorPos()
         selection = dfhack.maps.ensureTileBlock(pos.x,pos.y,pos.z)
         bpos = selection.map_pos
         path_info = string.format("blocks[%d][%d][%d]",bpos.x,bpos.y,bpos.z)

--- a/devel/tree-info.lua
+++ b/devel/tree-info.lua
@@ -1,5 +1,6 @@
 --Print a tree_info visualization of the tree at the cursor.
 --@module = true
+local guidm = require('gui.dwarfmode')
 
 -- [w][n][e][s]
 local branch_chars = {
@@ -172,7 +173,11 @@ function printTree(t)
 end
 
 if not dfhack_flags.module then
-    local p = dfhack.maps.getPlantAtTile(copyall(df.global.cursor))
+    local p = guidm.getCursorPos()
+    if not p then
+        qerror('No cursor!')
+    end
+    p = dfhack.maps.getPlantAtTile(p)
     if p and p.tree_info then
         printTree(p.tree_info)
     else

--- a/devel/tree-info.lua
+++ b/devel/tree-info.lua
@@ -173,11 +173,9 @@ function printTree(t)
 end
 
 if not dfhack_flags.module then
-    local p = guidm.getCursorPos()
-    if not p then
-        qerror('No cursor!')
-    end
-    p = dfhack.maps.getPlantAtTile(p)
+    local pos = guidm.getCursorPos()
+    if not pos then qerror('No cursor!') end
+    local p = dfhack.maps.getPlantAtTile(pos)
     if p and p.tree_info then
         printTree(p.tree_info)
     else

--- a/docs/extinguish.rst
+++ b/docs/extinguish.rst
@@ -3,7 +3,7 @@ extinguish
 
 .. dfhack-tool::
     :summary: Put out fires.
-    :tags: fort armok buildings items map units
+    :tags: fort adventure armok buildings items map units
 
 With this tool, you can put out fires affecting map tiles, plants, units, items,
 and buildings.

--- a/docs/firestarter.rst
+++ b/docs/firestarter.rst
@@ -3,7 +3,7 @@ firestarter
 
 .. dfhack-tool::
     :summary: Lights things on fire.
-    :tags: fort armok items map units
+    :tags: fort adventure armok items map units
 
 Feel the need to burn something? Set items, locations, or even entire
 inventories on fire! Use while viewing an item, with the cursor over a map tile,

--- a/docs/gui/create-item.rst
+++ b/docs/gui/create-item.rst
@@ -42,6 +42,10 @@ Options
 ``-f``, ``--unrestricted``
     Don't restrict the material options to only those that are normally
     appropriate for the selected item type.
+``-p``, ``--pos <x>,<y>,<z>``
+    If specified, items will be spawned at the given coordinates instead of at
+    the creator unit's feet. ``here`` can be used in place of ``<x>,<y>,<z>``
+    to use the active keyboard cursor.
 ``--startup``
     Instead of showing the item creation interface, start monitoring for a
     modded reaction with a code of ``DFHACK_WISH``. When a reaction with that

--- a/docs/launch.rst
+++ b/docs/launch.rst
@@ -3,7 +3,7 @@ launch
 
 .. dfhack-tool::
     :summary: Thrash your enemies with a flying suplex.
-    :tags: unavailable
+    :tags: adventure armok units
 
 Attack another unit and then run this command to grab them and fly in a glorious
 parabolic arc to where you have placed the cursor. You'll land safely and your

--- a/docs/modtools/create-item.rst
+++ b/docs/modtools/create-item.rst
@@ -48,4 +48,5 @@ Options
     caste associated with it.
 ``-p``, ``--pos <x>,<y>,<z>``
     If specified, items will be spawned at the given coordinates instead of at
-    the creator unit's feet.
+    the creator unit's feet. ``here`` can be used in place of ``<x>,<y>,<z>``
+    to use the active keyboard cursor.

--- a/docs/putontable.rst
+++ b/docs/putontable.rst
@@ -3,7 +3,7 @@ putontable
 
 .. dfhack-tool::
     :summary: Make an item appear on a table.
-    :tags: unavailable
+    :tags: adventure fort armok buildings items
 
 To use this tool, move an item to the ground on the same tile as a built table.
 Then, place the cursor over the table and item and run this command. The item

--- a/docs/toggle-kbd-cursor.rst
+++ b/docs/toggle-kbd-cursor.rst
@@ -3,14 +3,14 @@ toggle-kbd-cursor
 
 .. dfhack-tool::
     :summary: Toggles the keyboard cursor.
-    :tags: fort interface
+    :tags: adventure fort interface
 
 This tool simply toggles the keyboard cursor so you can quickly switch it on
 when you need it. Many other tools, like `autodump`, need a keyboard cursor for
 selecting a target tile. Note that you'll still need to enter an interface mode
 where the keyboard cursor is visible, like mining mode or dumping mode, in
-order to use the cursor. This tool does not function in adventure mode because
-the adventurer cursor cannot be trivially toggled.
+order to use the cursor. In adventure mode, this tool toggles look mode via
+simulated input.
 
 Usage
 -----

--- a/docs/toggle-kbd-cursor.rst
+++ b/docs/toggle-kbd-cursor.rst
@@ -3,9 +3,14 @@ toggle-kbd-cursor
 
 .. dfhack-tool::
     :summary: Toggles the keyboard cursor.
-    :tags: interface
+    :tags: fort interface
 
-This tool simply toggles the keyboard cursor so you can quickly switch it on when you need it. Many other tools, like `autodump`, need a keyboard cursor for selecting a target tile. Note that you'll still need to enter an interface mode where the keyboard cursor is visible, like mining mode or dumping mode, in order to use the cursor.
+This tool simply toggles the keyboard cursor so you can quickly switch it on
+when you need it. Many other tools, like `autodump`, need a keyboard cursor for
+selecting a target tile. Note that you'll still need to enter an interface mode
+where the keyboard cursor is visible, like mining mode or dumping mode, in
+order to use the cursor. This tool does not function in adventure mode because
+the adventurer cursor cannot be trivially toggled.
 
 Usage
 -----

--- a/docs/toggle-kbd-cursor.rst
+++ b/docs/toggle-kbd-cursor.rst
@@ -5,12 +5,15 @@ toggle-kbd-cursor
     :summary: Toggles the keyboard cursor.
     :tags: adventure fort interface
 
-This tool simply toggles the keyboard cursor so you can quickly switch it on
-when you need it. Many other tools, like `autodump`, need a keyboard cursor for
-selecting a target tile. Note that you'll still need to enter an interface mode
-where the keyboard cursor is visible, like mining mode or dumping mode, in
-order to use the cursor. In adventure mode, this tool toggles look mode via
-simulated input.
+This tool toggles the keyboard cursor so you can quickly switch it on when
+you need it. Many other DFHack tools, like `autodump` or `digv`, need a
+keyboard cursor for selecting a target tile.
+
+In fort mode, it toggles the game setting for "Enable keyboard cursor".
+Note that you'll still need to enter an interface mode where the keyboard
+cursor is visible, like mining mode or dumping mode.
+
+In adventure mode, it will toggle "Look" mode.
 
 Usage
 -----

--- a/gui/blueprint.lua
+++ b/gui/blueprint.lua
@@ -381,7 +381,7 @@ function Blueprint:onShow()
 end
 
 function Blueprint:save_cursor_pos()
-    self.saved_cursor = copyall(df.global.cursor)
+    self.saved_cursor = guidm.getCursorPos()
 end
 
 function Blueprint:is_setting_start_pos()

--- a/gui/companion-order.lua
+++ b/gui/companion-order.lua
@@ -25,10 +25,11 @@ Can be called with '-c' flag to display "cheating" commands.
 ]====]
 
 local gui = require 'gui'
+local guidm = require 'gui.dwarfmode'
 local dlg = require 'gui.dialogs'
 local args={...}
 local is_cheat=(#args>0 and args[1]=="-c")
-local cursor=xyz2pos(df.global.cursor.x,df.global.cursor.y,df.global.cursor.z)
+local cursor=guidm.getCursorPos()
 local permited_equips={}
 
 permited_equips[df.item_backpackst]="UPPERBODY"
@@ -46,7 +47,7 @@ function DoesHaveSubtype(item)
     return true
 end
 function CheckCursor(p)
-    if p.x==-30000 then
+    if not p then
         dlg.showMessage(
                 'Companion orders',
                 'You must have a cursor on some tile!', COLOR_LIGHTRED
@@ -54,12 +55,6 @@ function CheckCursor(p)
         return false
     end
     return true
-end
-function getxyz() -- this will return pointers x,y and z coordinates.
-    local x=df.global.cursor.x
-    local y=df.global.cursor.y
-    local z=df.global.cursor.z
-    return x,y,z -- return the coords
 end
 
 function EnumBodyEquipable(race_id,caste_id)
@@ -190,7 +185,7 @@ end
 function GetItemsAtPos(pos)
     local ret={}
     for k,v in pairs(df.global.world.items.other.IN_PLAY) do
-        if v.flags.on_ground and v.pos.x==pos.x and v.pos.y==pos.y and v.pos.z==pos.z then
+        if v.flags.on_ground and same_xyz(v.pos, pos) then
             table.insert(ret,v)
         end
     end
@@ -232,7 +227,7 @@ function move_unit( unit,tx,ty,tz ) --copied from http/commands.lua with minor m
     unit.idle_area_threshold=0
     unit.follow_distance=50
     --invalidate old path
-    unit.path.dest={x=unit.idle_area.x,y=unit.idle_area.y,z=unit.idle_area.z}
+    unit.path.dest=copyall(unit.idle_area)
     unit.path.goal=df.unit_path_goal.SeekStation
     unit.path.path.x:resize(0)
     unit.path.path.y:resize(0)
@@ -394,7 +389,7 @@ end},
         return false
     end
     adv=dfhack.world.getAdventurer()
-    item=GetItemsAtPos(df.global.cursor)[1]
+    item=GetItemsAtPos(cursor)[1]
     print(item.id)
     for k,v in pairs(unit_list) do
         v.riding_item_id=item.id

--- a/gui/create-item.lua
+++ b/gui/create-item.lua
@@ -232,7 +232,8 @@ local default_accessors = {
             partlayerok, partlayerID = script.showListPrompt('Wish', 'What creature material should it be?',
                 COLOR_LIGHTGREEN, getCreatureMaterialList(raceId, casteId), 1, true)
         else
-            --the offsets here are because indexes in lua are wonky (some start at 0, some start at 1), so we adjust for that, as well as the index offset created by inserting the "generic" option at the start of the body part selection prompt
+            --the offsets here are because indexes in lua are wonky (some start at 0, some start at 1), so we adjust for that,
+            --as well as the index offset created by inserting the "generic" option at the start of the body part selection prompt
             bodypart = bodypart - 2
             partlayerok, partlayerID = script.showListPrompt('Wish', 'What tissue layer should it be?',
                 COLOR_LIGHTGREEN, getCreaturePartLayerList(raceId, casteId, bodypart), 1, true)
@@ -274,6 +275,12 @@ local positionals = argparse.processArgsGetopt({ ... }, {
         'count',
         hasArg = true,
         handler = function(arg) opts.count = argparse.nonnegativeInt(arg, 'count') end,
+    },
+    {
+        'p',
+        'pos',
+        hasArg = true,
+        handler = function(arg) opts.pos = argparse.coords(arg, 'pos') end,
     },
 })
 

--- a/gui/tiletypes.lua
+++ b/gui/tiletypes.lua
@@ -767,11 +767,11 @@ function BoxSelection:onInput(keys)
     end
 
     local mousePos = dfhack.gui.getMousePos(true)
-    local cursorPos = copyall(df.global.cursor)
-    cursorPos.x = math.max(math.min(cursorPos.x, df.global.world.map.x_count - 1), 0)
-    cursorPos.y = math.max(math.min(cursorPos.y, df.global.world.map.y_count - 1), 0)
-
+    local cursorPos = guidm.getCursorPos()
+    
     if cursorPos and keys.SELECT then
+        cursorPos.x = math.max(math.min(cursorPos.x, df.global.world.map.x_count - 1), 0)
+        cursorPos.y = math.max(math.min(cursorPos.y, df.global.world.map.y_count - 1), 0)
         if self.first_point and not self.last_point then
             if not self.flat or cursorPos.z == self.first_point.z then
                 self.last_point = cursorPos
@@ -834,7 +834,7 @@ function BoxSelection:onRenderFrame(dc, rect)
     if not box then
         local selectedPos = dfhack.gui.getMousePos(true)
         if self.useCursor or not selectedPos then
-            selectedPos = copyall(df.global.cursor)
+            selectedPos = guidm.getCursorPos() or xyz2pos(nil)
             selectedPos.x = math.max(math.min(selectedPos.x, df.global.world.map.x_count - 1), 0)
             selectedPos.y = math.max(math.min(selectedPos.y, df.global.world.map.y_count - 1), 0)
         end

--- a/gui/tiletypes.lua
+++ b/gui/tiletypes.lua
@@ -768,7 +768,7 @@ function BoxSelection:onInput(keys)
 
     local mousePos = dfhack.gui.getMousePos(true)
     local cursorPos = guidm.getCursorPos()
-    
+
     if cursorPos and keys.SELECT then
         cursorPos.x = math.max(math.min(cursorPos.x, df.global.world.map.x_count - 1), 0)
         cursorPos.y = math.max(math.min(cursorPos.y, df.global.world.map.y_count - 1), 0)

--- a/hfs-pit.lua
+++ b/hfs-pit.lua
@@ -27,6 +27,7 @@ Examples::
 
 ]====]
 
+local guidm = require('gui.dwarfmode')
 local args={...}
 
 if args[1] == '?' or args[1] == 'help' then
@@ -34,7 +35,7 @@ if args[1] == '?' or args[1] == 'help' then
     return
 end
 
-local pos = copyall(df.global.cursor)
+local pos = guidm.getCursorPos()
 local size = tonumber(args[1])
 if size == nil or size < 1 then size = 1 end
 
@@ -49,7 +50,7 @@ for index, feature in ipairs(df.global.world.features.map_features) do
     end
 end
 
-if pos.x==-30000 then
+if not pos then
     qerror("Select a location by placing the cursor")
 end
 local x = 0
@@ -62,41 +63,40 @@ for x=pos.x-size,pos.x+size,1 do
         while z <= pos.z do
             local block = dfhack.maps.ensureTileBlock(x,y,z)
             if block then
-                if block.tiletype[x%16][y%16] ~= 335 then
+                local old_tt = block.tiletype[x%16][y%16]
+                if not hitAir and old_tt ~= df.tiletype.FeatureWall and old_tt ~= df.tiletype.EeriePit then
                     hitAir = true
                 end
-                if hitAir == true then
+                if hitAir then
                     if not hitCeiling then
                         if block.global_feature ~= underworldLayer or z > 10 then hitCeiling = true end
                         if stairs == 1 and x == pos.x and y == pos.y then
-                            if block.tiletype[x%16][y%16] == 32 then
+                            if old_tt == df.tiletype.OpenSpace or old_tt == df.tiletype.RampTop then
                                 if z == pos.z then
-                                    block.tiletype[x%16][y%16] = 56
+                                    block.tiletype[x%16][y%16] = df.tiletype.StoneStairD
                                 else
-                                    block.tiletype[x%16][y%16] = 55
+                                    block.tiletype[x%16][y%16] = df.tiletype.StoneStairUD
                                 end
                             else
-                                block.tiletype[x%16][y%16] = 57
+                                block.tiletype[x%16][y%16] = df.tiletype.StoneStairU
                             end
                         end
                     end
-                    if hitCeiling == true then
+                    if hitCeiling then
                         local needsWall = block.designation[x%16][y%16].flow_size > 0 or wallOff == 1
                         if (x == pos.x-size or x == pos.x+size or y == pos.y-size or y == pos.y+size) and z==pos.z then
                             --Do nothing, this is the lip of the hole
-                        elseif x == pos.x-size and y == pos.y-size then if needsWall == true then block.tiletype[x%16][y%16]=320 end
-                            elseif x == pos.x-size and y == pos.y+size then if needsWall == true then block.tiletype[x%16][y%16]=321 end
-                            elseif x == pos.x+size and y == pos.y+size then if needsWall == true then block.tiletype[x%16][y%16]=322 end
-                            elseif x == pos.x+size and y == pos.y-size then if needsWall == true then block.tiletype[x%16][y%16]=323 end
-                            elseif x == pos.x-size or x == pos.x+size then if needsWall == true then block.tiletype[x%16][y%16]=324 end
-                            elseif y == pos.y-size or y == pos.y+size then if needsWall == true then block.tiletype[x%16][y%16]=325 end
+                        elseif x == pos.x-size and y == pos.y-size then if needsWall then block.tiletype[x%16][y%16]=df.tiletype.StoneWallSmoothRD end
+                            elseif x == pos.x-size and y == pos.y+size then if needsWall then block.tiletype[x%16][y%16]=df.tiletype.StoneWallSmoothRU end
+                            elseif x == pos.x+size and y == pos.y+size then if needsWall then block.tiletype[x%16][y%16]=df.tiletype.StoneWallSmoothLU end
+                            elseif x == pos.x+size and y == pos.y-size then if needsWall then block.tiletype[x%16][y%16]=df.tiletype.StoneWallSmoothLD end
+                            elseif x == pos.x-size or x == pos.x+size then if needsWall then block.tiletype[x%16][y%16]=df.tiletype.StoneWallSmoothUD end
+                            elseif y == pos.y-size or y == pos.y+size then if needsWall then block.tiletype[x%16][y%16]=df.tiletype.StoneWallSmoothLR end
                             elseif stairs == 1 and x == pos.x and y == pos.y then
-                                if z == pos.z then block.tiletype[x%16][y%16]=56
-                                else block.tiletype[x%16][y%16]=55 end
-                            else block.tiletype[x%16][y%16]=32
+                                if z == pos.z then block.tiletype[x%16][y%16]=df.tiletype.StoneStairD
+                                else block.tiletype[x%16][y%16]=df.tiletype.StoneStairUD end
+                            else block.tiletype[x%16][y%16]=df.tiletype.OpenSpace
                         end
-                        block.designation[x%16][y%16].hidden = false
-                        --block.designation[x%16][y%16].liquid_type = true -- if true, magma.  if false, water.
                         block.designation[x%16][y%16].flow_size = 0
                         dfhack.maps.enableBlockUpdates(block)
                         block.designation[x%16][y%16].flow_forbid = false

--- a/launch.lua
+++ b/launch.lua
@@ -8,16 +8,16 @@ Activate with a cursor on screen and you will go there rapidly. Attack
 something first to ride them there.
 
 ]====]
+local guidm = require('gui.dwarfmode')
+
 function launch(unitSource,unitRider)
-    local curpos
-    if df.global.adventure.menu == df.ui_advmode_menu.Look then
-        curpos = df.global.cursor
-    elseif df.global.gamemode == df.game_mode.ADVENTURE then
-        qerror("No [l] cursor located! You would have slammed into the ground and exploded.")
-    else
+    if not dfhack.world.isAdventureMode() then
         qerror("Must be used in adventurer mode or the arena!")
     end
-
+    local curpos = guidm.getCursorPos()
+    if not curpos then
+        qerror("No cursor located! You would have slammed into the ground and exploded.")
+    end
 
     local count=0
     local l = df.global.world.projectiles.all
@@ -61,7 +61,7 @@ function launch(unitSource,unitRider)
     proj.flags.high_flying=true --this probably doesn't do anything, let me know if you figure out what it is
     proj.flags.parabolic=true
     proj.flags.no_collide=true
-    proj.flags.unk9=true
+    proj.flags.no_adv_pause=true
     proj.speed_x=resultx*10000
     proj.speed_y=resulty*10000
     proj.speed_z=resultz*15000 --higher z speed makes it easier to reach a target safely

--- a/modtools/create-item.lua
+++ b/modtools/create-item.lua
@@ -78,7 +78,10 @@ local function createCorpsePiece(creator, bodypart, partlayer, creatureID, caste
     casteID = tonumber(casteID)
     bodypart = tonumber(bodypart)
     partlayer = tonumber(partlayer)
-    -- somewhat similar to the bodypart variable below, a value of -1 here means that the user wants to spawn a whole body part. we set the partlayer to 0 (outermost) because the specific layer isn't important, and we're spawning them all anyway. if it's a generic corpsepiece we ignore it, as it gets added to anyway below (we can't do it below because between here and there there's lines that reference the part layer
+    -- somewhat similar to the bodypart variable below, a value of -1 here means that the user wants to spawn a whole body part.
+    -- we set the partlayer to 0 (outermost) because the specific layer isn't important, and we're spawning them all anyway.
+    -- if it's a generic corpsepiece we ignore it, as it gets added to anyway below (we can't do it below because between here and
+    -- there there's lines that reference the part layer
     if partlayer == -1 and not generic then
         partlayer = 0
         wholePart = true
@@ -177,7 +180,8 @@ local function createCorpsePiece(creator, bodypart, partlayer, creatureID, caste
         item.race = creatureID
         item.normal_race = creatureID
         item.normal_caste = casteID
-        -- usually the first two castes are for the creature's sex, so we set the item's sex to the caste if both the creature has one and it's a valid sex id (0 or 1)
+        -- usually the first two castes are for the creature's sex, so we set the item's sex to
+        -- the caste if both the creature has one and it's a valid sex id (0 or 1)
         if casteID < 2 and #(creatorRaceRaw.caste) > 1 then
             item.sex = casteID
         else
@@ -198,12 +202,14 @@ local function createCorpsePiece(creator, bodypart, partlayer, creatureID, caste
         for i,n in pairs(creatorBody.body_parts) do
             -- inserts
             item.body.body_part_relsize:insert('#', n.relsize)
-            item.body.components.body_part_status:insert(i, creator.body.components.body_part_status[0]) --copy the status of the creator's first part to every body_part_status of the desired creature
+            --copy the status of the creator's first part to every body_part_status of the desired creature
+            item.body.components.body_part_status:insert(i, creator.body.components.body_part_status[0])
             item.body.components.body_part_status[i].missing = true
         end
         for i in pairs(creatorBody.layer_part) do
             -- inserts
-            item.body.components.layer_status:insert(i, creator.body.components.layer_status[0]) --copy the layer status of the creator's first layer to every layer_status of the desired creature
+            -- copy the layer status of the creator's first layer to every layer_status of the desired creature
+            item.body.components.layer_status:insert(i, creator.body.components.layer_status[0])
             item.body.components.layer_status[i].gone = true
         end
         if item_type == 'CORPSE' then
@@ -222,7 +228,9 @@ local function createCorpsePiece(creator, bodypart, partlayer, creatureID, caste
                         item.body.components.layer_status[creatorBody.body_parts[i].layers[n].layer_id].gone = false
                     else
                         -- search through the target creature's body parts and bring back every one which has the desired material
-                        if creatorRaceRaw.tissue[creatorBody.body_parts[i].layers[n].tissue_id].tissue_material_str[1] == layerMat and creatorBody.body_parts[i].token ~= 'SKULL' and not creatorBody.body_parts[i].flags.SMALL then
+                        if creatorRaceRaw.tissue[creatorBody.body_parts[i].layers[n].tissue_id].tissue_material_str[1] == layerMat and
+                            creatorBody.body_parts[i].token ~= 'SKULL' and not creatorBody.body_parts[i].flags.SMALL then
+
                             item.body.components.body_part_status[i].missing = false
                             item.body.components.layer_status[creatorBody.body_parts[i].layers[n].layer_id].gone = false
                             -- save the index of the bone layer to a variable
@@ -251,7 +259,8 @@ end
 local function createItem(mat, itemType, quality, creator, description, amount)
     -- The "reaction-gloves" tweak can cause this to create multiple gloves
     local items = dfhack.items.createItem(creator, itemType[1], itemType[2], mat[1], mat[2])
-    assert(#items > 0, ('failed to create item: item_type: %s, item_subtype: %s, mat_type: %s, mat_index: %s, unit: %s'):format(itemType[1], itemType[2], mat[1], mat[2], creator and creator.id or 'nil'))
+    assert(#items > 0, ('failed to create item: item_type: %s, item_subtype: %s, mat_type: %s, mat_index: %s, unit: %s'):format(
+        itemType[1], itemType[2], mat[1], mat[2], creator and creator.id or 'nil'))
     local item = items[1]
     local mat_token = dfhack.matinfo.decode(item):getToken()
     quality = math.max(0, math.min(5, quality - 1))
@@ -350,6 +359,12 @@ function hackWish(accessors, opts)
             end
         end
     end
+    if opts.pos then
+        for _,item in ipairs(items) do
+            dfhack.items.moveToGround(item, opts.pos)
+        end
+    end
+
     return items
 end
 
@@ -435,9 +450,4 @@ local accessors = {
     end,
 }
 
-local items = hackWish(accessors, {})
-if items and opts.pos then
-    for _,item in ipairs(items) do
-        dfhack.items.moveToGround(item, opts.pos)
-    end
-end
+hackWish(accessors, {pos=opts.pos})

--- a/putontable.lua
+++ b/putontable.lua
@@ -10,19 +10,21 @@ Arguments:
 
 ]====]
 
-local pos=df.global.cursor
+local guidm = require('gui.dwarfmode')
+
 local args={...}
 local doall
 if args[1]=="-a" or args[1]=="--all" then
     doall=true
 end
 local items={} --as:df.item[]
-local build=dfhack.buildings.findAtTile(pos.x,pos.y,pos.z)
+local pos = guidm.getCursorPos()
+local build = pos and dfhack.buildings.findAtTile(pos.x,pos.y,pos.z) or nil
 if not df.building_tablest:is_instance(build) then
     error("No table found at cursor")
 end
 for k,v in pairs(df.global.world.items.other.IN_PLAY) do
-    if pos.x==v.pos.x and pos.y==v.pos.y and pos.z==v.pos.z and v.flags.on_ground then
+    if v.flags.on_ground and same_xyz(v.pos, pos) then
         table.insert(items,v)
         if not doall then
             break

--- a/source.lua
+++ b/source.lua
@@ -1,4 +1,5 @@
 --@ module = true
+local guidm = require('gui.dwarfmode')
 local repeatUtil = require('repeat-util')
 
 local GLOBAL_KEY = 'source' -- used for state change hooks and persistence
@@ -130,11 +131,11 @@ function main(args)
         return
     end
 
-    local targetPos = copyall(df.global.cursor)
+    local targetPos = guidm.getCursorPos()
     local index = find_liquid_source_at_pos(targetPos)
 
     if command == 'delete' then
-        if targetPos.x < 0 then
+        if not targetPos then
             qerror("Please place the cursor where there is a source to delete")
         end
         if index then
@@ -147,7 +148,7 @@ function main(args)
     end
 
     if command == 'add' then
-        if targetPos.x < 0 then
+        if not targetPos then
             qerror('Please place the cursor where you would like a source')
         end
         local liquidArg = args[2]

--- a/stripcaged.lua
+++ b/stripcaged.lua
@@ -1,4 +1,5 @@
 local argparse = require('argparse')
+local guidm = require('gui.dwarfmode')
 local opts = {}
 local positionals = argparse.processArgsGetopt({...}, {
     {'h', 'help', handler = function() opts.help = true end},
@@ -206,8 +207,8 @@ if positionals[2] == 'here' then
             end
         end
     -- Is the player trying to select a cage using the keyboard cursor?
-    elseif df.global.cursor.z > -10000 then -- cursor has values around -30000 if not valid/active.
-        local cursor = df.global.cursor
+    elseif guidm.getCursorPos() then
+        local cursor = guidm.getCursorPos()
         for _, cage in ipairs(df.global.world.items.other.ANY_CAGE_OR_TRAP) do
             if same_xyz(cursor, cage.pos) then
                 table.insert(list, cage)

--- a/teleport.lua
+++ b/teleport.lua
@@ -28,6 +28,8 @@ Examples:
 
 ]====]
 
+local guidm = require('gui.dwarfmode')
+
 function teleport(unit,pos)
  dfhack.units.teleport(unit, pos)
 end
@@ -53,12 +55,12 @@ if args.showunitid or args.showpos then
  if args.showunitid then
   print(dfhack.gui.getSelectedUnit(true).id)
  else
-  printall(df.global.cursor)
+  printall(guidm.getCursorPos())
  end
 else
  local unit = tonumber(args.unit) and df.unit.find(tonumber(args.unit)) or dfhack.gui.getSelectedUnit(true)
- local pos = not(not args.x or not args.y or not args.z) and {x=args.x,y=args.y,z=args.z} or {x=df.global.cursor.x,y=df.global.cursor.y,z=df.global.cursor.z}
+ local pos = not(not args.x or not args.y or not args.z) and {x=args.x,y=args.y,z=args.z} or guidm.getCursorPos()
  if not unit then qerror('A unit needs to be selected or specified. Use teleport -showunitid to get a unit\'s ID.') end
- if not pos.x or pos.x==-30000 then qerror('A position needs to be highlighted or specified. Use teleport -showpos to get a position\'s exact xyz values.') end
+ if not pos then qerror('A position needs to be highlighted or specified. Use teleport -showpos to get a position\'s exact xyz values.') end
  teleport(unit,pos)
 end

--- a/toggle-kbd-cursor.lua
+++ b/toggle-kbd-cursor.lua
@@ -1,16 +1,19 @@
+local gui = require('gui')
 local guidm = require('gui.dwarfmode')
 
 if dfhack.world.isAdventureMode() then
-    qerror('Adventure mode unsupported!')
-end
-
-local flags = df.global.d_init.feature.flags
-if flags.KEYBOARD_CURSOR then
-    flags.KEYBOARD_CURSOR = false
-    guidm.clearCursorPos()
-    print('Keyboard cursor disabled.')
+    local open = df.global.game.main_interface.adventure.look.open
+    gui.simulateInput(dfhack.gui.getDFViewscreen(), open and 'LEAVESCREEN' or 'A_LOOK')
+    print('Look mode '..(open and 'disabled.' or 'enabled.'))
 else
-    guidm.setCursorPos(guidm.Viewport.get():getCenter())
-    flags.KEYBOARD_CURSOR = true
-    print('Keyboard cursor enabled.')
+    local flags = df.global.d_init.feature.flags
+    if flags.KEYBOARD_CURSOR then
+        flags.KEYBOARD_CURSOR = false
+        guidm.clearCursorPos()
+        print('Keyboard cursor disabled.')
+    else
+        guidm.setCursorPos(guidm.Viewport.get():getCenter())
+        flags.KEYBOARD_CURSOR = true
+        print('Keyboard cursor enabled.')
+    end
 end

--- a/toggle-kbd-cursor.lua
+++ b/toggle-kbd-cursor.lua
@@ -1,10 +1,13 @@
 local guidm = require('gui.dwarfmode')
 
-local flags = df.global.d_init.feature.flags
+if dfhack.world.isAdventureMode() then
+    qerror('Adventure mode unsupported!')
+end
 
+local flags = df.global.d_init.feature.flags
 if flags.KEYBOARD_CURSOR then
     flags.KEYBOARD_CURSOR = false
-    guidm.setCursorPos(xyz2pos(-30000, -30000, -30000))
+    guidm.clearCursorPos()
     print('Keyboard cursor disabled.')
 else
     guidm.setCursorPos(guidm.Viewport.get():getCenter())


### PR DESCRIPTION
Make use of `gui.dwarfmode` cursor fns in a number of scripts. Also `same_xyz` where possible.

Added a `pos` arg for `gui/create-item` to define output position. Made `modtools/create-item` respect "opts.pos" being passed into `hackWish`.

Fixed up tiletypes in `hfs-pit`. Outdated numbers were being used instead of enums, causing weird behavior.

`toggle-kbd-cursor` now ignores adv mode. It would just reposition the look cursor if left as-is, and we can't easily toggle adv look mode. (Simulated input required.)

Added `adventure` tag to `extinguish` and `firestarter` since guidm changes made them function. (Other scripts like `colonies` will function, but aren't particularly useful due to lack of persistence.) `toggle-kbd-cursor` gets `fort` tag since it only functions in fort/arena.

Reinstated `launch` and `putontable`. I added the `adventure` tag to `putontable`, even though the adventurer can place things manually, since there might be some use for the "all" option.

I didn't fix up `modtools/create-unit.lua`, which is still using the global cursor. It's got old `unk` fields for structures (nemesis), and the whole thing just probably needs to be rewritten.