### PR TITLE
automatic memory layout export for dt on linux

### DIFF
--- a/devel/export-dt-linux.lua
+++ b/devel/export-dt-linux.lua
@@ -1,0 +1,17 @@
+-- uses the dwarf therapist export script to generate a layout in the right directory under linux
+
+dfhack.run_command('export-dt-ini')
+
+local home = os.getenv("HOME")
+local vstring = dfhack.getDFVersion()
+local platform = vstring:match("(%S+)%s*$")
+local filename = (string.sub(vstring, 1, 8) .. "-" .. platform .. "_linux64.ini")
+
+local src = assert(io.open("therapist.ini", "r"))
+local dest = assert(io.open(home .. "/.local/share/dwarftherapist/memory_layouts/linux/" .. filename , "w"))
+
+dest:write(src:read("*all"))
+src:close()
+dest:close()
+
+os.remove("therapist.ini")


### PR DESCRIPTION
Added devel/export-dt-linux which uses the export-dt-init script to export the current memory layout to the right linux path with the correct name for DT

"Automatic" might be an exaggeration as you still need to call it. I made this script on my own at some point to automatically export the memory layout with the right name under the right path on linux, so that dwarf therapist can connect immediately after using this command on any new version.

I thought later on that I might as well commit it but I do realize now that I am doing this that I don't really know if there are any development practices in place for this project. This is also my first time doing anything in lua at all so I may not be aware of better practices.

Notably... 

1.  I'm not sure if there are naming conventions to which I should adapt for the script's/command's name
2. It did say "no help available" in DF which seems to indicate that I should be able to put some documentation somewhere
3. I'm not sure if there is anyway to do an ifdef linux/win32 or whatever else in order for this command to only appear on systems where it will function
4. I did consider, instead of calling that other script, which does all the heavy lifting, modifying said script instead but I was not sure if it would be considered ethical. EG I would have probably checked for an argument, and, provided the argument was there, I would have altered the behavior so that it writes the file right away in the right place, instead of stupidly calling that command to make a file at the root of dwarf fortress, and then copy it and delete it. I'm willing to change that if preferable
5. Maybe the right approach would be to have it run automatically every time and check if that directory exists, and if that .ini exists, and then run the actual logic if we have that directory available (indicating that the user uses DT) but no memory layout for this version


Currently tested & working on linux, steam version. 