### PR TITLE
update color-schemes for v5X

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -47,6 +47,7 @@ Template for new versions:
 - `add-recipe`: fix to include incorrectly excluded recipes
 - `gui/control-panel`: fixed incorrect description of deteriorate commands
 - `gui/petitions`: fix deity display
+- `color-schemes`: updated for v5X
 
 ## Misc Improvements
 - `trackstop`: ``pressureplate`` overlay moved to `machine-toggle` as an ``armok`` tool

--- a/color-schemes.lua
+++ b/color-schemes.lua
@@ -259,8 +259,8 @@ function Scheme:load()
     for c,color in ipairs(COLORS) do
         for l,channel in ipairs(CHANNELS) do
             -- Use `math.max` for -1 values (not parsed correctly)
-            local value = math.max(0, self.values[color][channel]) / 255
-            df.global.enabler.ccolor[c - 1][l - 1] = value
+            local value = math.max(0, self.values[color][channel])
+            df.global.gps.uccolor[c - 1][l - 1] = value
         end
     end
     df.global.gps.force_full_display_count = 1

--- a/gui/color-schemes.lua
+++ b/gui/color-schemes.lua
@@ -611,7 +611,7 @@ function screen:onRegister()
         "Register",
         "Register color schemes by file or directory",
         COLOR_WHITE,
-        "/raw/colors/",
+        "/dfhack-config/colors/",
         function(path)
             ColorSchemes.register(path)
             self:populateList()


### PR DESCRIPTION
also, gui/color-schemes suggests registering from `/dfhack-config/colors` instead of `/raw/colors/`now.

note: doesn't use the `getConfigPath()` api, since that would be a pretty involved change and i'd rather get feedback first.
also doesn't update the gui style, that's out of my league
