### PR TITLE
gui/tiletypes: remove COLOR_RESET use with Pen

### DIFF
--- a/gui/tiletypes.lua
+++ b/gui/tiletypes.lua
@@ -203,7 +203,7 @@ end
 --#region UI Utilities
 
 ---@type widgets.LabelToken
-local EMPTY_TOKEN = { text=' ', hpen=dfhack.pen.make(COLOR_RESET), width=1 }
+local EMPTY_TOKEN = { text=' ', hpen=UI_COLORS.HIGHLIGHTED, width=1 }
 
 ---@class InlineButtonLabelSpec
 ---@field left_specs? widgets.ButtonLabelSpec


### PR DESCRIPTION
Ref DFHack/dfhack#5864

This Pen use of COLOR_RESET as a foreground color never actually caused any OOB reads (before DFHack/dfhack#5864) since the foreground value already had masking applied to it (related to bold handling).

The EMPTY_LABEL is used to fill (with space characters) the blank portions of the `gui/tiletypes` "more options" entries that are not text label nor checkbox. Since spaces usually don't have any foreground pixels, the foreground used here mostly doesn't matter.

To prevent a visual change for fonts that have foreground pixels in the space character, the foreground should be COLOR_WHITE since this is equivalent to what happens when a COLOR_RESET foreground is specified. Luckily, `UI_COLORS.HIGHLIGHTED` (used for the text portion of the entry while in the hover state) is also COLOR_WHITE.

Suggestion: Switch to specifying `hpen=UI_COLORS.HIGHLIGHTED`. This matches the text portion of the options and produces an effective Pen that is unchanged from when COLOR_RESET was used. Thus, there are no visible changes.

Pictured here:
The (top of the) "more options" window of `gui/tiletypes` with mouse hovering over the "Light" entry. This shows the COLOR_WHITE text under the mouse and the COLOR_GREY text for the non-hover entries. The bottom row shows what happens if the background of EMPTY_TOKEN is COLOR_WHITE instead of COLOR_BLACK.

<img width="476" height="264" alt="gui/tiletypes more options" src="https://github.com/user-attachments/assets/37e54044-9fc8-41bb-a38c-d8b2e10c7cdc" />
