### PR TITLE
`ban-cooking`: don't fail when honey missing

### DIFF
--- a/ban-cooking.lua
+++ b/ban-cooking.lua
@@ -81,7 +81,9 @@ end
 
 funcs.honey = function()
     local mat = dfhack.matinfo.find("CREATURE:HONEY_BEE:HONEY")
-    ban_cooking('honey bee honey', mat.type, mat.index, df.item_type.LIQUID_MISC, -1)
+    if mat then
+        ban_cooking('honey bee honey', mat.type, mat.index, df.item_type.LIQUID_MISC, -1)
+    end
 end
 
 funcs.tallow = function()


### PR DESCRIPTION
Do not attempt to ban honey if honey doesn't exist

If this PR makes an externally-visible change in behavior, please add an appropriate line to `changelog.txt`.
