### PR TITLE
bug fix: journal.lua minor performance lost due to typo "colllapsed"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -32,7 +32,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
-- `gui/journal`: fix typo which caused the table of contents to always be regenerated even when not needed 
+- `gui/journal`: fix typo which caused the table of contents to always be regenerated even when not needed
 - `gui/mod-manager`: gracefully handle mods with missing or broken ``info.txt`` files
 - `uniform-unstick`: resolve overlap with new buttons in 51.13
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `gui/journal`: fix typo which caused the table of contents to always be regenerated even when not needed 
 
 ## Misc Improvements
 

--- a/gui/journal.lua
+++ b/gui/journal.lua
@@ -72,7 +72,7 @@ function JournalWindow:init()
                 self.subviews.table_of_contents_panel.visible = not collapsed
                 self.subviews.table_of_contents_divider.visible = not collapsed
 
-                if not colllapsed then
+                if not collapsed then
                     self:reloadTableOfContents()
                 end
 


### PR DESCRIPTION
obvious typo causing unintended performance lost in journal.lua

 `collapsed` is typo-ed as `colllapsed` which is always nil

since `not colllapsed` is always true, unintended performance lost when `table_of_contents_panel` is collapsed.

https://github.com/DFHack/scripts/blob/8a2c8e7b13d703da672532d408e4250dd11a86c9/gui/journal.lua#L75
```lua
        shifter.Shifter{
            view_id='shifter',
            frame={l=0, w=1, t=1, b=2},
-- the intended name is collapsed here
            collapsed=not toc_visible,
            on_changed = function (collapsed)
                self.subviews.table_of_contents_panel.visible = not collapsed
                self.subviews.table_of_contents_divider.visible = not collapsed
-- if statement always true because it's spelled "colllapsed"
                if not colllapsed then
                    self:reloadTableOfContents()
                end

                self:ensurePanelsRelSize()
                self:updateLayout()
            end,
        },
```