### PR TITLE
fix nil index if there are no siege engines on the map (fixes #5751)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -32,6 +32,8 @@ Template for new versions:
 
 ## Fixes
 
+- `gui/siegemanager`: fix nil index if there are no siege engines on the map
+
 ## Misc Improvements
 
 ## Removed

--- a/gui/siegemanager.lua
+++ b/gui/siegemanager.lua
@@ -416,7 +416,7 @@ end
 function SiegeEngineList:set_selected_action(action)
     local _, selected = self.subviews.list:getSelected()
 
-    local successful = set_siege_engine_action({selected.data}, action)
+    local successful = selected and set_siege_engine_action({selected.data}, action)
     if not successful then
         self:refresh_view(true)
         return
@@ -464,6 +464,10 @@ function SiegeEngineList:onInput(keys)
     self:set_selected_action(action)
 end
 
+function SiegeEngineList:empty()
+    return not self.subviews.list:getSelected()
+end
+
 -- SiegeManager
 SiegeManager = defclass(SiegeManager, widgets.Window)
 SiegeManager.ATTRS = {
@@ -503,7 +507,10 @@ function SiegeManager:init()
             frame={b=0},
             key='CUSTOM_CTRL_C',
             label='Reveal in World',
-            on_activate=self:callback('reveal_selected')
+            on_activate=self:callback('reveal_selected'),
+            enabled = function ()
+                return not self.subviews.list:empty()
+            end
         },
     })
 
@@ -514,7 +521,10 @@ function SiegeManager:init()
                 key = action_button_keybinds[i],
                 key_sep = i == #action_button_order and ': ' or '',
                 label = i == #action_button_order and 'Set Action' or '',
-                on_activate = self:callback('set_action', action_button)
+                on_activate = self:callback('set_action', action_button),
+                enabled = function ()
+                    return not self.subviews.list:empty()
+                end
             }
         })
     end


### PR DESCRIPTION
In addition to fixing the actual nil index, I also disable the buttons to set siege engine actions if there are no siege engines.

fixes: https://github.com/DFHack/dfhack/issues/5751