### PR TITLE
Pedestal fixes3

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -46,6 +46,8 @@ Template for new versions:
 - `confirm`: the pause option now pauses individual confirmation types, allowing multiple different confirmations to be paused independently
 - `immortal-cravings`: prioritize high-value meals, properly split of portions, and don't go eating or drinking on a full stomach
 - `uniform-unstick`: no longer causes units to equip multiples of assigned items
+- `caravan`: in the pedestal item assignment dialog, add new items at the end of the list of displayed items instead of at a random position
+- `caravan`: in the pedestal item assignment dialog, consistently remove items from the list of displayed items
 
 ## Misc Improvements
 - `devel/hello-world`: updated to show off the new Slider widget

--- a/internal/caravan/pedestal.lua
+++ b/internal/caravan/pedestal.lua
@@ -599,8 +599,8 @@ end
 
 local function unassign_item(bld, item)
     if not bld then return end
-    local _, found, idx = utils.binsearch(bld.displayed_items, item.id)
-    if found then
+    local idx, _ = utils.linear_index(bld.displayed_items, item.id)
+    if idx then
         bld.displayed_items:erase(idx)
     end
 end
@@ -628,7 +628,7 @@ local function attach_item(item, display_bld)
     local ref = df.new(df.general_ref_building_display_furniturest)
     ref.building_id = display_bld.id
     item.general_refs:insert('#', ref)
-    utils.insert_sorted(display_bld.displayed_items, item.id)
+    display_bld.displayed_items:insert('#', item.id)
     item.flags.forbid = false
     item.flags.in_building = false
 end

--- a/internal/caravan/pedestal.lua
+++ b/internal/caravan/pedestal.lua
@@ -602,6 +602,7 @@ local function unassign_item(bld, item)
     local idx, _ = utils.linear_index(bld.displayed_items, item.id)
     if idx then
         bld.displayed_items:erase(idx)
+        item.flags.in_building = false
     end
 end
 


### PR DESCRIPTION
Two minor fixes to `internal/common/pedestal.lua`.  No user-visible changes, except that removing items from a pedestal using the DFHack interface will work correctly.

Well-tested.  *Extensive* comments in each commit.