### PR TITLE
Support for modded honey in ban-cooking

### DIFF
--- a/ban-cooking.lua
+++ b/ban-cooking.lua
@@ -80,9 +80,18 @@ funcs.booze = function()
 end
 
 funcs.honey = function()
-    local mat = dfhack.matinfo.find("CREATURE:HONEY_BEE:HONEY")
-    if mat then
-        ban_cooking('honey bee honey', mat.type, mat.index, df.item_type.LIQUID_MISC, -1)
+    for _, c in ipairs(df.global.world.raws.creatures.all) do
+        for _, m in ipairs(c.material) do
+            if m.flags.EDIBLE_COOKED then
+                for _, s in ipairs(m.reaction_product.id) do
+                    if s.value == "DRINK_MAT" then
+                        local matinfo = dfhack.matinfo.find(c.creature_id, m.id)
+                        ban_cooking(c.name[2] .. ' ' .. m.id, matinfo.type, matinfo.index, df.item_type.LIQUID_MISC, -1)
+                        break
+                    end
+                end
+            end
+        end
     end
 end
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -25,13 +25,13 @@ Template for new versions:
 ]]]
 
 # Future
-- `ban-cooking`: bans honey added by creatures other than vanilla honey bee
 
 ## New Tools
 
 ## New Features
 
 ## Fixes
+- `ban-cooking`: bans honey added by creatures other than vanilla honey bee
 
 ## Misc Improvements
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ Template for new versions:
 ]]]
 
 # Future
+- `ban-cooking`: bans honey added by creatures other than vanilla honey bee
 
 ## New Tools
 


### PR DESCRIPTION
This patch allows ban-cooking to ban honey/brewable materials added by creatures other than honey bees. This includes vanilla bumblebees, though their honey is not currently obtainable in vanilla. However, there are mods that make bumblebees hiveable, as well as adding other types of hiveable bees.