### PR TITLE
consistently set the initial filter to "All"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `gui/siegemanager`: consistently set the initial filter to "All"
 
 ## Misc Improvements
 

--- a/gui/siegemanager.lua
+++ b/gui/siegemanager.lua
@@ -489,7 +489,7 @@ function SiegeManager:init()
                 {label='Bolt Thrower', value=df.siegeengine_type.BoltThrower},
                 {label='Catapult', value=df.siegeengine_type.Catapult},
             },
-            initial_option=1,
+            initial_option=-1,
         },
         widgets.ToggleHotkeyLabel {
             view_id = 'configure_all',


### PR DESCRIPTION
Explanation: `initial_option` first tries to find the provided value as an option value. So in this case `1` matches `df.siegeengine_type.Ballista`, while the rest of this script assumes that the filter is set to `-1`. 

fixes: https://github.com/DFHack/dfhack/issues/5765
