### PR TITLE
Feat/adventurer journal

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -34,6 +34,7 @@ Template for new versions:
 
 ## New Features
 - `advtools`: new ``advtools.fastcombat`` overlay (enabled by default)  allows you to skip combat animations and the announcement "More" button by mashing the movement keys
+- `gui/journal`: now working in adventure mode
 
 ## Fixes
 - `position`: support for adv mode look cursor

--- a/docs/gui/journal.rst
+++ b/docs/gui/journal.rst
@@ -6,11 +6,11 @@ gui/journal
     :tags: fort interface
 
 The `gui/journal` interface makes it easy to take notes and document
-important details for the fortresses.
+important details for your fortresses and adventurers.
 
 With this multi-line text editor,
-you can keep track of your fortress's background story, goals, notable events,
-and both short-term and long-term plans.
+you can keep track of your fortress's/adventurer's background story, goals,
+notable events, and both short-term and long-term plans.
 
 This is particularly useful when you need to take a longer break from the game.
 Having detailed notes makes it much easier to resume your game after

--- a/docs/gui/journal.rst
+++ b/docs/gui/journal.rst
@@ -3,7 +3,7 @@ gui/journal
 
 .. dfhack-tool::
     :summary: Fort journal with a multi-line text editor.
-    :tags: fort interface
+    :tags: adventure fort interface
 
 The `gui/journal` interface makes it easy to take notes and document
 important details for your fortresses and adventurers.

--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -327,8 +327,9 @@ function JournalScreen:onDismiss()
 end
 
 function main(options)
-    if not dfhack.isMapLoaded() or not dfhack.world.isFortressMode() then
-        qerror('journal requires a fortress map to be loaded')
+    if not dfhack.isMapLoaded() or (not dfhack.world.isFortressMode()
+        and not dfhack.world.isAdventureMode()) then
+        qerror('journal requires a fortress/adventure map to be loaded')
     end
 
     local save_layout = options and options.save_layout

--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -14,6 +14,8 @@ local TOC_RESIZE_MIN = {w=24}
 
 journal_config = journal_config or json.open('dfhack-config/journal.json')
 
+JOURNAL_CONTEXT_MODE = journal_context.JOURNAL_CONTEXT_MODE
+
 JournalWindow = defclass(JournalWindow, widgets.Window)
 JournalWindow.ATTRS {
     frame_title='DF Journal',
@@ -266,15 +268,15 @@ end
 JournalScreen = defclass(JournalScreen, gui.ZScreen)
 JournalScreen.ATTRS {
     focus_path='journal',
-    save_on_change=true,
+    context_mode=DEFAULT_NIL,
     save_layout=true,
     save_prefix=''
 }
 
 function JournalScreen:init()
     self.journal_context = journal_context.journal_context_factory(
-        self.save_prefix,
-        self.save_on_change
+        self.context_mode,
+        self.save_prefix
     )
     local content = self.journal_context:load_content()
 
@@ -316,12 +318,14 @@ function main(options)
     end
 
     local save_layout = options and options.save_layout
-    local save_on_change = options and options.save_on_change
+    local overrided_context_mode = options and options.context_mode
+    local context_mode = overrided_context_mode == nil and
+        journal_context.detect_journal_context_mode() or overrided_context_mode
 
     view = view and view:raise() or JournalScreen{
         save_prefix=options and options.save_prefix or '',
         save_layout=save_layout == nil and true or save_layout,
-        save_on_change=save_on_change == nil and true or save_on_change,
+        context_mode=context_mode,
     }:show()
 end
 

--- a/internal/journal/contexts/adventure.lua
+++ b/internal/journal/contexts/adventure.lua
@@ -1,8 +1,31 @@
 --@ module = true
 
+local JOURNAL_WELCOME_COPY =  [=[
+Welcome to gui/journal, the adventurer's notebook for Dwarf Fortress!
+
+Here, you can jot down your travels, keep track of important places, or note anything worth remembering.
+The text you write here is saved together with your adventurer.
+
+For guidance on navigation and hotkeys, tap the ? button in the upper right corner.
+Safe travels!
+]=]
+
+local TOC_WELCOME_COPY =  [=[
+Start a line with # symbols and a space to create a header. For example:
+
+# My section heading
+
+or
+
+## My section subheading
+
+Those headers will appear here, and you can click on them to jump to them in the text.]=]
+
+
 AdventurerJournalContext = defclass(AdventurerJournalContext)
 AdventurerJournalContext.ATTRS{
   save_prefix='',
+  adventurer_id=DEFAULT_NIL
 }
 
 function get_adventurer_context_key(prefix, adventurer_id)
@@ -13,7 +36,7 @@ function get_adventurer_context_key(prefix, adventurer_id)
     )
 end
 
-function AdventurerJournalContext:save(text, cursor)
+function AdventurerJournalContext:save_content(text, cursor)
   if dfhack.isWorldLoaded() then
     dfhack.persistent.saveSiteData(
         get_adventurer_context_key(self.save_prefix, self.adventurer_id),
@@ -22,7 +45,7 @@ function AdventurerJournalContext:save(text, cursor)
   end
 end
 
-function AdventurerJournalContext:load()
+function AdventurerJournalContext:load_content()
   if dfhack.isWorldLoaded() then
     local site_data = dfhack.persistent.getSiteData(
         get_adventurer_context_key(self.save_prefix, self.adventurer_id)
@@ -35,4 +58,12 @@ function AdventurerJournalContext:load()
     site_data.cursor = site_data.cursor or {#site_data.text[1] + 1}
     return site_data
   end
+end
+
+function AdventurerJournalContext:welcomeCopy()
+  return JOURNAL_WELCOME_COPY
+end
+
+function AdventurerJournalContext:tocWelcomeCopy()
+  return TOC_WELCOME_COPY
 end

--- a/internal/journal/contexts/adventure.lua
+++ b/internal/journal/contexts/adventure.lua
@@ -1,0 +1,38 @@
+--@ module = true
+
+AdventurerJournalContext = defclass(AdventurerJournalContext)
+AdventurerJournalContext.ATTRS{
+  save_prefix='',
+}
+
+function get_adventurer_context_key(prefix, adventurer_id)
+    return string.format(
+      '%sjournal:adventurer:%s',
+      prefix,
+      adventurer_id
+    )
+end
+
+function AdventurerJournalContext:save(text, cursor)
+  if dfhack.isWorldLoaded() then
+    dfhack.persistent.saveSiteData(
+        get_adventurer_context_key(self.save_prefix, self.adventurer_id),
+        {text={text}, cursor={cursor}}
+    )
+  end
+end
+
+function AdventurerJournalContext:load()
+  if dfhack.isWorldLoaded() then
+    local site_data = dfhack.persistent.getSiteData(
+        get_adventurer_context_key(self.save_prefix, self.adventurer_id)
+    ) or {}
+
+    if not site_data.text then
+        site_data.text={''}
+        site_data.show_tutorial = true
+    end
+    site_data.cursor = site_data.cursor or {#site_data.text[1] + 1}
+    return site_data
+  end
+end

--- a/internal/journal/contexts/adventure.lua
+++ b/internal/journal/contexts/adventure.lua
@@ -38,7 +38,7 @@ end
 
 function AdventurerJournalContext:save_content(text, cursor)
   if dfhack.isWorldLoaded() then
-    dfhack.persistent.saveSiteData(
+    dfhack.persistent.saveWorldData(
         get_adventurer_context_key(self.save_prefix, self.adventurer_id),
         {text={text}, cursor={cursor}}
     )
@@ -47,16 +47,24 @@ end
 
 function AdventurerJournalContext:load_content()
   if dfhack.isWorldLoaded() then
-    local site_data = dfhack.persistent.getSiteData(
+    local world_data = dfhack.persistent.getWorldData(
         get_adventurer_context_key(self.save_prefix, self.adventurer_id)
     ) or {}
 
-    if not site_data.text then
-        site_data.text={''}
-        site_data.show_tutorial = true
+    if not world_data.text then
+        world_data.text={''}
+        world_data.show_tutorial = true
     end
-    site_data.cursor = site_data.cursor or {#site_data.text[1] + 1}
-    return site_data
+    world_data.cursor = world_data.cursor or {#world_data.text[1] + 1}
+    return world_data
+  end
+end
+
+function AdventurerJournalContext:delete_content()
+  if dfhack.isWorldLoaded() then
+    dfhack.persistent.deleteWorldData(
+        get_adventurer_context_key(self.save_prefix, self.adventurer_id)
+    )
   end
 end
 

--- a/internal/journal/contexts/dummy.lua
+++ b/internal/journal/contexts/dummy.lua
@@ -1,0 +1,13 @@
+--@ module = true
+
+-- Dummy Context, no storage --
+
+DummyJournalContext = defclass(DummyJournalContext)
+
+function DummyJournalContext:save(text, cursor)
+end
+
+function DummyJournalContext:load()
+  return {text={''}, cursor={1}, show_tutorial=true}
+end
+

--- a/internal/journal/contexts/dummy.lua
+++ b/internal/journal/contexts/dummy.lua
@@ -1,13 +1,30 @@
 --@ module = true
 
+local JOURNAL_WELCOME_COPY =  [=[
+Welcome to gui/journal. This is dummy context and it should be available only
+in automatic tests.
+]=]
+
+local TOC_WELCOME_COPY =  [=[
+This is Table of Contenst test welcome copy
+]=]
+
+
 -- Dummy Context, no storage --
 
 DummyJournalContext = defclass(DummyJournalContext)
 
-function DummyJournalContext:save(text, cursor)
+function DummyJournalContext:save_content(text, cursor)
 end
 
-function DummyJournalContext:load()
+function DummyJournalContext:load_content()
   return {text={''}, cursor={1}, show_tutorial=true}
 end
 
+function DummyJournalContext:welcomeCopy()
+  return JOURNAL_WELCOME_COPY
+end
+
+function DummyJournalContext:tocWelcomeCopy()
+  return TOC_WELCOME_COPY
+end

--- a/internal/journal/contexts/dummy.lua
+++ b/internal/journal/contexts/dummy.lua
@@ -1,15 +1,5 @@
 --@ module = true
 
-local JOURNAL_WELCOME_COPY =  [=[
-Welcome to gui/journal. This is dummy context and it should be available only
-in automatic tests.
-]=]
-
-local TOC_WELCOME_COPY =  [=[
-This is Table of Contenst test welcome copy
-]=]
-
-
 -- Dummy Context, no storage --
 
 DummyJournalContext = defclass(DummyJournalContext)
@@ -21,10 +11,13 @@ function DummyJournalContext:load_content()
   return {text={''}, cursor={1}, show_tutorial=true}
 end
 
+function DummyJournalContext:delete_content()
+end
+
 function DummyJournalContext:welcomeCopy()
-  return JOURNAL_WELCOME_COPY
+  return ''
 end
 
 function DummyJournalContext:tocWelcomeCopy()
-  return TOC_WELCOME_COPY
+  return ''
 end

--- a/internal/journal/contexts/fortress.lua
+++ b/internal/journal/contexts/fortress.lua
@@ -1,0 +1,34 @@
+--@ module = true
+
+FortressJournalContext = defclass(FortressJournalContext)
+FortressJournalContext.ATTRS{
+  save_prefix=''
+}
+
+function get_fort_context_key(prefix)
+    return prefix .. 'journal'
+end
+
+function FortressJournalContext:save(text, cursor)
+  if dfhack.isWorldLoaded() then
+    dfhack.persistent.saveSiteData(
+        get_fort_context_key(self.save_prefix),
+        {text={text}, cursor={cursor}}
+    )
+  end
+end
+
+function FortressJournalContext:load()
+  if dfhack.isWorldLoaded() then
+    local site_data = dfhack.persistent.getSiteData(
+        get_fort_context_key(self.save_prefix)
+    ) or {}
+
+    if not site_data.text then
+        site_data.text={''}
+        site_data.show_tutorial = true
+    end
+    site_data.cursor = site_data.cursor or {#site_data.text[1] + 1}
+    return site_data
+  end
+end

--- a/internal/journal/contexts/fortress.lua
+++ b/internal/journal/contexts/fortress.lua
@@ -55,6 +55,14 @@ function FortressJournalContext:load_content()
   end
 end
 
+function FortressJournalContext:delete_content()
+  if dfhack.isWorldLoaded() then
+    dfhack.persistent.deleteSiteData(
+        get_fort_context_key(self.save_prefix)
+    )
+  end
+end
+
 function FortressJournalContext:welcomeCopy()
   return JOURNAL_WELCOME_COPY
 end

--- a/internal/journal/contexts/fortress.lua
+++ b/internal/journal/contexts/fortress.lua
@@ -1,5 +1,27 @@
 --@ module = true
 
+local JOURNAL_WELCOME_COPY =  [=[
+Welcome to gui/journal, the chronicler's tool for Dwarf Fortress!
+
+Here, you can carve out notes, sketch your grand designs, or record the history of your fortress.
+The text you write here is saved together with your fort.
+
+For guidance on navigation and hotkeys, tap the ? button in the upper right corner.
+Happy digging!
+]=]
+
+local TOC_WELCOME_COPY =  [=[
+Start a line with # symbols and a space to create a header. For example:
+
+# My section heading
+
+or
+
+## My section subheading
+
+Those headers will appear here, and you can click on them to jump to them in the text.]=]
+
+
 FortressJournalContext = defclass(FortressJournalContext)
 FortressJournalContext.ATTRS{
   save_prefix=''
@@ -9,7 +31,7 @@ function get_fort_context_key(prefix)
     return prefix .. 'journal'
 end
 
-function FortressJournalContext:save(text, cursor)
+function FortressJournalContext:save_content(text, cursor)
   if dfhack.isWorldLoaded() then
     dfhack.persistent.saveSiteData(
         get_fort_context_key(self.save_prefix),
@@ -18,7 +40,7 @@ function FortressJournalContext:save(text, cursor)
   end
 end
 
-function FortressJournalContext:load()
+function FortressJournalContext:load_content()
   if dfhack.isWorldLoaded() then
     local site_data = dfhack.persistent.getSiteData(
         get_fort_context_key(self.save_prefix)
@@ -31,4 +53,12 @@ function FortressJournalContext:load()
     site_data.cursor = site_data.cursor or {#site_data.text[1] + 1}
     return site_data
   end
+end
+
+function FortressJournalContext:welcomeCopy()
+  return JOURNAL_WELCOME_COPY
+end
+
+function FortressJournalContext:tocWelcomeCopy()
+  return TOC_WELCOME_COPY
 end

--- a/internal/journal/journal_context.lua
+++ b/internal/journal/journal_context.lua
@@ -1,119 +1,29 @@
 --@ module = true
 
 local widgets = require 'gui.widgets'
-
-local JOURNAL_PERSIST_KEY = 'journal'
+local utils = require('utils')
+local DummyJournalContext = reqscript('internal/journal/contexts/dummy')
+local FortressJournalContext = reqscript('internal/journal/contexts/fortress')
+local AdventurerJournalContext = reqscript('internal/journal/contexts/adventure')
 
 function journal_context_factory(save_on_change, save_prefix)
   if not save_on_change then
     return DummyJournalContext{}
   elseif dfhack.world.isFortressMode() then
-    return FortJournalContext{save_prefix}
+    return FortressJournalContext{save_prefix}
   elseif dfhack.world.isAdventureMode() then
+    local interactions = df.global.adventure.interactions
+    if #interactions.party_core_members == 0 then
+      qerror('Can not identify party core member')
+    end
+
+    local adventurer_id = interactions.party_core_members[0]
+
     return AdventurerJournalContext{
       save_prefix,
-      adventurer_id=dfhack.world.getAdventurer().id
+      adventurer_id=adventurer_id
     }
   else
     qerror('unsupported game mode')
-  end
-end
-
-
--- Fortress Context --
-
-FortJournalContext = defclass(FortJournalContext)
-FortJournalContext.ATTRS{
-  save_prefix=''
-}
-
-function get_fort_context_key(prefix)
-    return prefix .. JOURNAL_PERSIST_KEY
-end
-
-function FortJournalContext:save(text, cursor)
-  if dfhack.isWorldLoaded() then
-    dfhack.persistent.saveSiteData(
-        get_fort_context_key(self.save_prefix),
-        {text={text}, cursor={cursor}}
-    )
-  end
-end
-
-function FortJournalContext:load()
-  if dfhack.isWorldLoaded() then
-    local site_data = dfhack.persistent.getSiteData(
-        get_fort_context_key(self.save_prefix)
-    ) or {}
-
-    if not site_data.text then
-        site_data.text={''}
-        site_data.show_tutorial = true
-    end
-    site_data.cursor = site_data.cursor or {#site_data.text[1] + 1}
-    return site_data
-  end
-end
-
--- Dummy Context, no storage --
-
-DummyJournalContext = defclass(DummyJournalContext)
-
-function DummyJournalContext:save(text, cursor)
-end
-
-function DummyJournalContext:load()
-  return {text={''}, cursor={1}, show_tutorial=true}
-end
-
--- Dummy Context, no storage --
-
-DummyJournalContext = defclass(DummyJournalContext)
-
-function DummyJournalContext:save(text, cursor)
-end
-
-function DummyJournalContext:load()
-  return {text={''}, cursor={1}, show_tutorial=true}
-end
-
--- Adventure Context --
-
-AdventurerJournalContext = defclass(AdventurerJournalContext)
-AdventurerJournalContext.ATTRS{
-  save_prefix='',
-  adventurer_id=''
-}
-
-function get_adventurer_context_key(prefix, adventurer_id)
-    return string.format(
-      '%s%s:adventurer:%s',
-      prefix,
-      JOURNAL_PERSIST_KEY,
-      adventurer_id
-    )
-end
-
-function AdventurerJournalContext:save(text, cursor)
-  if dfhack.isWorldLoaded() then
-    dfhack.persistent.saveSiteData(
-        get_adventurer_context_key(self.save_prefix, self.adventurer_id),
-        {text={text}, cursor={cursor}}
-    )
-  end
-end
-
-function AdventurerJournalContext:load()
-  if dfhack.isWorldLoaded() then
-    local site_data = dfhack.persistent.getSiteData(
-        get_adventurer_context_key(self.save_prefix, self.adventurer_id)
-    ) or {}
-
-    if not site_data.text then
-        site_data.text={''}
-        site_data.show_tutorial = true
-    end
-    site_data.cursor = site_data.cursor or {#site_data.text[1] + 1}
-    return site_data
   end
 end

--- a/internal/journal/journal_context.lua
+++ b/internal/journal/journal_context.lua
@@ -2,9 +2,9 @@
 
 local widgets = require 'gui.widgets'
 local utils = require('utils')
-local DummyJournalContext = reqscript('internal/journal/contexts/dummy')
-local FortressJournalContext = reqscript('internal/journal/contexts/fortress')
-local AdventurerJournalContext = reqscript('internal/journal/contexts/adventure')
+local DummyJournalContext = reqscript('internal/journal/contexts/dummy').DummyJournalContext
+local FortressJournalContext = reqscript('internal/journal/contexts/fortress').FortressJournalContext
+local AdventurerJournalContext = reqscript('internal/journal/contexts/adventure').AdventurerJournalContext
 
 function journal_context_factory(save_on_change, save_prefix)
   if not save_on_change then
@@ -13,12 +13,11 @@ function journal_context_factory(save_on_change, save_prefix)
     return FortressJournalContext{save_prefix}
   elseif dfhack.world.isAdventureMode() then
     local interactions = df.global.adventure.interactions
-    if #interactions.party_core_members == 0 then
+    if #interactions.party_core_members == 0 or interactions.party_core_members[0] == nil then
       qerror('Can not identify party core member')
     end
 
     local adventurer_id = interactions.party_core_members[0]
-
     return AdventurerJournalContext{
       save_prefix,
       adventurer_id=adventurer_id

--- a/internal/journal/journal_context.lua
+++ b/internal/journal/journal_context.lua
@@ -6,22 +6,39 @@ local DummyJournalContext = reqscript('internal/journal/contexts/dummy').DummyJo
 local FortressJournalContext = reqscript('internal/journal/contexts/fortress').FortressJournalContext
 local AdventurerJournalContext = reqscript('internal/journal/contexts/adventure').AdventurerJournalContext
 
-function journal_context_factory(save_on_change, save_prefix)
-  if not save_on_change then
-    return DummyJournalContext{}
-  elseif dfhack.world.isFortressMode() then
-    return FortressJournalContext{save_prefix}
+JOURNAL_CONTEXT_MODE = {
+  FORTRESS='fortress',
+  ADVENTURE='adventure',
+  DUMMY='dummy'
+}
+
+function detect_journal_context_mode()
+  if dfhack.world.isFortressMode() then
+    return JOURNAL_CONTEXT_MODE.FORTRESS
   elseif dfhack.world.isAdventureMode() then
+    return JOURNAL_CONTEXT_MODE.ADVENTURE
+  else
+    qerror('unsupported game mode')
+  end
+end
+
+function journal_context_factory(journal_context_mode, save_prefix)
+  if journal_context_mode == JOURNAL_CONTEXT_MODE.FORTRESS then
+    return FortressJournalContext{save_prefix}
+  elseif journal_context_mode == JOURNAL_CONTEXT_MODE.ADVENTURE then
     local interactions = df.global.adventure.interactions
     if #interactions.party_core_members == 0 or interactions.party_core_members[0] == nil then
       qerror('Can not identify party core member')
     end
 
     local adventurer_id = interactions.party_core_members[0]
+
     return AdventurerJournalContext{
       save_prefix,
       adventurer_id=adventurer_id
     }
+  elseif journal_context_mode == JOURNAL_CONTEXT_MODE.DUMMY then
+    return DummyJournalContext{}
   else
     qerror('unsupported game mode')
   end

--- a/internal/journal/journal_context.lua
+++ b/internal/journal/journal_context.lua
@@ -4,15 +4,23 @@ local widgets = require 'gui.widgets'
 
 local JOURNAL_PERSIST_KEY = 'journal'
 
-function journal_context_factory(save_prefix, save_on_change)
+function journal_context_factory(save_on_change, save_prefix)
   if not save_on_change then
     return DummyJournalContext{}
   elseif dfhack.world.isFortressMode() then
     return FortJournalContext{save_prefix}
+  elseif dfhack.world.isAdventureMode() then
+    return AdventurerJournalContext{
+      save_prefix,
+      adventurer_id=dfhack.world.getAdventurer().id
+    }
   else
     qerror('unsupported game mode')
   end
 end
+
+
+-- Fortress Context --
 
 FortJournalContext = defclass(FortJournalContext)
 FortJournalContext.ATTRS{
@@ -47,6 +55,8 @@ function FortJournalContext:load()
   end
 end
 
+-- Dummy Context, no storage --
+
 DummyJournalContext = defclass(DummyJournalContext)
 
 function DummyJournalContext:save(text, cursor)
@@ -54,4 +64,56 @@ end
 
 function DummyJournalContext:load()
   return {text={''}, cursor={1}, show_tutorial=true}
+end
+
+-- Dummy Context, no storage --
+
+DummyJournalContext = defclass(DummyJournalContext)
+
+function DummyJournalContext:save(text, cursor)
+end
+
+function DummyJournalContext:load()
+  return {text={''}, cursor={1}, show_tutorial=true}
+end
+
+-- Adventure Context --
+
+AdventurerJournalContext = defclass(AdventurerJournalContext)
+AdventurerJournalContext.ATTRS{
+  save_prefix='',
+  adventurer_id=''
+}
+
+function get_adventurer_context_key(prefix, adventurer_id)
+    return string.format(
+      '%s%s:adventurer:%s',
+      prefix,
+      JOURNAL_PERSIST_KEY,
+      adventurer_id
+    )
+end
+
+function AdventurerJournalContext:save(text, cursor)
+  if dfhack.isWorldLoaded() then
+    dfhack.persistent.saveSiteData(
+        get_adventurer_context_key(self.save_prefix, self.adventurer_id),
+        {text={text}, cursor={cursor}}
+    )
+  end
+end
+
+function AdventurerJournalContext:load()
+  if dfhack.isWorldLoaded() then
+    local site_data = dfhack.persistent.getSiteData(
+        get_adventurer_context_key(self.save_prefix, self.adventurer_id)
+    ) or {}
+
+    if not site_data.text then
+        site_data.text={''}
+        site_data.show_tutorial = true
+    end
+    site_data.cursor = site_data.cursor or {#site_data.text[1] + 1}
+    return site_data
+  end
 end

--- a/internal/journal/journal_context.lua
+++ b/internal/journal/journal_context.lua
@@ -1,0 +1,57 @@
+--@ module = true
+
+local widgets = require 'gui.widgets'
+
+local JOURNAL_PERSIST_KEY = 'journal'
+
+function journal_context_factory(save_prefix, save_on_change)
+  if not save_on_change then
+    return DummyJournalContext{}
+  elseif dfhack.world.isFortressMode() then
+    return FortJournalContext{save_prefix}
+  else
+    qerror('unsupported game mode')
+  end
+end
+
+FortJournalContext = defclass(FortJournalContext)
+FortJournalContext.ATTRS{
+  save_prefix=''
+}
+
+function get_fort_context_key(prefix)
+    return prefix .. JOURNAL_PERSIST_KEY
+end
+
+function FortJournalContext:save(text, cursor)
+  if dfhack.isWorldLoaded() then
+    dfhack.persistent.saveSiteData(
+        get_fort_context_key(self.save_prefix),
+        {text={text}, cursor={cursor}}
+    )
+  end
+end
+
+function FortJournalContext:load()
+  if dfhack.isWorldLoaded() then
+    local site_data = dfhack.persistent.getSiteData(
+        get_fort_context_key(self.save_prefix)
+    ) or {}
+
+    if not site_data.text then
+        site_data.text={''}
+        site_data.show_tutorial = true
+    end
+    site_data.cursor = site_data.cursor or {#site_data.text[1] + 1}
+    return site_data
+  end
+end
+
+DummyJournalContext = defclass(DummyJournalContext)
+
+function DummyJournalContext:save(text, cursor)
+end
+
+function DummyJournalContext:load()
+  return {text={''}, cursor={1}, show_tutorial=true}
+end

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -99,9 +99,6 @@ local function arrange_empty_journal(options)
     local text_area = journal_window.subviews.journal_editor.text_area
 
     text_area.enable_cursor_blink = false
-    -- if not options.save_on_change then
-    --     text_area:setText('')
-    -- end
 
     if not options.allow_layout_restore then
         local toc_panel = journal_window.subviews.table_of_contents_panel

--- a/test/gui/journal.lua
+++ b/test/gui/journal.lua
@@ -1,5 +1,6 @@
 local gui = require('gui')
 local gui_journal = reqscript('gui/journal')
+local journal_context = reqscript('internal/journal/journal_context')
 
 config = {
     target = 'gui/journal',
@@ -75,8 +76,8 @@ local function arrange_empty_journal(options)
     options = options or {}
 
     gui_journal.main({
-        save_prefix='test:',
-        save_on_change=options.save_on_change or false,
+        save_prefix=options.save_prefix or 'test:',
+        context_mode=options.context_mode or gui_journal.JOURNAL_CONTEXT_MODE.DUMMY,
         save_layout=options.allow_layout_restore or false,
     })
 
@@ -98,9 +99,9 @@ local function arrange_empty_journal(options)
     local text_area = journal_window.subviews.journal_editor.text_area
 
     text_area.enable_cursor_blink = false
-    if not options.save_on_change then
-        text_area:setText('')
-    end
+    -- if not options.save_on_change then
+    --     text_area:setText('')
+    -- end
 
     if not options.allow_layout_restore then
         local toc_panel = journal_window.subviews.table_of_contents_panel
@@ -202,7 +203,10 @@ function test.restore_layout()
 end
 
 function test.restore_text_between_sessions()
-    local journal, text_area = arrange_empty_journal({w=80,save_on_change=true})
+    local journal, text_area = arrange_empty_journal({
+        w=80,
+        context_mode=gui_journal.JOURNAL_CONTEXT_MODE.FORTRESS
+    })
 
     simulate_input_keys('CUSTOM_CTRL_A')
     simulate_input_keys('CUSTOM_DELETE')
@@ -224,7 +228,10 @@ function test.restore_text_between_sessions()
 
     journal:dismiss()
 
-    journal, text_area = arrange_empty_journal({w=80, save_on_change=true})
+    journal, text_area = arrange_empty_journal({
+        w=80,
+        context_mode=gui_journal.JOURNAL_CONTEXT_MODE.FORTRESS
+    })
 
     expect.eq(read_rendered_text(text_area), table.concat({
         '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
@@ -600,11 +607,27 @@ function test.table_of_contents_keyboard_navigation()
     journal:dismiss()
 end
 
-function test.show_tutorials_on_first_use()
-    local journal, text_area, journal_window = arrange_empty_journal({w=65})
+function test.show_fortress_tutorials_on_first_use()
+    local save_prefix = 'test:'
+    local context = journal_context.journal_context_factory(
+        gui_journal.JOURNAL_CONTEXT_MODE.FORTRESS,
+        save_prefix
+    )
+    -- reset saved data
+    context:delete_content()
+
+    local journal, text_area, journal_window = arrange_empty_journal({
+        w=125,
+        context_mode=gui_journal.JOURNAL_CONTEXT_MODE.FORTRESS,
+        save_prefix=save_prefix
+    })
+
     simulate_input_keys('CUSTOM_CTRL_O')
 
-    expect.str_find('Welcome to gui/journal', read_rendered_text(text_area));
+    expect.str_find(
+        "Welcome to gui/journal, the chronicler's tool for Dwarf Fortress!",
+        read_rendered_text(text_area)
+    );
 
     simulate_input_text(' ')
 


### PR DESCRIPTION
Add adventure mode support for `gui/journal`.
The journal is stored per ID for the character the player created on the save.

It's not support `bodyswap` and other tools - using them u changing ur character, and new one will have new journal!

Also, add dedicated intro text for journal on adventure mode.

I do not see a way to test journal on CI in adventure mode right now.