### PR TITLE
Data-driven DF toolbar position info; and use it in gui/mass-remove.toolbar

### DIFF
--- a/gui/mass-remove.lua
+++ b/gui/mass-remove.lua
@@ -407,20 +407,12 @@ end
 -- l/r/t/b frame positioning fields). However, to preserve player-positioning,
 -- we take a more circuitous route.
 
--- The button and tooltip are anchored to the right of the overlay's frame.
--- Then, to respond to different interface widths, we adjust the width of the
+-- The button and tooltip are anchored to one side of the overlay's frame (which
+-- one depends on which edge the overlay itself is anchored to). Then, to
+-- respond to different interface sizes, we adjust the width and height of the
 -- overlay's frame to arrange for the button to land in its expected place.
 
--- This resize handling breaks down a bit if the player switches the overlay to
--- be anchored to the top or right edges, but it still works okay for
--- windows/interfaces that don't change size, which is probably the common case.
-
 local tb = reqscript('internal/df-bottom-toolbars')
-
-local function mass_remove_button_offset(interface_rect)
-    local remove_buttons = tb.fort.center:secondary_toolbar_frame(interface_rect, 'erase')
-    return remove_buttons.l + remove_buttons.w -- to the right of the right-most button
-end
 
 local MR_BUTTON_WIDTH = 4
 local MR_BUTTON_HEIGHT = 3
@@ -428,12 +420,23 @@ local MR_TOOLTIP_WIDTH = 26
 local MR_TOOLTIP_HEIGHT = 6
 local MR_WIDTH = math.max(MR_BUTTON_WIDTH, MR_TOOLTIP_WIDTH)
 local MR_HEIGHT = MR_TOOLTIP_HEIGHT + 1 --[[empty line]] + MR_BUTTON_HEIGHT
-local MR_MIN_OFFSET = mass_remove_button_offset(tb.MINIMUM_INTERFACE_RECT)
+
+local function mass_remove_button_offsets(interface_rect)
+    local remove_buttons = tb.CENTER_TOOLBAR:secondary_toolbar_frame(interface_rect, 'erase')
+    return {
+        l = remove_buttons.l + remove_buttons.w,
+        r = remove_buttons.r - MR_BUTTON_WIDTH,
+        t = remove_buttons.t,
+        b = remove_buttons.b,
+    }
+end
+
+local MR_MIN_OFFSETS = mass_remove_button_offsets(tb.MINIMUM_INTERFACE_RECT)
 
 MassRemoveToolbarOverlay = defclass(MassRemoveToolbarOverlay, overlay.OverlayWidget)
 MassRemoveToolbarOverlay.ATTRS{
     desc='Adds a button to the erase toolbar to open the mass removal tool.',
-    default_pos={x=MR_MIN_OFFSET+1, y=-(tb.TOOLBAR_HEIGHT+1)},
+    default_pos={x=MR_MIN_OFFSETS.l+1, y=-(MR_MIN_OFFSETS.b+1)},
     default_enabled=true,
     viewscreens='dwarfmode/Designate/ERASE',
     frame={w=MR_WIDTH, h=MR_HEIGHT},
@@ -448,6 +451,7 @@ function MassRemoveToolbarOverlay:init()
 
     self:addviews{
         widgets.Panel{
+            view_id='tooltip',
             frame={t=0, r=0, w=MR_WIDTH, h=MR_TOOLTIP_HEIGHT},
             frame_style=gui.FRAME_PANEL,
             frame_background=gui.CLEAR_PEN,
@@ -500,8 +504,29 @@ function MassRemoveToolbarOverlay:init()
 end
 
 function MassRemoveToolbarOverlay:preUpdateLayout(parent_rect)
-    local extra_width = mass_remove_button_offset(parent_rect) - MR_MIN_OFFSET
+    local extra_width
+    local offsets = mass_remove_button_offsets(parent_rect)
+    if self.frame.l then
+        extra_width = offsets.l - MR_MIN_OFFSETS.l
+        self.subviews.tooltip.frame.l = nil
+        self.subviews.tooltip.frame.r = 0
+        self.subviews.icon.frame.l = nil
+        self.subviews.icon.frame.r = MR_WIDTH-MR_BUTTON_WIDTH
+    else
+        extra_width = offsets.r - MR_MIN_OFFSETS.r
+        self.subviews.tooltip.frame.r = nil
+        self.subviews.tooltip.frame.l = 0
+        self.subviews.icon.frame.r = nil
+        self.subviews.icon.frame.l = 0
+    end
+    local extra_height
+    if self.frame.b then
+        extra_height = offsets.b - MR_MIN_OFFSETS.b
+    else
+        extra_height = offsets.t - MR_MIN_OFFSETS.t
+    end
     self.frame.w = MR_WIDTH + extra_width
+    self.frame.h = MR_HEIGHT + extra_height
 end
 
 function MassRemoveToolbarOverlay:onInput(keys)

--- a/internal/df-bottom-toolbars.lua
+++ b/internal/df-bottom-toolbars.lua
@@ -1,0 +1,478 @@
+-- Provide data-driven locations for the DF toolbars at the bottom of the
+-- screen. Not quite as nice as getting the data from DF directly, but better
+-- than hand-rolling calculations for each "interesting" button.
+
+--@module = true
+
+TOOLBAR_HEIGHT = 3
+SECONDARY_TOOLBAR_HEIGHT = 3
+MINIMUM_INTERFACE_RECT = require('gui').mkdims_wh(0, 0, 114, 46)
+
+---@generic T
+---@param sequences T[][]
+---@return T[]
+local function concat_sequences(sequences)
+    local collected = {}
+    for _, sequence in ipairs(sequences) do
+        table.move(sequence, 1, #sequence, #collected + 1, collected)
+    end
+    return collected
+end
+
+---@alias NamedWidth table<string,integer> -- single entry, value is width
+---@alias NamedOffsets table<string,integer> -- multiple entries, values are offsets
+
+---@class Toolbar
+---@field button_offsets NamedOffsets
+---@field width integer
+
+---@class Toolbar.Widget.frame
+---@field l integer Gap between the left edge of the frame and the parent.
+---@field t integer Gap between the top edge of the frame and the parent.
+---@field r integer Gap between the right edge of the frame and the parent.
+---@field b integer Gap between the bottom edge of the frame and the parent.
+---@field w integer Width
+---@field h integer Height
+
+---@param widths NamedWidth[] single-name entries only!
+---@return Toolbar
+local function button_widths_to_offsets(widths)
+    local offsets = {}
+    local offset = 0
+    for _, ww in ipairs(widths) do
+        local name, w = next(ww)
+        if name then
+            if not name:startswith('_') then
+                offsets[name] = offset
+            end
+            offset = offset + w
+        end
+    end
+    return { button_offsets = offsets, width = offset }
+end
+
+---@param buttons string[]
+---@return NamedWidth[]
+local function buttons_to_widths(buttons)
+    local widths = {}
+    for _, button_name in ipairs(buttons) do
+        table.insert(widths, { [button_name] = 4 })
+    end
+    return widths
+end
+
+---@param buttons string[]
+---@return Toolbar
+local function buttons_to_offsets(buttons)
+    return button_widths_to_offsets(buttons_to_widths(buttons))
+end
+
+-- Fortress mode toolbar definitions
+fort = {}
+
+---@class LeftToolbar : Toolbar
+fort.left = buttons_to_offsets{
+    'citizens', 'tasks', 'places', 'labor',
+    'orders', 'nobles', 'objects', 'justice',
+}
+
+---@param interface_rect gui.dimension
+---@return Toolbar.Widget.frame
+function fort.left:frame(interface_rect)
+    return {
+        l = 0,
+        w = self.width,
+        r = interface_rect.width - self.width,
+
+        t = interface_rect.height - TOOLBAR_HEIGHT,
+        h = TOOLBAR_HEIGHT,
+        b = 0,
+    }
+end
+
+fort.left_center_gap_minimum = 7
+
+---@class CenterToolbar: Toolbar
+fort.center = button_widths_to_offsets{
+    { _left_border = 1 },
+    { dig = 4 }, { chop = 4 }, { gather = 4 }, { smooth = 4 }, { erase = 4 },
+    { _divider = 1 },
+    { build = 4 }, { stockpile = 4 }, { zone = 4 },
+    { _divider = 1 },
+    { burrow = 4 }, { cart = 4 }, { traffic = 4 },
+    { _divider = 1 },
+    { mass_designation = 4 },
+    { _right_border = 1 },
+}
+
+---@param interface_rect gui.dimension
+---@return Toolbar.Widget.frame
+function fort.center:frame(interface_rect)
+    -- center toolbar is "centered" in interface area, but never closer to the
+    -- left toolbar than fort.left_center_gap_minimum
+
+    local interface_offset_centered = math.ceil((interface_rect.width - self.width + 1) / 2)
+    local interface_offset_min = fort.left.width + fort.left_center_gap_minimum
+    local interface_offset = math.max(interface_offset_min, interface_offset_centered)
+
+    return {
+        l = interface_offset,
+        w = self.width,
+        r = interface_rect.width - interface_offset - self.width,
+
+        t = interface_rect.height - TOOLBAR_HEIGHT,
+        h = TOOLBAR_HEIGHT,
+        b = 0,
+    }
+end
+
+---@alias CenterToolbarToolNames              'dig' | 'chop' | 'gather' | 'smooth' | 'erase' | 'build' | 'stockpile' |                     'zone' | 'burrow' |                   'cart' | 'traffic' | 'mass_designation'
+---@alias CenterToolbarSecondaryToolbarNames  'dig' | 'chop' | 'gather' | 'smooth' | 'erase' |           'stockpile' | 'stockpile_paint' |                      'burrow_paint' |          'traffic' | 'mass_designation'
+
+---@param interface_rect gui.dimension
+---@param toolbar_name CenterToolbarSecondaryToolbarNames
+---@return Toolbar.Widget.frame
+function fort.center:secondary_toolbar_frame(interface_rect, toolbar_name)
+    local secondary_toolbar = self.secondary_toolbars[toolbar_name] or
+        dfhack.error('invalid toolbar name: ' .. toolbar_name)
+
+    ---@type CenterToolbarToolNames
+    local tool_name
+    if toolbar_name == 'stockpile_paint' then
+        tool_name = 'stockpile'
+    elseif toolbar_name == 'burrow_paint' then
+        tool_name = 'burrow'
+    else
+        tool_name = toolbar_name --[[@as CenterToolbarToolNames]]
+    end
+    local toolbar_offset = self:frame(interface_rect).l
+    local toolbar_button_offset = self.button_offsets[tool_name] or dfhack.error('invalid tool name: ' .. tool_name)
+
+    -- Ideally, the secondary toolbar is positioned directly above the (main) toolbar button
+    local ideal_offset = toolbar_offset + toolbar_button_offset
+
+    -- In "narrow" interfaces conditions, a wide secondary toolbar (pretty much
+    -- any tool that has "advanced" options) that was ideally positioned above
+    -- its tool's button would extend past the right edge of the interface area.
+    -- Such wide secondary toolbars are instead right justified with a bit of
+    -- padding.
+
+    -- padding necessary to line up width-constrained secondaries
+    local secondary_padding = 5
+    local width_constrained_offset = math.max(0, interface_rect.width - (secondary_toolbar.width + secondary_padding))
+
+    -- Use whichever position is left-most.
+    local l = math.min(ideal_offset, width_constrained_offset)
+    return {
+        l = l,
+        w = secondary_toolbar.width,
+        r = interface_rect.width - l - secondary_toolbar.width,
+
+        t = interface_rect.height - TOOLBAR_HEIGHT - SECONDARY_TOOLBAR_HEIGHT,
+        h = SECONDARY_TOOLBAR_HEIGHT,
+        b = TOOLBAR_HEIGHT,
+    }
+end
+
+---@type table<CenterToolbarSecondaryToolbarNames,NamedOffsets>
+fort.center.secondary_toolbars = {
+    dig = buttons_to_offsets{
+        'dig', 'stairs', 'ramp', 'channel', 'remove_construction', '_gap',
+        'rectangle', 'draw', '_gap',
+        'advanced_toggle', '_gap',
+        'all', 'auto', 'ore_gem', 'gem', '_gap',
+        'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', '_gap',
+        'blueprint', 'blueprint_to_standard', 'standard_to_blueprint',
+    },
+    chop = buttons_to_offsets{
+        'chop', '_gap',
+        'rectangle', 'draw', '_gap',
+        'advanced_toggle', '_gap',
+        'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', '_gap',
+        'blueprint', 'blueprint_to_standard', 'standard_to_blueprint',
+    },
+    gather = buttons_to_offsets{
+        'gather', '_gap',
+        'rectangle', 'draw', '_gap',
+        'advanced_toggle', '_gap',
+        'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', '_gap',
+        'blueprint', 'blueprint_to_standard', 'standard_to_blueprint',
+    },
+    smooth = buttons_to_offsets{
+        'smooth', 'engrave', 'carve_track', 'carve_fortification', '_gap',
+        'rectangle', 'draw', '_gap',
+        'advanced_toggle', '_gap',
+        'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', '_gap',
+        'blueprint', 'blueprint_to_standard', 'standard_to_blueprint',
+    },
+    erase = buttons_to_offsets{
+        'rectangle',
+        'draw',
+    },
+    -- build   -- completely different and quite variable
+    stockpile = buttons_to_offsets{ 'add_stockpile' },
+    stockpile_paint = buttons_to_offsets{
+        'rectangle', 'draw', 'erase_toggle', 'remove',
+    },
+    -- zone    -- no secondary toolbar
+    -- burrow -- no direct secondary toolbar
+    burrow_paint = buttons_to_offsets{
+        'rectangle', 'draw', 'erase_toggle', 'remove',
+    },
+    -- cart    -- no secondary toolbar
+    traffic = button_widths_to_offsets(
+        concat_sequences{ buttons_to_widths{
+            'high', 'normal', 'low', 'restricted', '_gap',
+            'rectangle', 'draw', '_gap',
+            'advanced_toggle', '_gap',
+        }, {
+            { weight_which = 4 },
+            { weight_slider = 26 },
+            { weight_input = 6 },
+        } }
+    ),
+    mass_designation = buttons_to_offsets{
+        'claim', 'forbid', 'dump', 'no_dump', 'melt', 'no_melt', 'hidden', 'visible', '_gap',
+        'rectangle', 'draw',
+    },
+}
+
+---@class RightToolbar: Toolbar
+fort.right = buttons_to_offsets{
+    'squads', 'world',
+}
+
+---@param interface_rect gui.dimension
+---@return Toolbar.Widget.frame
+function fort.right:frame(interface_rect)
+    return {
+        l = interface_rect.width - self.width,
+        w = self.width,
+        r = 0,
+
+        t = interface_rect.height - TOOLBAR_HEIGHT,
+        h = TOOLBAR_HEIGHT,
+        b = 0,
+    }
+end
+
+---@param interface_rect gui.dimension
+---@return gui.dimension
+function fort.right:rect(interface_rect)
+    local width = self.width
+    local height = 3
+    return gui.mkdims_wh(interface_rect.x2 - (width - 1), interface_rect.y2 - (height - 1), width, height)
+end
+
+if dfhack_flags.module then return end
+
+if not dfhack.world.isFortressMode() then
+    qerror('Demo only supports fort mode.')
+end
+
+local gui = require('gui')
+local Panel = require('gui.widgets.containers.panel')
+local Label = require('gui.widgets.labels.label')
+local Window = require('gui.widgets.containers.window')
+local Toggle = require('gui.widgets.labels.toggle_hotkey_label')
+
+local screen
+
+local visible_when_not_focused = true
+
+local function visible()
+    return visible_when_not_focused or screen and screen:isActive() and not screen.defocused
+end
+
+ToolbarDemoPanel = defclass(ToolbarDemoPanel, Panel)
+ToolbarDemoPanel.ATTRS{
+    frame_style = function(...)
+        local style = gui.FRAME_THIN(...)
+        style.signature_pen = false
+        return style
+    end,
+    visible_override = true,
+    visible = visible,
+    frame_background = { ch = 32, bg = COLOR_BLACK },
+}
+
+local temp_x, temp_y = 10, 10
+local label_width = 9 -- max len of words left, right, center, secondary
+local demo_panel_width = label_width + 4
+local demo_panel_height = 3
+
+local left_toolbar_demo = ToolbarDemoPanel{
+    frame = { l = temp_x, t = temp_y, w = demo_panel_width, h = demo_panel_height },
+    subviews = { Label{ frame = { xalign = 0.5, w = label_width }, text = 'left' } },
+}
+local center_toolbar_demo = ToolbarDemoPanel{
+    frame = { l = temp_x + demo_panel_width, t = temp_y, w = demo_panel_width, h = demo_panel_height },
+    subviews = { Label{ frame = { xalign = 0.5, w = label_width }, text = 'center' } },
+}
+local right_toolbar_demo = ToolbarDemoPanel{
+    frame = { l = temp_x + 2 * demo_panel_width, t = temp_y, w = demo_panel_width, h = demo_panel_height },
+    subviews = { Label{ frame = { xalign = 0.5, w = label_width }, text = 'right' } },
+}
+local secondary_visible = false
+local secondary_toolbar_demo
+secondary_toolbar_demo = ToolbarDemoPanel{
+    frame = { l = temp_x + demo_panel_width, t = temp_y - demo_panel_height, w = demo_panel_width, h = demo_panel_height },
+    subviews = { Label{ frame = { xalign = 0.5, w = label_width }, text = 'secondary' } },
+    visible = function() return visible() and secondary_visible end,
+}
+
+---@param secondary CenterToolbarSecondaryToolbarNames
+function update_demonstrations(secondary)
+    -- by default, draw primary toolbar demonstrations right above the primary toolbars:
+    -- {l demo}   {c demo}   {r demo}
+    -- [l tool]   [c tool]   [r tool]  (bottom of UI)
+    local toolbar_demo_dy = -TOOLBAR_HEIGHT
+    local ir = gui.get_interface_rect()
+    local function update(v, frame)
+        v.frame = {
+            w = frame.w,
+            h = frame.h,
+            l = frame.l + ir.x1,
+            t = frame.t + ir.y1 + toolbar_demo_dy,
+        }
+    end
+    if secondary then
+        -- a secondary toolbar is active, move the primary demonstration up to
+        -- let the secondary be demonstrated right above the actual secondary:
+        -- {l demo}   {c demo}   {r demo}
+        --               {s demo}
+        --               [s tool]
+        -- [l tool]   [c tool]   [r tool]  (bottom of UI)
+        update(secondary_toolbar_demo, fort.center:secondary_toolbar_frame(ir, secondary))
+        secondary_visible = true
+        toolbar_demo_dy = toolbar_demo_dy - 2 * SECONDARY_TOOLBAR_HEIGHT
+    else
+        secondary_visible = false
+    end
+
+    update(left_toolbar_demo, fort.left:frame(ir))
+    update(right_toolbar_demo, fort.right:frame(ir))
+    update(center_toolbar_demo, fort.center:frame(ir))
+end
+
+local tool_from_designation = {
+    -- from df.main_designation_type
+    NONE = nil,
+    DIG_DIG = 'dig',
+    DIG_REMOVE_STAIRS_RAMPS = 'dig',
+    DIG_STAIR_UP = 'dig',
+    DIG_STAIR_UPDOWN = 'dig',
+    DIG_STAIR_DOWN = 'dig',
+    DIG_RAMP = 'dig',
+    DIG_CHANNEL = 'dig',
+    CHOP = 'chop',
+    GATHER = 'gather',
+    SMOOTH = 'smooth',
+    TRACK = 'smooth',
+    ENGRAVE = 'smooth',
+    FORTIFY = 'smooth',
+    -- REMOVE_CONSTRUCTION -- not used?
+    CLAIM = 'mass_designation',
+    UNCLAIM = 'mass_designation',
+    MELT = 'mass_designation',
+    NO_MELT = 'mass_designation',
+    DUMP = 'mass_designation',
+    NO_DUMP = 'mass_designation',
+    HIDE = 'mass_designation',
+    NO_HIDE = 'mass_designation',
+    -- TOGGLE_ENGRAVING -- not used?
+    DIG_FROM_MARKER = 'dig',
+    DIG_TO_MARKER = 'dig',
+    CHOP_FROM_MARKER = 'chop',
+    CHOP_TO_MARKER = 'chop',
+    GATHER_FROM_MARKER = 'gather',
+    GATHER_TO_MARKER = 'gather',
+    SMOOTH_FROM_MARKER = 'smooth',
+    SMOOTH_TO_MARKER = 'smooth',
+    DESIGNATE_TRAFFIC_HIGH = 'traffic',
+    DESIGNATE_TRAFFIC_NORMAL = 'traffic',
+    DESIGNATE_TRAFFIC_LOW = 'traffic',
+    DESIGNATE_TRAFFIC_RESTRICTED = 'traffic',
+    ERASE = 'erase',
+}
+local tool_from_bottom = {
+    -- from df.main_bottom_mode_type
+    -- NONE
+    -- BUILDING
+    -- BUILDING_PLACEMENT
+    -- BUILDING_PICK_MATERIALS
+    -- ZONE
+    -- ZONE_PAINT
+    STOCKPILE = 'stockpile',
+    STOCKPILE_PAINT = 'stockpile_paint',
+    -- BURROW
+    BURROW_PAINT = 'burrow_paint'
+    -- HAULING
+    -- ARENA_UNIT
+    -- ARENA_TREE
+    -- ARENA_WATER_PAINT
+    -- ARENA_MAGMA_PAINT
+    -- ARENA_SNOW_PAINT
+    -- ARENA_MUD_PAINT
+    -- ARENA_REMOVE_PAINT
+}
+---@return CenterToolbarSecondaryToolbarNames
+local function active_secondary()
+    local designation = df.global.game.main_interface.main_designation_selected
+    if designation ~= df.main_designation_type.NONE then
+        return tool_from_designation[df.main_designation_type[designation]]
+    end
+    local bottom = df.global.game.main_interface.bottom_mode_selected
+    if bottom ~= df.main_bottom_mode_type.NONE then
+        return tool_from_bottom[df.main_bottom_mode_type[bottom]]
+    end
+end
+
+DemoWindow = defclass(DemoWindow, Window)
+DemoWindow.ATTRS{
+    frame_title = 'DF "bottom toolbars" module demo',
+    frame = { w = 39, h = 5 },
+    resizable = true,
+}
+
+function DemoWindow:init()
+    self:addviews{
+        Toggle{
+            label = 'Demos visible when not focused?',
+            initial_option = visible_when_not_focused,
+            on_change = function(new, old)
+                visible_when_not_focused = new
+            end
+        }
+    }
+end
+
+DemoScreen = defclass(DemoScreen, gui.ZScreen)
+function DemoScreen:init()
+    self:addviews{
+        DemoWindow{},
+        left_toolbar_demo,
+        center_toolbar_demo,
+        right_toolbar_demo,
+        secondary_toolbar_demo,
+    }
+end
+
+local secondary, if_percentage
+function DemoScreen:render(...)
+    if visible_when_not_focused then
+        local new_secondary = active_secondary()
+        local new_if_percentage = df.global.init.display.max_interface_percentage
+        if new_secondary ~= secondary or new_if_percentage ~= if_percentage then
+            secondary = new_secondary
+            self:updateLayout()
+        end
+    end
+    return DemoScreen.super.render(self, ...)
+end
+
+function DemoScreen:postComputeFrame(frame_body)
+    update_demonstrations(active_secondary())
+end
+
+screen = DemoScreen{}:show()


### PR DESCRIPTION
I mentioned on Discord that I had worked up a data-driven way of calculating the positions of DF toolbars.

Here it is. Of course, it would be better to get position information directly from DF, but having a single place that calculates this stuff should make it easier to provide reliable positioning for all the new toolbar buttons that are being added.

Running `internal/df-bottom-toolbars` will launch a "demonstration" that can be used to check that the computed values match what DF does at various screen sizes and interface percentages.

Highlights of the positioning calculations:

- Derived from black-box observations.
  - Not sure if it is feasible to have the RE team verify the magic/oddities noted below (7 columns between left and center, "'double" rounding when centering, 5 columns to the left of secondary)
- All positioning is inside the interface area.
- There are three fort-mode toolbars:
  - 1 flush-left (info buttons)
  - 1 "centered" (designations, etc.)
    - the centered toolbar is always at least 7 columns away from the left toolbar, so not always exactly "centered"
    - the centering involves a little bit of odd rounding  

          math.ceil((interface_rect.width - self.width + 1) / 2)

      This odd double-rounding seems to work correctly and kind of matches part of `gui.get_interface_rect()` (was that re-implemented from reverse engineering?).
  - 1 flush-right (squad and world)
- Most of the center toolbar "tools" can have a secondary toolbar that opens above the main toolbar
  - the secondary toolbar "wants to" be positioned directly above the button that opened it
    - when this is not possible because the secondary toolbar is too wide (possibly because of hidden advanced options that still influence placement), it may be pushed to the left to fit into the interface area
      - if the secondary toolbar is "being pushed from the right", there will be a 5 column gap between the right end of the secondary toolbar at the far-right side of the interface area

