### PR TITLE
[gui/journal] don't pass pause events through the ui

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -35,6 +35,7 @@ Template for new versions:
 
 ## Fixes
 - `idle-crafting`: check that units still have crafting needs before creating a job for them
+- `gui/journal`: prevent pause/unpause events from leaking through the UI when keys are mashed
 
 ## Misc Improvements
 

--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -268,6 +268,7 @@ end
 JournalScreen = defclass(JournalScreen, gui.ZScreen)
 JournalScreen.ATTRS {
     focus_path='journal',
+    pass_pause=false,
     context_mode=DEFAULT_NIL,
     save_layout=true,
     save_prefix=''


### PR DESCRIPTION
can happen if keys are mashed in just the right way

Fixes: https://github.com/DFHack/dfhack/issues/5367
