### PR TITLE
remove-stress also removes long-term stress, which also immediately removes stressed and haggard statuses

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -38,6 +38,7 @@ Template for new versions:
 - `starvingdead`: ensure undead decay does not happen faster than the declared decay rate when saving and loading the game
 
 ## Misc Improvements
+- `remove-stress`: also applied to long-term stress, immediately removing stressed and haggard statuses
 
 ## Removed
 

--- a/remove-stress.lua
+++ b/remove-stress.lua
@@ -1,7 +1,6 @@
 -- Sets stress to negative one million
 --By Putnam; http://www.bay12forums.com/smf/index.php?topic=139553.msg5820486#msg5820486
 --edited by Bumber
---edited by BlakeMW
 --@module = true
 
 local utils = require('utils')

--- a/remove-stress.lua
+++ b/remove-stress.lua
@@ -1,6 +1,7 @@
 -- Sets stress to negative one million
 --By Putnam; http://www.bay12forums.com/smf/index.php?topic=139553.msg5820486#msg5820486
 --edited by Bumber
+--edited by BlakeMW
 --@module = true
 
 local utils = require('utils')
@@ -13,6 +14,9 @@ function removeStress(unit,value)
     if unit.status.current_soul then
         if unit.status.current_soul.personality.stress > value then
             unit.status.current_soul.personality.stress = value
+        end
+        if unit.status.current_soul.personality.longterm_stress > value then
+            unit.status.current_soul.personality.longterm_stress =  value
         end
     end
 end


### PR DESCRIPTION
While in its current implementation remove-stress will over time bring down long-term stress, it seems much more intuitive to just immediately remove the long-term stress.