### PR TITLE
Minor fixes to uniform-unstick

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,10 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `uniform-unstick`: added quivers, backpacks, and flasks/waterskins to uniform analysis
+- `uniform-unstick`: the ``--drop`` option now only evaluates clothing as possible items to drop
+- `uniform-unstick`: the ``--free`` option no longer redundantly reports an improperly assigned item when that item is removed from a uniform
+- `uniform-unstick`: the ``--drop`` and ``--free`` options now only drop items which are actually in a unit's inventory
 
 ## Misc Improvements
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -35,6 +35,7 @@ Template for new versions:
 - `uniform-unstick`: the ``--drop`` option now only evaluates clothing as possible items to drop
 - `uniform-unstick`: the ``--free`` option no longer redundantly reports an improperly assigned item when that item is removed from a uniform
 - `uniform-unstick`: the ``--drop`` and ``--free`` options now only drop items which are actually in a unit's inventory
+- `uniform-unstick`: the ``--all`` and ``--drop`` options, when used together, now print the separator line between each unit's report in the proper place
 
 ## Misc Improvements
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,18 @@ Template for new versions:
 # Future
 
 ## New Tools
+
+## New Features
+
+## Fixes
+
+## Misc Improvements
+
+## Removed
+
+# 52.03-r2
+
+## New Tools
 - `autotraining`: new tool to assign citizens to a military squad when they need Martial Training
 - `gui/autotraining`: configuration tool for autotraining
 - `entomb`: allow any unit that has a corpse or body parts to be assigned a tomb zone

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -281,8 +281,12 @@ local function do_drop(item_list)
 
     for _, item in pairs(item_list) do
         local pos = get_visible_item_pos(item)
+
+        -- only drop if the item is on the map and is being held by a unit.
         if not pos then
             dfhack.printerr("Could not find drop location for " .. item_description(item))
+        elseif dfhack.items.getHolderUnit(item) == nil then
+            -- dfhack.printerr("Not in inventory: " .. item_description(item))
         else
             if dfhack.items.moveToGround(item, pos) then
                 print("Dropped " .. item_description(item))

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -111,6 +111,7 @@ local function remove_item_from_position(squad_position, item_id)
 end
 
 -- Will figure out which items need to be moved to the floor, returns an item_id:item map
+--   and a flag that indicates whether a separator line needs to be printed
 local function process(unit, args)
     local silent = args.all -- Don't print details if we're iterating through all dwarves
     local unit_name = dfhack.df2console(dfhack.units.getReadableName(unit))
@@ -266,15 +267,10 @@ local function process(unit, args)
         end
     end
 
-    -- add a spacing line if there was any output
-    if printed then
-        print()
-    end
-
-    return to_drop
+    return to_drop, printed
 end
 
-local function do_drop(item_list)
+local function do_drop(item_list, printed)
     if not item_list then
         return
     end
@@ -294,6 +290,11 @@ local function do_drop(item_list)
                 dfhack.printerr("Could not drop " .. item_description(item))
             end
         end
+    end
+
+    -- add a spacing line if there was any output
+    if printed then
+        print()
     end
 end
 

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -109,6 +109,7 @@ end
 -- @param squad_position df.squad_position
 -- @param item_id number
 local function remove_item_from_position(squad_position, item_id)
+    utils.erase_sorted(squad_position.equipment.assigned_items, item_id)
     for _, uniform_slot_specs in ipairs(squad_position.equipment.uniform) do
         for _, uniform_spec in ipairs(uniform_slot_specs) do
             for idx, assigned_item_id in ipairs(uniform_spec.assigned) do

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -62,38 +62,20 @@ local function bodyparts_that_can_wear(unit, item)
     local bodyparts = {}
     local unitparts = dfhack.units.getCasteRaw(unit).body_info.body_parts
 
-    if item._type == df.item_helmst then
-        for index, part in ipairs(unitparts) do
-            if part.flags.HEAD then
-                table.insert(bodyparts, index)
+    for bodypart_flag, item_type in pairs({
+        HEAD       = df.item_helmst,
+        UPPERBODY  = df.item_armorst,
+        GRASP      = df.item_glovesst,
+        LOWERBODY  = df.item_pantsst,
+        STANCE     = df.item_shoesst,
+    }) do
+        if item._type == item_type then
+            for index, part in ipairs(unitparts) do
+                if part.flags[bodypart_flag] then
+                    table.insert(bodyparts, index)
+                end
             end
         end
-    elseif item._type == df.item_armorst then
-        for index, part in ipairs(unitparts) do
-            if part.flags.UPPERBODY then
-                table.insert(bodyparts, index)
-            end
-        end
-    elseif item._type == df.item_glovesst then
-        for index, part in ipairs(unitparts) do
-            if part.flags.GRASP then
-                table.insert(bodyparts, index)
-            end
-        end
-    elseif item._type == df.item_pantsst then
-        for index, part in ipairs(unitparts) do
-            if part.flags.LOWERBODY then
-                table.insert(bodyparts, index)
-            end
-        end
-    elseif item._type == df.item_shoesst then
-        for index, part in ipairs(unitparts) do
-            if part.flags.STANCE then
-                table.insert(bodyparts, index)
-            end
-        end
-    else
-        -- print("Ignoring item type for "..item_description(item) )
     end
 
     return bodyparts

--- a/uniform-unstick.lua
+++ b/uniform-unstick.lua
@@ -247,8 +247,10 @@ local function process(unit, args)
     local covered = {} -- map of body part id to true/nil
     if not args.multi then
         for item_id, item in pairs(present_ids) do
-            -- weapons and shields don't "cover" the bodypart they're assigned to. (Needed to figure out if we're missing gloves.)
-            if item._type ~= df.item_weaponst and item._type ~= df.item_shieldst then
+            -- only the five clothing types can block armor for the bodypart they're worn on.
+            if utils.linear_index({ df.item_helmst, df.item_armorst, df.item_glovesst,
+                df.item_pantsst, df.item_shoesst }, item._type)
+            then
                 covered[worn_parts[item_id]] = true
             end
         end
@@ -264,9 +266,13 @@ local function process(unit, args)
         end
     end
 
-    -- Drop everything (except uniform pieces) from body parts which should be covered but aren't
+    -- Drop clothing (except uniform pieces) from body parts which should be covered but aren't
     for worn_item_id, item in pairs(worn_items) do
-        if uniform_assigned_items[worn_item_id] == nil then -- don't drop uniform pieces (including shields, weapons for hands)
+        if uniform_assigned_items[worn_item_id] == nil  -- don't drop uniform pieces
+            -- only the five clothing types can block armor for the bodypart they're worn on.
+            and utils.linear_index({ df.item_helmst, df.item_armorst, df.item_glovesst,
+                df.item_pantsst, df.item_shoesst }, item._type)
+        then
             if uncovered[worn_parts[worn_item_id]] then
                 print(unit_name .. " potentially has " .. item_description(item) .. " blocking a missing uniform item.")
                 printed = true


### PR DESCRIPTION
* added quivers, backpacks, and flasks/waterskins to uniform analysis
* the ``--drop`` option now only evaluates clothing as possible items to drop
* the ``--free`` option no longer redundantly reports an improperly assigned item when that item is removed from a uniform
* the ``--drop`` and ``--free`` options now only drop items which are actually in a unit's inventory
* the ``--all`` and ``--drop`` options, when used together, now print the separator line between each unit's report in the proper place

There are notes in the commits' log messages.

I listed all of these changes as Fixes; arguably the first and second are Misc Improvements.