### PR TITLE
`idle-crafting`: ignore happy units until their needs are strong

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -43,6 +43,8 @@ Template for new versions:
 - `advtools`: new ``advtools.fastcombat`` overlay (enabled by default) allows you to skip combat animations and the announcement "More" button by mashing the movement keys
 - `gui/journal`: now working in adventure mode
 - `emigration`: new ``nobles`` command for sending "freeloader" barons back to the sites that they rule over
+- `advtools`: new ``advtools.fastcombat`` overlay (enabled by default)  allows you to skip combat animations and the announcement "More" button by mashing the movement keys
+- `idle-crafting`: default to only considering happy and ecstatic units for the highest need threshold
 
 ## Fixes
 - `position`: support for adv mode look cursor
@@ -52,6 +54,7 @@ Template for new versions:
 - `rejuvenate`: update unit portrait and sprite when aging up babies and children
 - `rejuvenate`: recalculate labor assignments for unit when aging up babies and children (so they can start accepting jobs)
 - `gui/liquids`: don't add liquids to wall tiles
+- `idle-crafting`: check that units still have crafting needs before creating a job for them
 
 ## Misc Improvements
 - `hide-tutorials`: handle tutorial popups for adventure mode

--- a/docs/idle-crafting.rst
+++ b/docs/idle-crafting.rst
@@ -26,6 +26,12 @@ Usage
      given unit. Units meeting higher thresholds will be prioritized. Defaults
      to ``500,1000,10000``.
 
+``idle-crafting happy [yes|no]``
+     If set to ``no``, "happy" and "ecstatic" dwarves not suffering from
+     long-term stress will only satisfy their crafting needs when meeting the
+     highest configured threshold (eg. ``10000`` at default settings). Defaults
+     to ``no``.
+
 ``disable idle-crafting``
      Disallow idle crafting at all workshops. You can re-enable idle crafting
      at individual Craftsdwarf's workshops.
@@ -34,7 +40,10 @@ Examples
 --------
 
 ``idle-crafting thresholds 500,1000,10000``
-    Reset thresholds to defaults.
+     Reset thresholds to defaults.
+
+``idle-crafting happy yes``
+     Treat happy and ecstatic dwarves the same as everyone else.
 
 Overlay
 -------


### PR DESCRIPTION
Note: this also introduces a check that a unit still has crafting needs before it gets assigned a crafting job.
