### PR TITLE
[gui/design] toggle vanilla dimensions flag on overlay toggle

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -50,6 +50,7 @@ Template for new versions:
 - `gui/sitemap`: shift click to start following the selected unit or artifact
 - `prioritize`: when prioritizing jobs of a specified type, also output how many of those jobs were already prioritized before you ran the command
 - `prioritize`: don't include already-prioritized jobs in the output of ``prioritize -j``
+- `gui/design`: only display vanilla dimensions tooltip if the DFHack dimensions tooltip is disabled
 
 ## Removed
 

--- a/docs/gui/design.rst
+++ b/docs/gui/design.rst
@@ -7,7 +7,8 @@ gui/design
     :tags: fort design productivity interface map
 
 This tool provides a point and click interface to make designating shapes
-and patterns easier. Supports both digging designations and placing constructions.
+and patterns easier. Supports both digging designations and placing
+constructions.
 
 Usage
 -----
@@ -19,18 +20,23 @@ Usage
 Overlay
 -------
 
-This tool also provides two overlays that are managed by the `overlay` framework.
+This tool also provides two overlays that are managed by the `overlay`
+framework.
 
 dimensions
 ~~~~~~~~~~
 
-The ``gui/design.dimensions`` overlay shows the selected dimensions when designating
-with vanilla tools, for example when painting a burrow or designating digging.
-The dimensions show up in a tooltip that follows the mouse cursor.
+The ``gui/design.dimensions`` overlay shows the selected dimensions when
+designating with vanilla tools, for example when painting a burrow or
+designating digging. The dimensions show up in a tooltip that follows the mouse
+cursor.
+
+When this overlay is enabled, the vanilla dimensions display will be hidden.
+When this overlay is disabled, the vanilla dimensions display will be unhidden.
 
 rightclick
 ~~~~~~~~~~
 
-The ``gui/design.rightclick`` overlay prevents the right mouse button and other keys
-bound to "Leave screen" from exiting out of designation mode when drawing a box with
-vanilla tools, instead making it cancel the designation first.
+The ``gui/design.rightclick`` overlay prevents the right mouse button and other
+keys bound to "Leave screen" from exiting out of designation mode when drawing
+a box with vanilla tools, instead making it cancel the designation first.

--- a/gui/design.lua
+++ b/gui/design.lua
@@ -122,6 +122,14 @@ function DimensionsOverlay:preUpdateLayout(parent_rect)
     self.frame.h = parent_rect.height
 end
 
+function DimensionsOverlay:overlay_onenable()
+    df.global.d_init.display.flags.SHOW_RECTANGLE_DIMENSIONS = false
+end
+
+function DimensionsOverlay:overlay_ondisable()
+    df.global.d_init.display.flags.SHOW_RECTANGLE_DIMENSIONS = true
+end
+
 ---
 --- RightClickOverlay
 ---


### PR DESCRIPTION
ensure vanilla tooltip is hidden when ours is enabled

depends on: https://github.com/DFHack/dfhack/pull/5316

Fixes: https://github.com/DFHack/dfhack/issues/5281