### PR TITLE
replace hardcoded `hack` with `getHackPath()`

### DIFF
--- a/gui/biomes.lua
+++ b/gui/biomes.lua
@@ -9,16 +9,16 @@ local guidm = require('gui.dwarfmode')
 local INITIAL_LIST_HEIGHT = 5
 local INITIAL_INFO_HEIGHT = 15
 
-local texturesOnOff8x12 = dfhack.textures.loadTileset('hack/data/art/on-off.png', 8, 12, true)
+local texturesOnOff8x12 = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/on-off.png', 8, 12, true)
 local LIST_ITEM_HIGHLIGHTED = dfhack.textures.getTexposByHandle(texturesOnOff8x12[1]) -- yellow-ish indicator
 
-local texturesOnOff = dfhack.textures.loadTileset('hack/data/art/on-off_top-left.png', 32, 32, true)
+local texturesOnOff = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/on-off_top-left.png', 32, 32, true)
 local TILE_HIGHLIGHTED = dfhack.textures.getTexposByHandle(texturesOnOff[1]) -- yellow-ish indicator
 if TILE_HIGHLIGHTED < 0 then -- use a fallback
     TILE_HIGHLIGHTED = 88 -- `X`
 end
 
-local texturesSmallLetters = dfhack.textures.loadTileset('hack/data/art/curses-small-letters_top-left.png', 32, 32, true)
+local texturesSmallLetters = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/curses-small-letters_top-left.png', 32, 32, true)
 local TILE_STARTING_SYMBOL = dfhack.textures.getTexposByHandle(texturesSmallLetters[1])
 if TILE_STARTING_SYMBOL < 0 then -- use a fallback
     TILE_STARTING_SYMBOL = 97 -- `a`

--- a/gui/design.lua
+++ b/gui/design.lua
@@ -341,7 +341,7 @@ function Design:init()
     local DESIGN_ICON_ROW_COUNT = 2
     local DESIGN_CHAR_WIDTH = 8
     local DESIGN_CHAR_HEIGHT = 12
-    local shape_tileset = dfhack.textures.loadTileset('hack/data/art/design.png', DESIGN_CHAR_WIDTH, DESIGN_CHAR_HEIGHT, true)
+    local shape_tileset = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/design.png', DESIGN_CHAR_WIDTH, DESIGN_CHAR_HEIGHT, true)
 
     local STRIDE = DESIGN_ICONS_WIDTH / DESIGN_CHAR_WIDTH
     local CHARS_PER_ROW = DESIGN_ICONS_HEIGHT / (DESIGN_ICON_ROW_COUNT * DESIGN_CHAR_HEIGHT)

--- a/gui/mass-remove.lua
+++ b/gui/mass-remove.lua
@@ -2,7 +2,7 @@
 
 --@ module = true
 
-local toolbar_textures = dfhack.textures.loadTileset('hack/data/art/mass_remove_toolbar.png', 8, 12)
+local toolbar_textures = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/mass_remove_toolbar.png', 8, 12)
 
 local gui = require('gui')
 local guidm = require('gui.dwarfmode')

--- a/gui/sitemap.lua
+++ b/gui/sitemap.lua
@@ -5,7 +5,7 @@ local utils = require('utils')
 local widgets = require('gui.widgets')
 local overlay = require('plugins.overlay')
 
-local toolbar_textures = dfhack.textures.loadTileset('hack/data/art/sitemap_toolbar.png', 8, 12)
+local toolbar_textures = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/sitemap_toolbar.png', 8, 12)
 
 function launch_sitemap()
     dfhack.run_script('gui/sitemap')

--- a/gui/tiletypes.lua
+++ b/gui/tiletypes.lua
@@ -34,7 +34,7 @@ local UI_COLORS = {
     INVALID_OPTION= COLOR_RED,
 }
 
-local TILESET = dfhack.textures.loadTileset('hack/data/art/tiletypes.png', 8, 12, true)
+local TILESET = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/tiletypes.png', 8, 12, true)
 local TILESET_STRIDE = 16
 
 local DEFAULT_OPTIONS = {

--- a/notes.lua
+++ b/notes.lua
@@ -6,7 +6,7 @@ local note_manager = reqscript('internal/notes/note_manager')
 
 textures = {
     green_pin = dfhack.textures.loadTileset(
-        'hack/data/art/note_green_pin_map.png',
+        dfhack.getHackPath()..'/data/art/note_green_pin_map.png',
         32,
         32,
         true


### PR DESCRIPTION
This replaces a hardcoded use of the `hack` path root in several lua scripts with a call to `getHackDir()`, to remove dependency on `hack` being in the CWD of the DF process