### PR TITLE
Improve `fix/stuck-squad`

### DIFF
--- a/docs/fix/stuck-squad.rst
+++ b/docs/fix/stuck-squad.rst
@@ -2,25 +2,18 @@ fix/stuck-squad
 ===============
 
 .. dfhack-tool::
-    :summary: Allow squads and messengers to rescue lost squads.
+    :summary: Rescue stranded squads.
     :tags: fort bugfix military
 
 Occasionally, squads that you send out on a mission get stuck on the world map.
 They lose their ability to navigate and are unable to return to your fortress.
-This tool allows a messenger that is returning from a holding or any other of
-your squads that is returning from a mission to rescue the lost squad along the
-way and bring them home.
+This tool brings them back to their senses and redirects them back home.
 
 This fix is enabled by default in the DFHack
-`control panel <gui/control-panel>`, or you can run it as needed. However, it
-is still up to you to send out a messenger or squad that can be tasked with the
-rescue. If you have a holding that is linked to your fort, you can send out a
-messenger -- you don't have to actually request any workers. Otherwise, you can
-send a squad out on a mission with minimal risk, like "Demand one-time tribute".
+`control panel <gui/control-panel>`, or you can run it as needed.
 
 This tool is integrated with `gui/notify`, so you will get a notification in
-the DFHack notification panel when a squad is stuck and there are no squads or
-messengers currently out traveling that can rescue them.
+the DFHack notification panel when a squad is stuck and hasn't been fixed yet.
 
 Note that there might be other reasons why your squad appears missing -- if it
 got wiped out in combat and nobody survived to report back, for example -- but
@@ -31,4 +24,27 @@ Usage
 
 ::
 
-    fix/stuck-squad
+    fix/stuck-squad [<options>]
+
+Fix stuck squads and direct their armies back home. Multiple squads can share
+a single army if sent on the same mission, and only armies are counted in the
+total.
+
+Examples
+--------
+
+``fix/stuck-squad``
+    Fix stuck squads and print the number of affected armies.
+``fix/stuck-squad -v``
+    Same as above, but also print info about armies, etc.
+
+Options
+-------
+
+``-v``, ``--verbose``
+    Print IDs for the affected armies, controllers, and player fort.
+    Indicate which specific armies were ignored (due to controller not fully
+    removed).
+``-q``, ``--quiet``
+    Don't print the number of affected armies if it's zero. Intended for
+    automatic use.

--- a/internal/control-panel/registry.lua
+++ b/internal/control-panel/registry.lua
@@ -94,7 +94,7 @@ COMMANDS_BY_IDX = {
     {command='fix/stuck-instruments', group='bugfix', mode='repeat', default=true,
         params={'--time', '1', '--timeUnits', 'days', '--command', '[', 'fix/stuck-instruments', ']'}},
     {command='fix/stuck-squad', group='bugfix', mode='repeat', default=true,
-        params={'--time', '1', '--timeUnits', 'days', '--command', '[', 'fix/stuck-squad', ']'}},
+        params={'--time', '1', '--timeUnits', 'days', '--command', '[', 'fix/stuck-squad', '-vq', ']'}},
     {command='fix/stuck-worship', group='bugfix', mode='repeat', default=true,
         params={'--time', '1', '--timeUnits', 'days', '--command', '[', 'fix/stuck-worship', '-q', ']'}},
     {command='fix/noexert-exhaustion', group='bugfix', mode='repeat', default=true,

--- a/internal/notify/notifications.lua
+++ b/internal/notify/notifications.lua
@@ -341,27 +341,20 @@ NOTIFICATIONS_BY_IDX = {
         desc='Notifies when a squad is stuck on the world map.',
         default=true,
         dwarf_fn=function()
-            local stuck_armies, outbound_army, returning_army = stuck_squad.scan_fort_armies()
-            if #stuck_armies == 0 then return end
-            if repeat_util.isScheduled('control-panel/fix/stuck-squad') and (outbound_army or returning_army) then
-                return
-            end
-            return ('%d squad%s need%s rescue'):format(
-                #stuck_armies,
-                #stuck_armies == 1 and '' or 's',
-                #stuck_armies == 1 and 's' or ''
-            )
+            local stuck_armies = stuck_squad.scan_fort_armies()
+            local n = #stuck_armies
+            if n == 0 then return end
+            return ('%d squad %s rescue'):format(n, n == 1 and 'army needs' or 'armies need')
         end,
         on_click=function()
-            local message = 'A squad is lost on the world map and needs rescue!\n\n' ..
-                'Please send a messenger to a holding or a squad out on a mission\n' ..
-                'that will return to the fort (e.g. a Demand one-time tribute mission,\n' ..
-                'but not a Conquer and occupy mission). They will rescue the stuck\n' ..
-                'squad on their way home.'
-            if not repeat_util.isScheduled('control-panel/fix/stuck-squad') then
-                message = message .. '\n\n' ..
-                    'Please enable fix/stuck-squad in the DFHack control panel to enable\n'..
-                    'missions to rescue stuck squads.'
+            local message = 'A squad is lost on the world map and needs rescue!\n\n'
+            if repeat_util.isScheduled('control-panel/fix/stuck-squad') then
+                message = message ..
+                    'fix/stuck-squad is enabled, and the squad will be directed home shortly.'
+            else
+                message = message ..
+                    'Please enable fix/stuck-squad in the DFHack control panel or\n' ..
+                    'run "fix/stuck-squad" manually.'
             end
             dlg.showMessage('Rescue stuck squads', message, COLOR_WHITE)
         end,


### PR DESCRIPTION
Attach new controller based on how DF handles cancelled missions, rather than requiring a returning squad.
Fix assumptions about one squad per army.
Some functions that might be useful to manipulate armies in general. (E.g., force any army to join a site.)
`verbose` and `quiet` options.