### PR TITLE
`idle-crafting` :  do not assign crafting jobs to nobles holding meetings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -38,6 +38,7 @@ Template for new versions:
 ## Fixes
 - `position`: support for adv mode look cursor
 - `gui/liquids`: using the remove tool with magma selected will no longer create unexpected unpathable tiles
+- `idle-crafting`: do not assign crafting jobs to nobles holding meetings (avoid dangling jobs)
 
 ## Misc Improvements
 - `hide-tutorials`: handle tutorial popups for adventure mode

--- a/idle-crafting.lua
+++ b/idle-crafting.lua
@@ -333,6 +333,8 @@ end
 function unitIsAvailable(unit)
     if unit.job.current_job then
         return false
+    elseif #unit.specific_refs > 0 then -- activities such as "Conduct Meeting"
+        return false
     elseif #unit.social_activities > 0 then
         return false
     elseif #unit.individual_drills > 0 then


### PR DESCRIPTION
Assigning crafting jobs to nobles holding meetings leads to those jobs being incompletely canceled (both references are removed, but the job is not canceled) ([discord discussion](https://discord.com/channels/793331351645323264/807444467140788254/1346542301865971814))
