### PR TITLE
refine display of readable names

### DIFF
--- a/gui/sitemap.lua
+++ b/gui/sitemap.lua
@@ -18,7 +18,7 @@ end
 Sitemap = defclass(Sitemap, widgets.Window)
 Sitemap.ATTRS {
     frame_title='Sitemap',
-    frame={w=67, r=2, t=18, h=25},
+    frame={w=67, r=2, t=18, h=26},
     resizable=true,
     resize_min={w=44, h=20},
     frame_inset={l=1, t=1, r=0, b=0},
@@ -141,12 +141,10 @@ end
 local function get_unit_choice_text(unit)
     local disposition, disposition_pen, affiliation = get_unit_disposition_and_pen_and_affiliation(unit)
     return {
-        dfhack.units.getReadableName(unit),
-        ' (',
-        {text=disposition, pen=disposition_pen},
+        dfhack.units.getReadableName(unit), NEWLINE,
+        {gap=2, text=disposition, pen=disposition_pen},
         affiliation and ': ' or '',
         {text=affiliation, pen=COLOR_YELLOW},
-        ')',
     }
 end
 
@@ -277,6 +275,7 @@ function Sitemap:init()
                         },
                         widgets.FilteredList{
                             view_id='list',
+                            row_height=2,
                             on_submit=zoom_to_unit,
                             on_submit2=follow_unit,
                             choices=unit_choices,

--- a/gui/unit-info-viewer.lua
+++ b/gui/unit-info-viewer.lua
@@ -174,9 +174,15 @@ end
 
 local function get_name_chunk(unit)
     return {
-        text=dfhack.units.getReadableName(unit),
+        text=dfhack.units.getReadableName(unit, true),
         pen=dfhack.units.getProfessionColor(unit)
     }
+end
+
+local function get_translated_name_chunk(unit)
+    local tname = dfhack.translation.translateName(dfhack.units.getVisibleName(unit), true)
+    if #tname == 0 then return '' end
+    return ('"%s"'):format(tname)
 end
 
 local function get_description_chunk(unit)
@@ -456,8 +462,13 @@ function UnitInfo:init()
             auto_height=false,
         },
         widgets.Label{
+            view_id='translated_name',
+            frame={t=1, l=0, h=1},
+            auto_height=false,
+        },
+        widgets.Label{
             view_id='chunks',
-            frame={t=2, l=0, b=0, r=0},
+            frame={t=3, l=0, b=0, r=0},
             auto_height=false,
             text='Please select a unit.',
         },
@@ -483,6 +494,7 @@ end
 function UnitInfo:refresh(unit, width)
     self.unit_id = unit.id
     self.subviews.nameprof:setText{get_name_chunk(unit)}
+    self.subviews.translated_name:setText{get_translated_name_chunk(unit)}
 
     local chunks = {}
     add_chunk(chunks, get_description_chunk(unit), width)

--- a/prioritize.lua
+++ b/prioritize.lua
@@ -703,7 +703,7 @@ end
 
 function EnRouteOverlay:get_builder_name()
     if not self.builder then return 'N/A' end
-    return dfhack.units.getReadableName(self.builder)
+    return dfhack.units.getReadableName(self.builder, true)
 end
 
 function EnRouteOverlay:get_builder_name_pen()


### PR DESCRIPTION
in particular, `gui/sitemap` now has 2 rows per unit