### PR TITLE
Fix inconsistent space in `gui/control-panel` command help

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+``gui/control-panel``: fixed inconsistent space in command help ("tweak" -> "tweak ", like with other commands)
 
 ## Misc Improvements
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -31,7 +31,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
-`gui/control-panel`: fixed inconsistent space in command help ("tweak" -> "tweak ", like with other commands)
+- `gui/control-panel`: fixed inconsistent space in command help ("tweak" -> "tweak ", like with other commands)
 
 ## Misc Improvements
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -31,7 +31,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
-``gui/control-panel``: fixed inconsistent space in command help ("tweak" -> "tweak ", like with other commands)
+`gui/control-panel`: fixed inconsistent space in command help ("tweak" -> "tweak ", like with other commands)
 
 ## Misc Improvements
 

--- a/gui/control-panel.lua
+++ b/gui/control-panel.lua
@@ -403,7 +403,7 @@ function CommandTab:init_footer(panel)
 end
 
 local function launch_help(data)
-    dfhack.run_command('gui/launcher', data.help_command or data.command .. ' ')
+    dfhack.run_command('gui/launcher', (data.help_command or data.command) .. ' ')
 end
 
 function CommandTab:show_help()


### PR DESCRIPTION
When viewing command help, there's usually an extra space applied at the end of the console. (Presumably in case you want to enter a command?) Any registry entry using `help_command` was missing this space, causing an inconsistency.