### PR TITLE
mod-manager.lua hotfix for error "Temporaries of type path not supported"

### DIFF
--- a/gui/mod-manager.lua
+++ b/gui/mod-manager.lua
@@ -73,7 +73,11 @@ local function move_mod_entry(viewscreen, to, from, mod_id, mod_version)
     end
 
     for k, v in pairs(to_fields) do
-        if type(from_fields[k][mod_index]) == "userdata" then
+
+        if k == "src_dir" then  -- 0.52.02 hotfix workaround.
+            v:resize(#v + 1)
+            v[#v - 1] = from_fields[k][mod_index]
+        elseif type(from_fields[k][mod_index]) == "userdata" then
             v:insert('#', from_fields[k][mod_index]:new())
         else
             v:insert('#', from_fields[k][mod_index])


### PR DESCRIPTION
These three `df.viewscreen_new_regionst` fields:
    `.base_available_src_dir`
    `.object_load_order_src_dir`
    `.available_src_dir`
have changed from type `vector<string*>` to type `vector<path>`.

Attempting to `:insert()` new elements into these vectors throws an error:
    Temporaries of type path not supported

No issue has been opened at this time.

Some discussion at
https://discord.com/channels/793331351645323264/807444467140788254/1398044412851781672