### PR TITLE
[fix/loyaltycascade, makeown] remove unit from current conflict activities

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,8 @@ Template for new versions:
 ## Fixes
 
 ## Misc Improvements
+- `fix/loyaltycascade`: now also breaks up brawls and other intra-fort conflicts that *look* like loyalty cascades
+- `makeown`: remove selected unit from any current conflicts so they don't just start attacking other citizens when you make them a citizen of your fort
 
 ## Removed
 

--- a/docs/fix/loyaltycascade.rst
+++ b/docs/fix/loyaltycascade.rst
@@ -6,7 +6,9 @@ fix/loyaltycascade
     :tags: fort bugfix units
 
 This tool neutralizes loyalty cascades by fixing units who consider their own
-civilization to be the enemy.
+civilization to be the enemy. It will also halt all fighting on the map that
+involves your citizens, though "real" enemies will re-engage in combat after a
+short delay.
 
 Usage
 -----

--- a/docs/makeown.rst
+++ b/docs/makeown.rst
@@ -6,7 +6,8 @@ makeown
     :tags: fort armok units
 
 Select a unit in the UI and run this tool to converts that unit to be a fortress
-citizen (if sentient). It also removes their foreign affiliation, if any.
+citizen (if sentient). It also removes their foreign affiliation, if any, and
+removes the unit from any current conflict they are engaged in.
 
 This tool also fixes :bug:`10921`, where you request workers from your
 holdings, but they come with the "Merchant" profession and are unable to

--- a/fix/loyaltycascade.lua
+++ b/fix/loyaltycascade.lua
@@ -1,4 +1,5 @@
 -- Prevents a "loyalty cascade" (intra-fort civil war) when a citizen is killed.
+-- Also breaks up brawls and other conflicts.
 
 local makeown = reqscript('makeown')
 
@@ -76,7 +77,7 @@ local function fixUnit(unit)
         makeown.clear_enemy_status(unit)
     end
 
-    return false
+    return makeown.remove_from_conflict(unit) or fixed
 end
 
 local count = 0
@@ -87,7 +88,7 @@ for _, unit in pairs(dfhack.units.getCitizens()) do
 end
 
 if count > 0 then
-    print(('Fixed %s units from a loyalty cascade.'):format(count))
+    print(('Fixed %s units with loyalty issues.'):format(count))
 else
     print('No loyalty cascade found.')
 end


### PR DESCRIPTION
Fixes: https://github.com/DFHack/dfhack/issues/1422
