### PR TITLE
embark-anyone.lua bugfix: Test the current viewscreen

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- ``embark-anyone``: validate viewscreen before using, avoids a crash
 
 ## Misc Improvements
 

--- a/embark-anyone.lua
+++ b/embark-anyone.lua
@@ -1,19 +1,17 @@
 local dialogs = require('gui.dialogs')
 local utils = require('utils')
 
-function addCivToEmbarkList(info)
-   local viewscreen = dfhack.gui.getDFViewscreen(true)
-   if viewscreen._type ~= df.viewscreen_choose_start_sitest then
-      qerror("This script can only be used on the embark screen!")
+function embarkAnyone()
+
+   function addCivToEmbarkList(info)
+      local viewscreen = dfhack.gui.getDFViewscreen(true)
+
+      viewscreen.start_civ:insert ('#', info.civ)
+      viewscreen.start_civ_nem_num:insert ('#', info.nemeses)
+      viewscreen.start_civ_entpop_num:insert ('#', info.pops)
+      viewscreen.start_civ_site_num:insert ('#', info.sites)
    end
 
-   viewscreen.start_civ:insert ('#', info.civ)
-   viewscreen.start_civ_nem_num:insert ('#', info.nemeses)
-   viewscreen.start_civ_entpop_num:insert ('#', info.pops)
-   viewscreen.start_civ_site_num:insert ('#', info.sites)
-end
-
-function embarkAnyone()
    local viewscreen = dfhack.gui.getDFViewscreen(true)
    if viewscreen._type ~= df.viewscreen_choose_start_sitest then
       qerror("This script can only be used on the embark screen!")

--- a/embark-anyone.lua
+++ b/embark-anyone.lua
@@ -3,6 +3,9 @@ local utils = require('utils')
 
 function addCivToEmbarkList(info)
    local viewscreen = dfhack.gui.getDFViewscreen(true)
+   if viewscreen._type ~= df.viewscreen_choose_start_sitest then
+      qerror("This script can only be used on the embark screen!")
+   end
 
    viewscreen.start_civ:insert ('#', info.civ)
    viewscreen.start_civ_nem_num:insert ('#', info.nemeses)
@@ -12,14 +15,14 @@ end
 
 function embarkAnyone()
    local viewscreen = dfhack.gui.getDFViewscreen(true)
+   if viewscreen._type ~= df.viewscreen_choose_start_sitest then
+      qerror("This script can only be used on the embark screen!")
+   end
+
    local choices, existing_civs = {}, {}
 
    for _,existing_civ in ipairs(viewscreen.start_civ) do
       existing_civs[existing_civ.id] = true
-   end
-
-   if viewscreen._type ~= df.viewscreen_choose_start_sitest then
-      qerror("This script can only be used on the embark screen!")
    end
 
    for i, civ in ipairs (df.global.world.entities.all) do


### PR DESCRIPTION
Test the current viewscreen to ensure that it is the choose_start_site viewscreen, before trying to use it.

The bug: if the embark-anyone script is executed on any viewscreen **other than** the embark viewscreen, it aborts with a stack trace.

This bugfix makes it cleanly abort with a reasonably-descriptive error message.

This was found while diagnosing Issue #5509, but is not related.

Minimal changes to the script.