### PR TITLE
Add z_fix_minecarts 

### DIFF
--- a/docs/z_fix_minecarts.rst
+++ b/docs/z_fix_minecarts.rst
@@ -1,0 +1,7 @@
+This DFHack script iterates over all minecart tool items in the current Dwarf Fortress world, clears their `in_job` flag if it’s set, and reports the total number of flags flipped from `true` to `false`.
+
+## Features
+
+* **Tool Scanning**: Identifies all items of subtype `ITEM_TOOL_MINECART`.
+* **Flag Clearing**: Automatically clears the `in_job` flag on minecart tools that are currently marked in a job.
+* **Summary Reporting**: Outputs the total count of flags flipped from `true` to `false`.

--- a/z_fix_minecarts.lua
+++ b/z_fix_minecarts.lua
@@ -1,0 +1,20 @@
+-- Iterate over all tools, clear the in_job flag for minecarts, and report how many flags were actually flipped from true to false
+
+local tools = df.global.world.items.other.TOOL
+local flipped = 0
+for i = 0, #tools - 1 do
+    local tool = tools[i]
+    -- Only consider minecart tools
+    if tool.subtype.id == "ITEM_TOOL_MINECART" then
+        -- Only flip if it was true
+        if tool.flags.in_job then
+            tool.flags.in_job = false
+            flipped = flipped + 1
+        end
+    end
+end
+
+-- Print count of flags flipped from true to false
+dfhack.printerr(string.format(
+    "clear_minecart_jobs: flipped in_job flag on %d minecart tool(s) from true to false\n", flipped
+))


### PR DESCRIPTION
This DFHack script iterates over all minecart tool items in the current Fortress , clears their `in_job` flag if it’s set, and reports the total number of flags flipped from `true` to `false`.

## Features

* **Tool Scanning**: Identifies all items of subtype `ITEM_TOOL_MINECART`.
* **Flag Clearing**: Automatically clears the `in_job` flag on minecart tools that are currently marked in a job.
* **Summary Reporting**: Outputs the total count of flags flipped from `true` to `false`.
