### PR TITLE
remove `think_counter` from `gui/gm-unit`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `gui/gm-unit`: remove reference to ``think_counter``, removed in v51.12
 
 ## Misc Improvements
 

--- a/internal/gm-unit/editor_counters.lua
+++ b/internal/gm-unit/editor_counters.lua
@@ -9,7 +9,6 @@ Editor_Counters=defclass(Editor_Counters, base_editor.Editor)
 Editor_Counters.ATTRS{
     frame_title = "Counters editor",
     counters1={
-    "think_counter",
     "job_counter",
     "swap_counter",
     "winded",


### PR DESCRIPTION
for 51.12 compatibility

should have been included in 51.12 release but we missed it
