### PR TITLE
Fix for rename

### DIFF
--- a/gui/rename.lua
+++ b/gui/rename.lua
@@ -93,13 +93,16 @@ local function get_hf_target(hf)
     local unit = df.unit.find(hf.unit_id)
     local sync_names = {}
     if unit then
-        local unit_name = dfhack.units.getVisibleName(unit)
-        if unit_name ~= name then
-            table.insert(sync_names, unit_name)
+        -- Always sync unit.name
+        table.insert(sync_names, unit.name)
+        -- Also sync current_soul.name if present
+        if unit.status.current_soul then
+            table.insert(sync_names, unit.status.current_soul.name)
         end
     end
     return {name=name, sync_names=sync_names, civ_id=hf.civ_id}
 end
+
 
 local function get_unit_target(unit)
     if not unit then return end


### PR DESCRIPTION
Names are stored in 3 locations (the main unit, historical figure, and soul), not 2

I think this is fine but ***if anything in the vanilla game can cause current_soul to have a different name than the unit and historical figure***, then never mind - I have never had current_soul be changed to a separate individual with a different name from the unit itself, but I am new to the game.