### PR TITLE
`confirm` fixes: pausing, Escape from uniform, order-remove descriptions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -42,6 +42,7 @@ Template for new versions:
 - `confirm`: when removing a manager order, show correct order description when using non-100% interface setting
 - `confirm`: when removing a manager order, show correct order description after prior order removal or window resize (when scrolled to bottom of order list)
 - `confirm`: when removing a manager order, show specific item/job type for ammo, shield, helm, gloves, shoes, trap component, and meal orders
+- `confirm`: the pause option now only pauses future instances of the current confirmation instead of all confirmations in the current context
 
 ## Misc Improvements
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -40,6 +40,7 @@ Template for new versions:
 - `confirm`: only show pause option for pausable confirmations
 - `confirm`: when editing a uniform, confirm discard of changes when exiting with Escape
 - `confirm`: when removing a manager order, show correct order description when using non-100% interface setting
+- `confirm`: when removing a manager order, show correct order description after prior order removal or window resize (when scrolled to bottom of order list)
 
 ## Misc Improvements
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -41,6 +41,7 @@ Template for new versions:
 - `confirm`: when editing a uniform, confirm discard of changes when exiting with Escape
 - `confirm`: when removing a manager order, show correct order description when using non-100% interface setting
 - `confirm`: when removing a manager order, show correct order description after prior order removal or window resize (when scrolled to bottom of order list)
+- `confirm`: when removing a manager order, show specific item/job type for ammo, shield, helm, gloves, shoes, trap component, and meal orders
 
 ## Misc Improvements
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -37,6 +37,7 @@ Template for new versions:
 ## Fixes
 - `starvingdead`: properly restore to correct enabled state when loading a new game that is different from the first game loaded in this session
 - `starvingdead`: ensure undead decay does not happen faster than the declared decay rate when saving and loading the game
+- `confirm`: only show pause option for pausable confirmations
 
 ## Misc Improvements
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -38,6 +38,7 @@ Template for new versions:
 - `starvingdead`: properly restore to correct enabled state when loading a new game that is different from the first game loaded in this session
 - `starvingdead`: ensure undead decay does not happen faster than the declared decay rate when saving and loading the game
 - `confirm`: only show pause option for pausable confirmations
+- `confirm`: when editing a uniform, confirm discard of changes when exiting with Escape
 
 ## Misc Improvements
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -39,6 +39,7 @@ Template for new versions:
 - `starvingdead`: ensure undead decay does not happen faster than the declared decay rate when saving and loading the game
 - `confirm`: only show pause option for pausable confirmations
 - `confirm`: when editing a uniform, confirm discard of changes when exiting with Escape
+- `confirm`: when removing a manager order, show correct order description when using non-100% interface setting
 
 ## Misc Improvements
 

--- a/confirm.lua
+++ b/confirm.lua
@@ -108,12 +108,15 @@ function ConfirmOverlay:matches_conf(conf, keys, scr)
 end
 
 function ConfirmOverlay:onInput(keys)
-    if self.paused_conf or self.simulating then
+    if self.simulating then
         return false
     end
     local scr = dfhack.gui.getDFViewscreen(true)
     for id, conf in pairs(specs.REGISTRY) do
         if specs.config.data[id].enabled and self:matches_conf(conf, keys, scr) then
+            if conf == self.paused_conf then
+                return false
+            end
             local mouse_pos = xy2pos(dfhack.screen.getMousePos())
             local propagate_fn = function(pause)
                 if conf.on_propagate then

--- a/confirm.lua
+++ b/confirm.lua
@@ -131,8 +131,9 @@ function ConfirmOverlay:onInput(keys)
                 gui.simulateInput(scr, keys)
                 self.simulating = false
             end
+            local pause_fn = conf.pausable and curry(propagate_fn, true) or nil
             dialogs.showYesNoPrompt(conf.title, utils.getval(conf.message):wrap(45), COLOR_YELLOW,
-                propagate_fn, nil, curry(propagate_fn, true), curry(dfhack.run_script, 'gui/confirm', tostring(conf.id)))
+                propagate_fn, nil, pause_fn, curry(dfhack.run_script, 'gui/confirm', tostring(conf.id)))
             return true
         end
     end

--- a/internal/confirm/specs.lua
+++ b/internal/confirm/specs.lua
@@ -325,13 +325,13 @@ ConfirmSpec{
     id='uniform-discard-changes',
     title='Discard uniform changes',
     message='Are you sure you want to discard changes to this uniform?',
-    intercept_keys={'_MOUSE_L', '_MOUSE_R'},
+    intercept_keys={'LEAVESCREEN', '_MOUSE_L', '_MOUSE_R'},
     -- sticks out the left side so it can move with the panel
     -- when the screen is resized too narrow
     intercept_frame={r=32, t=19, w=101, b=3},
     context='dwarfmode/Squads/Equipment/Customizing/Default',
     predicate=function(keys, mouse_offset)
-        if keys._MOUSE_R then
+        if keys.LEAVESCREEN or keys._MOUSE_R then
             return uniform_has_changes()
         end
         if clicked_on_confirm_button(mouse_offset) then

--- a/internal/confirm/specs.lua
+++ b/internal/confirm/specs.lua
@@ -458,7 +458,16 @@ ConfirmSpec{
     message=function()
         local order_desc = ''
         local scroll_pos = mi.info.work_orders.scroll_position_work_orders
-        local y_offset = gui.get_interface_rect().width > 154 and 8 or 10
+        local ir = gui.get_interface_rect()
+        local y_offset = ir.width > 154 and 8 or 10
+        local order_rows = (ir.height - y_offset - 9) // 3
+        local max_scroll_pos = math.max(0, #orders - order_rows) -- DF keeps list view "full" (no empty rows at bottom), if possible
+        if scroll_pos > max_scroll_pos then
+            -- sometimes, DF does not adjust scroll_position_work_orders (when
+            -- scrolled to bottom: order removed, or list view height grew);
+            -- compensate to keep order_idx in sync (and in bounds)
+            scroll_pos = max_scroll_pos
+        end
         local _, y = dfhack.screen.getMousePos()
         if y then
             local order_idx = scroll_pos + (y - y_offset) // 3

--- a/internal/confirm/specs.lua
+++ b/internal/confirm/specs.lua
@@ -7,6 +7,7 @@
 
 local json = require('json')
 local trade_internal = reqscript('internal/caravan/trade')
+local gui = require('gui')
 
 local CONFIG_FILE = 'dfhack-config/confirm.json'
 
@@ -457,7 +458,7 @@ ConfirmSpec{
     message=function()
         local order_desc = ''
         local scroll_pos = mi.info.work_orders.scroll_position_work_orders
-        local y_offset = dfhack.screen.getWindowSize() > 154 and 8 or 10
+        local y_offset = gui.get_interface_rect().width > 154 and 8 or 10
         local _, y = dfhack.screen.getMousePos()
         if y then
             local order_idx = scroll_pos + (y - y_offset) // 3

--- a/internal/confirm/specs.lua
+++ b/internal/confirm/specs.lua
@@ -453,6 +453,12 @@ local orders = df.global.world.manager_orders.all
 local itemdefs = df.global.world.raws.itemdefs
 local reactions = df.global.world.raws.reactions.reactions
 
+local meal_type_by_ingredient_count = {
+    [2] = 'easy',
+    [3] = 'fine',
+    [4] = 'lavish',
+}
+
 local function make_order_desc(order)
     if order.job_type == df.job_type.CustomReaction then
         for _, reaction in ipairs(reactions) do
@@ -461,16 +467,35 @@ local function make_order_desc(order)
             end
         end
         return ''
+    elseif order.job_type == df.job_type.PrepareMeal then
+        -- DF uses mat_type as ingredient count?
+        local meal_type = meal_type_by_ingredient_count[order.mat_type]
+        if meal_type then
+            return 'prepare ' .. meal_type .. ' meal'
+        end
+        return 'prepare meal'
     end
     local noun
     if order.job_type == df.job_type.MakeArmor then
         noun = itemdefs.armor[order.item_subtype].name
     elseif order.job_type == df.job_type.MakeWeapon then
         noun = itemdefs.weapons[order.item_subtype].name
+    elseif order.job_type == df.job_type.MakeShield then
+        noun = itemdefs.shields[order.item_subtype].name
+    elseif order.job_type == df.job_type.MakeAmmo then
+        noun = itemdefs.ammo[order.item_subtype].name
+    elseif order.job_type == df.job_type.MakeHelm then
+        noun = itemdefs.helms[order.item_subtype].name
+    elseif order.job_type == df.job_type.MakeGloves then
+        noun = itemdefs.gloves[order.item_subtype].name
     elseif order.job_type == df.job_type.MakePants then
         noun = itemdefs.pants[order.item_subtype].name
+    elseif order.job_type == df.job_type.MakeShoes then
+        noun = itemdefs.shoes[order.item_subtype].name
     elseif order.job_type == df.job_type.MakeTool then
         noun = itemdefs.tools[order.item_subtype].name
+    elseif order.job_type == df.job_type.MakeTrapComponent then
+        noun = itemdefs.trapcomps[order.item_subtype].name
     elseif order.job_type == df.job_type.SmeltOre then
         noun = 'ore'
     else


### PR DESCRIPTION
The individual commits here are mostly independent and the commit messages give descriptions and motivations.

---

The last "order-remove descriptions" commit (4bce233fb8f11664c7fb5f69d4ba571e6a90b9d1) depends on its parent (a small refactoring), but could be reworked without it.

---

The last commit (fb25d4d2e7d0b34cbdbb9c1f175573729cb5ae02: only pause specific confirmations) is a bit speculative. The motivating example is that pausing any of `trade-`{`un`,}`mark-all-`{`fort`,`merchant`} will also pause `trade-seize` since they all share the same context. Trading and hauling seem to be the only pausable confirmations (after 435fcd066dcd6ee0e271a67fbd2e4d1dbfec376c) with shared contexts. Does this seem reasonable for both of them? There is a large disparity in the ramifications of an unintentionally skipped seize/offer/trade action versus the un/mark-all trade confirmations, so it seems important there. Maybe it is a good idea for hauling too, since the buttons for deleting a stop and a whole route are right next to each other?

In the changelog for this "pause specific confirmations" change, I used the words "in the current context", but that probably does not mean much to players (and the underlying focus strings are not easy to observe). Not sure what can be done to better communicate this (maybe some visible widget that indicates when and which confirmations are paused?).

---

Similar fixes to the "stale scroll position" commit (ded125a055f0d7b452b7628156ca88ce68c44f03) definitely need to be made in some other places, too. Of the other `scroll_position`s in `internal/confirm/specs`:
* hotkey-reset `mi.hotkey.scroll_position` goes stale when scrolled to the bottom and the window gains height, and does cause similar index confusion
* uniform-delete `mi.assign_uniform.scroll_position` seems immune to this since the displayed list doesn't seem to change size with window height (even when its 9 "uniform rows" don't fit in the available area)

There are plenty of other `scroll_position` hits in the type definitions, but there are many fewer in the Lua files (and none in the C++ files?). I'll open a placeholder issue while I investigate these.