### PR TITLE
Add gear assembly toggle widget

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@ Template for new versions:
 ## New Tools
 
 ## New Features
+- `trackstop`: can now toggle gear assemblies
 
 ## Fixes
 

--- a/docs/trackstop.rst
+++ b/docs/trackstop.rst
@@ -5,7 +5,7 @@ trackstop
     :summary: Overlay to allow changing track stop and related building settings after construction.
     :tags: fort buildings interface
 
-This script provides 3 overlays that are managed by the `overlay` framework.
+This script provides 4 overlays that are managed by the `overlay` framework.
 The script does nothing when executed.
 
 The ``trackstop`` overlay allows the player to change the friction and dump
@@ -19,3 +19,8 @@ of a selected pressure plate after it has been constructed. Manual value entry
 of ranges for minecart and creature triggers is provided, allowing greater
 precision than the game interface normally permits. Incrementing or decrementing
 values always restricts them to the usual intervals.
+
+The ``gearassembly`` overlay allows the player to toggle the state of a selected
+gear assembly without linking it to a lever first. This is useful for dwarfputing
+and other applications where it may be desirable to default to the disengaged
+state until triggered.

--- a/trackstop.lua
+++ b/trackstop.lua
@@ -196,7 +196,7 @@ function RollerOverlay:render(dc)
   self.subviews.direction:setOption(DIRECTION_MAP_REVERSE[b.direction])
   self.subviews.speed:setOption(SPEED_MAP_REVERSE[b.speed])
 
-  TrackStopOverlay.super.render(self, dc)
+  RollerOverlay.super.render(self, dc)
 end
 
 function RollerOverlay:init()
@@ -539,8 +539,38 @@ function PlateOverlay:init()
   }
 end
 
+GearOverlay = defclass(GearOverlay, overlay.OverlayWidget)
+GearOverlay.ATTRS{
+  desc='Adds widget for toggling gear assemblies.',
+  default_pos={x=-83, y=32},
+  version=2,
+  default_enabled=true,
+  viewscreens='dwarfmode/ViewSheets/BUILDING/GearAssembly',
+  frame={w=15, h=3},
+  frame_style=gui.MEDIUM_FRAME,
+  frame_background=gui.CLEAR_PEN,
+}
+
+function GearOverlay:render(dc)
+  self.subviews.gear_toggle:setOption(not getBuild().gear_flags.disengaged)
+  GearOverlay.super.render(self, dc)
+end
+
+function GearOverlay:init()
+  self:addviews{
+    widgets.ToggleHotkeyLabel{
+      view_id='gear_toggle',
+      frame={t=0, l=0},
+      label='State:',
+      key='CUSTOM_SHIFT_X',
+      on_change=function() getBuild():setTriggerState(0) end,
+    },
+  }
+end
+
 OVERLAY_WIDGETS = {
   trackstop=TrackStopOverlay,
   rollers=RollerOverlay,
   pressureplate=PlateOverlay,
+  gearassembly=GearOverlay,
 }


### PR DESCRIPTION
Add a toggle button on the gear assembly building that allows engaging/disengaging them.

Toggling a gear assembly at will is possibly Armok mode level control. However, I think it's already possible to disengage machines through spooky action by cancelling construction of unfinished machine parts to cause a collapse. I'd require dwarf interaction if I could.

`RollerOverlay:render` was using `TrackStopOverlay.super.render`. I fixed that, but I'm not sure there's a visible effect to that change.

It may be worth renaming the `trackstop` script to something fitting the increased scope at some point.