### PR TITLE
add new tool `store-owned`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ Template for new versions:
 # Future
 
 ## New Tools
+- `store-owned`: task owned items to be stored in the owner's room furniture
 
 ## New Features
 

--- a/docs/store-owned.rst
+++ b/docs/store-owned.rst
@@ -1,0 +1,43 @@
+store-owned
+===========
+
+.. dfhack-tool::
+    :summary: Task units to store their owned items.
+    :tags: fort items buildings
+
+Task any owned item to be stored in an appropriate storage furniture in
+a room assigned to the item's owner.
+
+Usage
+-----
+
+``store-owned [<option>]``
+
+Select an owned item and run the tool to task the owner to put the item
+into storage.
+
+If the storage furniture is full, unreachable, or unavailable, the item
+will be dropped off on the floor of the owner's room. If the owner has
+no assigned room or is unable to access their room(s), the item will be
+stored in the dormitory if available. If the dormitory is unreachable or
+unavailable, the item will be dropped off at the trade depot instead.
+
+This tool can be used to unburden a unit that has acquired too many
+trinkets, or simply as an alternative to ``cleanowned`` when cleaning
+up scattered owned items. It can also be used to force a unit to
+relinquish ownership of the selected item.
+
+Options
+-------
+
+``discard``
+    Force the owner of the selected item to relinquish ownership of
+    said item. The item will not be tasked for storage. If the item
+    is in the owner's inventory, they will drop it to the ground.
+
+``dorm``
+    Task the selected owned item for storage in an appropriate storage
+    furniture, or on the floor, in any available dormitory zone.
+
+``depot``
+    Task the selected owned item to be dropped off at the trade depot.

--- a/store-owned.lua
+++ b/store-owned.lua
@@ -1,0 +1,410 @@
+-- Task units to store their owned items.
+
+local utils = require('utils')
+
+local function GetUnit(item, options)
+    local unit = dfhack.items.getOwner(item)
+    if not unit then
+        print('Selected item is not owned by any unit.')
+    elseif not dfhack.units.isJobAvailable(unit) and not options.discard then
+        unit = nil
+        print('Owner of selected item is currently busy.')
+    end
+    return unit
+end
+
+local function isValidItem(item, unit)
+    local validItem = true
+    local itemPos = item and xyz2pos(dfhack.items.getPosition(item))
+    local building = dfhack.items.getHolderBuilding(item)
+    if item.flags.in_job or
+        item.flags.hostile or
+        item.flags.removed or
+        item.flags.dead_dwarf or
+        item.flags.rotten or
+        item.flags.spider_web or
+        item.flags.construction or
+        item.flags.encased or
+        item.flags.trader or
+        item.flags.garbage_collect or
+        item.flags.forbid or
+        item.flags.dump or
+        item.flags.on_fire or
+        item.flags.melt or
+        not dfhack.maps.isTileVisible(itemPos)
+    then
+        validItem = false
+        print('Selected item cannot be stored.')
+    elseif building then
+        for _, civzone in ipairs(building.relations) do
+            if civzone.assigned_unit_id == unit.id then
+                if df.building_cabinetst:is_instance(building) or
+                    df.building_armorstandst:is_instance(building) or
+                    df.building_weaponrackst:is_instance(building) or
+                    df.building_boxst:is_instance(building)
+                then
+                    validItem = false
+                    print('Selected item is already stored in the owner\'s room furniture.')
+                    goto skipCheck
+                end
+            end
+        end
+        if item.flags.in_building then
+            validItem = false
+            print('Selected item is part of a building.')
+        end
+    else
+        local unitPos = unit and xyz2pos(dfhack.units.getPosition(unit))
+        if not dfhack.maps.canWalkBetween(itemPos, unitPos) then
+            validItem = false
+            print('Owner of selected item cannot reach the item.')
+        end
+    end
+    ::skipCheck::
+    return validItem
+end
+
+local function isClothing(item)
+    if df.item_armorst:is_instance(item) or
+        df.item_shoesst:is_instance(item) or
+        df.item_glovesst:is_instance(item) or
+        df.item_helmst:is_instance(item) or
+        df.item_pantsst:is_instance(item)
+    then
+        return true
+    end
+    return false
+end
+
+local function isArmor(item)
+    if isClothing(item) and item.subtype.armorlevel > 0 then
+        return true
+    end
+    return false
+end
+
+local function isWeapon(item)
+    if df.item_weaponst:is_instance(item) then
+        return true
+    end
+    return false
+end
+
+local function isGoods(item)
+    if df.item_amuletst:is_instance(item) or
+        df.item_braceletst:is_instance(item) or
+        df.item_crownst:is_instance(item) or
+        df.item_earringst:is_instance(item) or
+        df.item_figurinest:is_instance(item) or
+        df.item_gemst:is_instance(item) or
+        df.item_instrumentst:is_instance(item) or
+        df.item_ringst:is_instance(item) or
+        df.item_scepterst:is_instance(item) or
+        df.item_totemst:is_instance(item) or
+        df.item_toyst:is_instance(item) or
+        df.item_toolst:is_instance(item) -- Owned books and scrolls, which can be stored in boxes.
+    then
+        return true
+    end
+    return false
+end
+
+local function GetContainerType(item)
+    local containerType
+    if isArmor(item) then
+        containerType = df.building_armorstandst
+    elseif isWeapon(item) then
+        containerType = df.building_weaponrackst
+    elseif isClothing(item) then
+        containerType = df.building_cabinetst
+    elseif isGoods(item) then
+        containerType = df.building_boxst
+    end
+    return containerType
+end
+
+local function isEnoughCapacity(item, container)
+    local capacity = 0
+    local totalVol = 0
+    local itemVol = item:getVolume()
+    for _, containedItem in ipairs(container.contained_items) do
+        -- Assume only one item is the container.
+        if containedItem.item.flags.in_building and capacity == 0 then
+            if df.item_armorstandst:is_instance(containedItem.item) or
+                df.item_weaponrackst:is_instance(containedItem.item) or
+                df.item_cabinetst:is_instance(containedItem.item) or
+                df.item_boxst:is_instance(containedItem.item)
+            then
+                capacity = dfhack.items.getCapacity(containedItem.item)
+            end
+        else
+            totalVol = totalVol + containedItem.item:getVolume()
+        end
+    end
+    local remainingCapacity = capacity - (totalVol + itemVol)
+    if remainingCapacity >= 0 then
+        return true
+    end
+    return false
+end
+
+local function GetCivzoneName(civzone)
+    local strCivzoneName
+    if #civzone.name > 0 then
+        strCivzoneName = civzone.name
+    else
+        strCivzoneName = dfhack.buildings.getName(civzone)
+    end
+    return strCivzoneName
+end
+
+local function GetPosFromContainer(item, unitPos, civzone)
+    local containerType = GetContainerType(item)
+    local strStoreContainer = 'Selected item will be stored inside %s of %s.'
+    local strCivzoneName = GetCivzoneName(civzone)
+    for _, container in ipairs(civzone.contained_buildings) do
+        if containerType:is_instance(container) then
+            local containerPos = utils.getBuildingCenter(container)
+            if containerPos and
+                isEnoughCapacity(item, container) and
+                dfhack.maps.canWalkBetween(containerPos, unitPos)
+            then
+                local jobPos = containerPos
+                print(string.format(strStoreContainer, dfhack.buildings.getName(container), strCivzoneName))
+                return jobPos
+            end
+        end
+    end
+    return nil
+end
+
+-- Items can be placed on any walkable tile, but in order to mimic native behavior
+-- more closely, the item will be placed on a tile not occupied by a building.
+-- However, to reduce visual clutter, any loose items already occupying the tile will be ignored.
+local function GetPosFromTile(unitPos, civzone)
+    local jobPos = civzone and xyz2pos(civzone.centerx, civzone.centery, civzone.z)
+    if not dfhack.maps.canWalkBetween(jobPos, unitPos) or dfhack.buildings.findAtTile(jobPos) then
+        jobPos = nil
+        local x1, x2, y1, y2, z = civzone.x1, civzone.x2, civzone.y1, civzone.y2, civzone.z
+        for y = y1, y2, 1 do
+            for x = x1, x2, 1 do
+                if dfhack.buildings.containsTile(civzone, x, y) then
+                    local tilePos = xyz2pos(x, y, z)
+                    if dfhack.maps.canWalkBetween(tilePos, unitPos) and
+                        not dfhack.buildings.findAtTile(tilePos)
+                    then
+                        jobPos = tilePos
+                        goto returnPos
+                    end
+                end
+            end
+        end
+    end
+    ::returnPos::
+    if jobPos then
+        local strStoreFloor = 'Selected item will be placed on the floor of %s.'
+        local strCivzoneName = GetCivzoneName(civzone)
+        print(string.format(strStoreFloor, strCivzoneName))
+    end
+    return jobPos
+end
+
+local function GetPosFromCivzone(unit, item, unitPos, zoneType, putOnFloor)
+    local jobPos
+    local civzones = unit.owned_buildings
+    local strZoneType = 'assigned room(s)'
+    local strDormZone = 'the dormitory'
+    local strNoRoom = 'Owner of selected item does not have any assigned rooms.'
+    local strNoDorm = 'No dormitory available.'
+    local strNoPos = '%s %s.'
+    local strNoPosReason = 'No storage furniture with sufficient space available in'
+    local strNoRoomAccess = 'Owner of selected item cannot reach'
+    if zoneType == df.civzone_type.Dormitory then
+        civzones = df.global.world.buildings.other.ZONE_DORMITORY
+        strZoneType = strDormZone
+        strNoRoom = strNoDorm
+    end
+    if #civzones > 0 then
+        for _, civzone in ipairs(civzones) do
+            if civzone.type == zoneType then
+                if not putOnFloor then
+                    jobPos = GetPosFromContainer(item, unitPos, civzone)
+                else
+                    strNoPosReason = strNoRoomAccess
+                    jobPos = GetPosFromTile(unitPos, civzone)
+                end
+            end
+            if jobPos then return jobPos end
+        end
+        if not jobPos then
+            print(string.format(strNoPos, strNoPosReason, strZoneType))
+        end
+    else
+        print(strNoRoom)
+    end
+    return nil
+end
+
+local function GetPosFromOwnedCivzone(unit, item, unitPos, putOnFloor)
+    local jobPos
+    local zoneTypes = {
+        df.civzone_type.Bedroom,
+        df.civzone_type.Office,
+        df.civzone_type.DiningHall,
+        df.civzone_type.Tomb
+    }
+    for _, zoneType in ipairs(zoneTypes) do
+        jobPos = GetPosFromCivzone(unit, item, unitPos, zoneType, putOnFloor)
+        if jobPos then return jobPos end
+    end
+    return nil
+end
+
+local function GetPosFromDepot(unitPos)
+    local depots = df.global.world.buildings.other.TRADE_DEPOT
+    if #depots > 0 then
+        for _, depot in ipairs(depots) do
+            -- Item will be dropped on the center tile of the trade depot rather than stored inside it.
+            local depotPos = depot and utils.getBuildingCenter(depot)
+            if depotPos and dfhack.maps.canWalkBetween(depotPos, unitPos) then
+                local jobPos = depotPos
+                print('Selected item will be dropped off at the '..dfhack.buildings.getName(depot))
+                return jobPos
+            end
+        end
+    else
+        print('No trade depot available.')
+    end
+    return nil
+end
+
+-- Prioritize storing in bedroom > office > dining room > tomb > dormitory > trade depot.
+local function GetJobPos(unit, item, options)
+    local jobPos
+    local unitPos = unit and xyz2pos(dfhack.units.getPosition(unit))
+    local putOnFloor = false
+    if options.dorm then
+        goto skipOwnedCivzones
+    elseif options.depot then
+        goto skipDorm
+    end
+    jobPos = GetPosFromOwnedCivzone(unit, item, unitPos, putOnFloor)
+    if not jobPos then
+        putOnFloor = true
+        jobPos = GetPosFromOwnedCivzone(unit, item, unitPos, putOnFloor)
+        if not jobPos then
+            print('')
+        end
+    end
+    ::skipOwnedCivzones::
+    if not jobPos then
+        local zoneType = df.civzone_type.Dormitory
+        putOnFloor = false
+        jobPos = GetPosFromCivzone(unit, item, unitPos, zoneType, putOnFloor)
+        if not jobPos then
+            putOnFloor = true
+            jobPos = GetPosFromCivzone(unit, item, unitPos, zoneType, putOnFloor)
+        end
+        if not jobPos then
+            print('')
+        end
+    end
+    ::skipDorm::
+    if not jobPos then
+        GetPosFromDepot(unitPos)
+    end
+    return jobPos
+end
+
+local function AssignJob(item, unit, jobPos)
+    local job = df.job:new()
+    job.job_type = df.job_type.StoreOwnedItem
+    job.pos = jobPos
+    dfhack.job.attachJobItem(job, item, df.job_role_type.Hauled, -1, -1)
+    dfhack.job.addWorker(job, unit)
+    dfhack.job.linkIntoWorld(job, true)
+    local strTasked = '%s has been tasked to store away %s.'
+    local strUnitName = unit and dfhack.units.getReadableName(unit)
+    local strItemName = item and dfhack.items.getReadableDescription(item)
+    print(string.format(strTasked, strUnitName, strItemName))
+end
+
+local function GetIdx(unitUniform, id)
+    for i, v in pairs(unitUniform) do
+        if v == id then
+            return i
+        end
+    end
+    return nil
+end
+
+local function RemoveFromUniform(item, unit, options)
+    if options.discard then
+        local strItemName = item and dfhack.items.getReadableDescription(item)
+        local strUnitName = unit and dfhack.units.getReadableName(unit)
+        dfhack.items.setOwner(item, nil)
+        local strDiscard = 'Ownership of %s was removed from %s.'
+        print(string.format(strDiscard, strItemName, strUnitName))
+    end
+    local unitUniform = unit.uniform.uniforms.CLOTHING
+    local idx = GetIdx(unitUniform, item.id)
+    if idx then unitUniform:erase(idx) end
+end
+
+local function processArgs(args)
+    local options = {
+        help = false,
+        discard = false,
+        dorm = false,
+        depot = false
+    }
+    if #args > 0 then
+        if args[1] == 'help' then options.help = true
+        elseif args[1] == 'discard' then options.discard = true
+        elseif args[1] == 'dorm' then options.dorm = true
+        elseif args[1] == 'depot' then options.depot = true
+        end
+    end
+    return options
+end
+
+local function Main(args)
+    local options = processArgs(args)
+    if args[1] == 'help' or options.help then
+        print(dfhack.script_help())
+        return
+    end
+    local item = dfhack.gui.getSelectedItem(true)
+    if not item then
+        qerror('No item selected.')
+    end
+    local unit = GetUnit(item, options)
+    local strCannotStore = 'Unable to task selected item for storage.'
+    if not unit and not options.discard then
+        qerror(strCannotStore)
+    elseif options.discard then
+        if not unit then
+            qerror('Removal of ownership from selected item is not necessary.')
+        else
+            goto removeItem
+        end
+    else
+        local validItem = isValidItem(item, unit)
+        if not validItem then
+            qerror(strCannotStore)
+        end
+        local jobPos = GetJobPos(unit, item, options)
+        if not jobPos then
+            qerror('Unable to store selected item in any owned room, dormitory, or trade depot.')
+        end
+        AssignJob(item, unit, jobPos)
+    end
+    ::removeItem::
+    RemoveFromUniform(item, unit, options)
+end
+
+if not dfhack.isSiteLoaded() and not dfhack.world.isFortressMode() then
+    qerror('This script requires the game to be in fortress mode.')
+end
+
+Main({...})


### PR DESCRIPTION
This is a new tool that will allow any selected owned item to be tasked for storage in the owner's room furniture (cabinets, boxes, etc).

It will check to see if there's a container building of the appropriate type with sufficient space in the owner's bedroom, before looking in any owned office, dining hall or tomb, in that order.
If no container is found (or lacks sufficient space), it will attempt to find a tile unoccupied by any building in said rooms in the same order, to place the item on the floor of said tile.
If neither container nor tile can be found in any owned rooms, it will check if there's a dormitory zone available and check for container buildings in it, or an unoccupied floor if no container is available.
If it still can't find a container or tile, the job destination will default to the trade depot's center tile.
Finally, a "Store owned item" job will be created and assigned to the item's owner. 
The tool will also remove the item from the unit's uniform.

Players may also opt to task the item to be stored in the dorm or sent straight to the depot.
The tool also includes option to force the owner to relinquish ownership of the item.

Possible use cases:
- Unburden units that have acquired too many trinkets.
- Clean up scattered owned items selectively without removing ownership.