### PR TITLE
Issue #5751 - gui/siegemanager - cleaner error logging if no siege engine selected

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `gui/siegemanager`: Added error message in the console if no siege engine is selected
 
 ## Misc Improvements
 

--- a/gui/siegemanager.lua
+++ b/gui/siegemanager.lua
@@ -419,7 +419,7 @@ function SiegeEngineList:set_selected_action(action)
     if not selected then
         qerror('No siege engine selected')
     end
-    
+
     local successful = set_siege_engine_action({selected.data}, action)
     if not successful then
         self:refresh_view(true)

--- a/gui/siegemanager.lua
+++ b/gui/siegemanager.lua
@@ -416,6 +416,10 @@ end
 function SiegeEngineList:set_selected_action(action)
     local _, selected = self.subviews.list:getSelected()
 
+    if not selected then
+        qerror('No siege engine selected')
+    end
+    
     local successful = set_siege_engine_action({selected.data}, action)
     if not successful then
         self:refresh_view(true)


### PR DESCRIPTION
If this PR makes an externally-visible change in behavior, please add an appropriate line to `changelog.txt`.
