### PR TITLE
Added new announcement to fixUnit in fix/loyaltycascade

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@ Template for new versions:
 ## New Tools
 
 ## New Features
+- `fix/loyaltycascade`: Added announcements for units who aren't renegades but still got removed from conflicts by makeown.remove_from_conflict in fixUnit
 
 ## Fixes
 

--- a/fix/loyaltycascade.lua
+++ b/fix/loyaltycascade.lua
@@ -77,7 +77,14 @@ local function fixUnit(unit)
         makeown.clear_enemy_status(unit)
     end
 
-    return makeown.remove_from_conflict(unit) or fixed
+    local calmed = makeown.remove_from_conflict(unit)
+
+    if calmed and not fixed then
+        dfhack.gui.showAnnouncement(
+            ('loyaltycascade: %s is now removed from miscellaneous conflicts'):format(unit_name), COLOR_WHITE)
+    end
+
+    return calmed or fixed
 end
 
 local count = 0


### PR DESCRIPTION
Added an additional announcement to fix/loyaltycascade for units who didn't turn against your civ but got removed from conflicts nonetheless by makeown.remove_from_conflict within fixUnit