### PR TITLE
Feat/worldmap journal

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -36,6 +36,7 @@ Template for new versions:
 - `gui/spectate`: added "Prefer nicknamed" to the list of options
 - `gui/mod-manager`: when run in a loaded world, shows a list of active mods -- click to export the list to the clipboard for easy sharing or posting
 - `gui/blueprint`: now records zone designations
+- `gui/journal`: now working on worldmap, before embark -- journal is per world map, stored even if you decided to not embark
 
 ## Fixes
 - `starvingdead`: properly restore to correct enabled state when loading a new game that is different from the first game loaded in this session

--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -334,6 +334,23 @@ function main(options)
     }:show()
 end
 
+local last_viewscreen_focus = nil
+local SCREEN_SETUP_FORTRESS = 'setupdwarfgame/Default'
+
+dfhack.onStateChange['gui/journal'] = function (sc)
+    if sc == SC_VIEWSCREEN_CHANGED then
+        local scr = dfhack.gui.getDFViewscreen(true)
+        local curr_viewscreen_focus = dfhack.gui.getFocusStrings(scr)[1]
+        if last_viewscreen_focus == SCREEN_SETUP_FORTRESS and
+           curr_viewscreen_focus ~= last_viewscreen_focus then
+            -- hide worldmap journal when embark on fortress is done
+            view:dismiss()
+        end
+
+        last_viewscreen_focus = curr_viewscreen_focus
+    end
+end
+
 if not dfhack_flags.module then
     main()
 end

--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -313,13 +313,17 @@ function JournalScreen:onDismiss()
 end
 
 function main(options)
-    if not dfhack.isMapLoaded() or (not dfhack.world.isFortressMode()
-        and not dfhack.world.isAdventureMode()) then
+    local fortress_worldmap_mode = not dfhack.isMapLoaded() and dfhack.world.isFortressMode()
+    local fortress_mode = dfhack.isMapLoaded() and dfhack.world.isFortressMode()
+    local adventure_mode = dfhack.isMapLoaded() and dfhack.world.isAdventureMode()
+
+    if not fortress_mode and not adventure_mode and not fortress_worldmap_mode then
         qerror('journal requires a fortress/adventure map to be loaded')
     end
 
     local save_layout = options and options.save_layout
     local overrided_context_mode = options and options.context_mode
+
     local context_mode = overrided_context_mode == nil and
         journal_context.detect_journal_context_mode() or overrided_context_mode
 

--- a/internal/journal/contexts/worldmap.lua
+++ b/internal/journal/contexts/worldmap.lua
@@ -1,0 +1,74 @@
+--@ module = true
+
+local json = require 'json'
+
+local JOURNAL_WELCOME_COPY =  [=[
+Welcome to gui/journal, your planning scroll for the world of Dwarf Fortress!
+
+Here, you can outline your fortress ideas, compare embark sites, or record thoughts before founding your settlement.
+The text you write here is saved together with your world - even if you cancel the embark.
+
+For guidance on navigation and hotkeys, tap the ? button in the upper right corner.
+Strike the earth!
+]=]
+
+local TOC_WELCOME_COPY =  [=[
+Start a line with # symbols and a space to create a header. For example:
+
+# My section heading
+
+or
+
+## My section subheading
+
+Those headers will appear here, and you can click on them to jump to them in the text.]=]
+
+worldmap_config = worldmap_config or json.open('dfhack-config/journal-context.json')
+
+WorldmapJournalContext = defclass(WorldmapJournalContext)
+WorldmapJournalContext.ATTRS{
+  save_prefix='',
+  world_id=DEFAULT_NIL
+}
+
+function get_worldmap_context_key(prefix, world_id)
+    return prefix .. 'world:' .. world_id
+end
+
+function WorldmapJournalContext:save_content(text, cursor)
+  if dfhack.isWorldLoaded() then
+    local key = get_worldmap_context_key(self.save_prefix, self.world_id)
+    worldmap_config.data[key] = {text={text}, cursor={cursor}}
+    worldmap_config:write()
+  end
+end
+
+function WorldmapJournalContext:load_content()
+  if dfhack.isWorldLoaded() then
+    local key = get_worldmap_context_key(self.save_prefix, self.world_id)
+    local worldmap_data = copyall(worldmap_config.data[key] or {})
+
+    if not worldmap_data.text or #worldmap_data.text[1] == 0 then
+        worldmap_data.text={''}
+        worldmap_data.show_tutorial = true
+    end
+    worldmap_data.cursor = worldmap_data.cursor or {#worldmap_data.text[1] + 1}
+    return worldmap_data
+  end
+end
+
+function WorldmapJournalContext:delete_content()
+  if dfhack.isWorldLoaded() then
+    local key = get_worldmap_context_key(self.save_prefix, self.world_id)
+    table.remove(worldmap_config.data, key)
+    worldmap_config:write()
+  end
+end
+
+function WorldmapJournalContext:welcomeCopy()
+  return JOURNAL_WELCOME_COPY
+end
+
+function WorldmapJournalContext:tocWelcomeCopy()
+  return TOC_WELCOME_COPY
+end

--- a/internal/journal/journal_context.lua
+++ b/internal/journal/journal_context.lua
@@ -1,21 +1,25 @@
 --@ module = true
 
 local widgets = require 'gui.widgets'
-local utils = require('utils')
+local utils = require 'utils'
 local DummyJournalContext = reqscript('internal/journal/contexts/dummy').DummyJournalContext
 local FortressJournalContext = reqscript('internal/journal/contexts/fortress').FortressJournalContext
+local WorldmapJournalContext = reqscript('internal/journal/contexts/worldmap').WorldmapJournalContext
 local AdventurerJournalContext = reqscript('internal/journal/contexts/adventure').AdventurerJournalContext
 
 JOURNAL_CONTEXT_MODE = {
   FORTRESS='fortress',
   ADVENTURE='adventure',
+  WORLDMAP='WORLDMAP',
   DUMMY='dummy'
 }
 
 function detect_journal_context_mode()
-  if dfhack.world.isFortressMode() then
+  if not dfhack.isMapLoaded() and dfhack.world.isFortressMode() then
+    return JOURNAL_CONTEXT_MODE.WORLDMAP
+  elseif dfhack.isMapLoaded() and dfhack.world.isFortressMode() then
     return JOURNAL_CONTEXT_MODE.FORTRESS
-  elseif dfhack.world.isAdventureMode() then
+  elseif dfhack.isMapLoaded() and dfhack.world.isAdventureMode() then
     return JOURNAL_CONTEXT_MODE.ADVENTURE
   else
     qerror('unsupported game mode')
@@ -24,7 +28,7 @@ end
 
 function journal_context_factory(journal_context_mode, save_prefix)
   if journal_context_mode == JOURNAL_CONTEXT_MODE.FORTRESS then
-    return FortressJournalContext{save_prefix}
+    return FortressJournalContext{save_prefix=save_prefix}
   elseif journal_context_mode == JOURNAL_CONTEXT_MODE.ADVENTURE then
     local interactions = df.global.adventure.interactions
     if #interactions.party_core_members == 0 or interactions.party_core_members[0] == nil then
@@ -34,9 +38,13 @@ function journal_context_factory(journal_context_mode, save_prefix)
     local adventurer_id = interactions.party_core_members[0]
 
     return AdventurerJournalContext{
-      save_prefix,
+      save_prefix=save_prefix,
       adventurer_id=adventurer_id
     }
+  elseif journal_context_mode == JOURNAL_CONTEXT_MODE.WORLDMAP then
+    local world_id =  df.global.world.cur_savegame.world_header.id1
+
+    return WorldmapJournalContext{save_prefix=save_prefix, world_id=world_id}
   elseif journal_context_mode == JOURNAL_CONTEXT_MODE.DUMMY then
     return DummyJournalContext{}
   else


### PR DESCRIPTION
Add worldmap mode support for `gui/journal`.

![screen](https://github.com/user-attachments/assets/d7ee674d-e922-4a55-8aa7-df406518ee50)

The journal is stored per ID of the worldmap.

Journal is saved in global dfhack config file, as it need to work even if the user do not embark and save the map.

Related discussion: https://discord.com/channels/793331351645323264/1017471248567124049/1273019956983894077