### PR TITLE
Prevent flow_forbid from being set without liquid present

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -36,6 +36,7 @@ Template for new versions:
 
 ## Fixes
 - `position`: support for adv mode look cursor
+- `gui/liquids`: using the remove tool with magma selected will no longer create unexpected unpathable tiles
 
 ## Misc Improvements
 - `hide-tutorials`: handle tutorial popups for adventure mode

--- a/modtools/spawn-liquid.lua
+++ b/modtools/spawn-liquid.lua
@@ -21,6 +21,10 @@ function spawnLiquid(position, liquid_level, liquid_type)
   local map_block = dfhack.maps.getTileBlock(position)
   local tile = dfhack.maps.getTileFlags(position)
 
+  if liquid_level == 0 then
+    liquid_type = df.tile_liquid.Water
+  end
+
   tile.flow_size = liquid_level or 3
   tile.liquid_type = liquid_type
   tile.flow_forbid = liquid_type == df.tile_liquid.Magma or liquid_level >= 4
@@ -33,6 +37,8 @@ function spawnLiquid(position, liquid_level, liquid_type)
   local z_level = df.global.world.map_extras.z_level_flags
   z_level.update = true
   z_level.update_twice = true
+
+  df.global.world.reindex_pathfinding = true
 
   resetTemperature(position)
 end


### PR DESCRIPTION
With `liquid_type` Magma and `liquid_level` 0, the `flow_forbid` flag was being set, creating unexpectedly unpathable tiles.

This change makes it so setting the liquid_level to zero with any type results in a `liquid_type` of water, the default for empty tiles, as well as with the `flow_forbid` flag unset.

Fixes https://github.com/DFHack/dfhack/issues/5284